### PR TITLE
Nullability annotations

### DIFF
--- a/generator/src/main/java/io/github/jwharm/javagi/generator/BindingsGenerator.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/generator/BindingsGenerator.java
@@ -48,7 +48,7 @@ public class BindingsGenerator {
 
             for (Function function : gir.namespace.functionList) {
                 if (function.isSafeToBind()) {
-                    function.generate(writer, false, true);
+                    function.generate(writer, function.parent instanceof Interface, true);
                 }
             }
             

--- a/generator/src/main/java/io/github/jwharm/javagi/generator/GirParser.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/generator/GirParser.java
@@ -148,7 +148,8 @@ public class GirParser extends DefaultHandler {
             }
             case "instance-parameter" -> {
                 InstanceParameter newInstanceParameter = new InstanceParameter(current, attr.getValue("name"),
-                        attr.getValue("transfer-ownership"));
+                        attr.getValue("transfer-ownership"), attr.getValue("nullable"),
+                        attr.getValue("allow-none"));
                 ((Parameters) current).parameterList.add(newInstanceParameter);
                 current = newInstanceParameter;
             }
@@ -214,7 +215,8 @@ public class GirParser extends DefaultHandler {
                 current = new Repository();
             }
             case "return-value" -> {
-                ReturnValue newReturnValue = new ReturnValue(current, attr.getValue("transfer-ownership"));
+                ReturnValue newReturnValue = new ReturnValue(current, attr.getValue("transfer-ownership"),
+                        attr.getValue("nullable"));
                 ((CallableType) current).setReturnValue(newReturnValue);
                 current = newReturnValue;
             }

--- a/generator/src/main/java/io/github/jwharm/javagi/model/Callback.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/Callback.java
@@ -24,6 +24,7 @@ public class Callback extends RegisteredType implements CallableType {
     private void generateFunctionalInterface(Writer writer) throws IOException {
         generatePackageDeclaration(writer);
         writer.write("import io.github.jwharm.javagi.*;\n");
+        writer.write("import org.jetbrains.annotations.*;\n");
         writer.write("\n");
         generateJavadoc(writer);
         writer.write("@FunctionalInterface\n");

--- a/generator/src/main/java/io/github/jwharm/javagi/model/Constructor.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/Constructor.java
@@ -11,13 +11,13 @@ public class Constructor extends Method {
         super(parent, name, cIdentifier, deprecated, throws_);
     }
 
-    public void generate(Writer writer) throws IOException {
+    public void generate(Writer writer, boolean isInterface) throws IOException {
         // Do not generate deprecated constructors.
         if ("1".equals(deprecated)) {
             return;
         }
 
-        generateMethodHandle(writer);
+        generateMethodHandle(writer, isInterface);
 
         String privateMethodName = generateConstructorHelper(writer);
 
@@ -50,10 +50,10 @@ public class Constructor extends Method {
         writer.write("    \n");
     }
 
-    public void generateNamed(Writer writer) throws IOException {
+    public void generateNamed(Writer writer, boolean isInterface) throws IOException {
         RegisteredType clazz = (RegisteredType) parent;
 
-        generateMethodHandle(writer);
+        generateMethodHandle(writer, isInterface);
 
         String privateMethodName = generateConstructorHelper(writer);
 

--- a/generator/src/main/java/io/github/jwharm/javagi/model/InstanceParameter.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/InstanceParameter.java
@@ -2,7 +2,7 @@ package io.github.jwharm.javagi.model;
 
 public class InstanceParameter extends Parameter {
 
-    public InstanceParameter(GirElement parent, String name, String transferOwnership) {
-        super(parent, name, transferOwnership, null, null, null);
+    public InstanceParameter(GirElement parent, String name, String transferOwnership, String nullable, String allowNone) {
+        super(parent, name, transferOwnership, nullable, allowNone, null);
     }
 }

--- a/generator/src/main/java/io/github/jwharm/javagi/model/Interface.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/Interface.java
@@ -27,7 +27,7 @@ public class Interface extends RegisteredType {
 
         for (Function function : functionList) {
             if (function.isSafeToBind()) {
-                function.generate(writer, false, true);
+                function.generate(writer, true, true);
             }
         }
 

--- a/generator/src/main/java/io/github/jwharm/javagi/model/Method.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/Method.java
@@ -23,8 +23,10 @@ public class Method extends GirElement implements CallableType {
         }
     }
     
-    protected void generateMethodHandle(Writer writer) throws IOException {
-        writer.write("    static final MethodHandle " + cIdentifier + " = Interop.downcallHandle(\n");
+    protected void generateMethodHandle(Writer writer, boolean isInterface) throws IOException {
+        if (isInterface) writer.write("    @ApiStatus.Internal static final ");
+        else writer.write("    private static final ");
+        writer.write("MethodHandle " + cIdentifier + " = Interop.downcallHandle(\n");
         writer.write("        \"" + cIdentifier + "\",\n");
         writer.write("        FunctionDescriptor.");
         if (returnValue.type == null || "void".equals(returnValue.type.simpleJavaType)) {
@@ -51,16 +53,16 @@ public class Method extends GirElement implements CallableType {
         writer.write("    \n");
     }
 
-    public void generate(Writer writer, boolean isDefault, boolean isStatic) throws IOException {
+    public void generate(Writer writer, boolean isInterface, boolean isStatic) throws IOException {
         
         // Do not generate deprecated methods.
         if ("1".equals(deprecated)) {
             return;
         }
         
-        generateMethodHandle(writer);
+        generateMethodHandle(writer, isInterface);
 
-        writeMethodDeclaration(writer, doc, name, throws_, isDefault, isStatic);
+        writeMethodDeclaration(writer, doc, name, throws_, isInterface, isStatic);
         writer.write(" {\n");
 
         if (throws_ != null) {

--- a/generator/src/main/java/io/github/jwharm/javagi/model/Parameters.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/Parameters.java
@@ -39,7 +39,7 @@ public class Parameters extends GirElement {
             if (counter++ > 0) {
                 writer.write(", ");
             }
-            p.generateTypeAndName(writer, p.isOutParameter() ? true : pointerForArray);
+            p.generateTypeAndName(writer, p.isOutParameter() || pointerForArray);
         }
     }
 

--- a/generator/src/main/java/io/github/jwharm/javagi/model/RegisteredType.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/RegisteredType.java
@@ -28,6 +28,7 @@ public abstract class RegisteredType extends GirElement {
         writer.write("import io.github.jwharm.javagi.*;\n");
         writer.write("import java.lang.foreign.*;\n");
         writer.write("import java.lang.invoke.*;\n");
+        writer.write("import org.jetbrains.annotations.*;\n");
         writer.write("\n");
     }
 
@@ -62,10 +63,11 @@ public abstract class RegisteredType extends GirElement {
     protected void generateConstructors(Writer writer) throws IOException {
         for (Constructor c : constructorList) {
             if (c.isSafeToBind()) {
+                boolean isInterface = this instanceof Interface;
                 if (c.name.equals("new")) {
-                    c.generate(writer);
+                    c.generate(writer, isInterface);
                 } else {
-                    c.generateNamed(writer);
+                    c.generateNamed(writer, isInterface);
                 }
             }
         }

--- a/generator/src/main/java/io/github/jwharm/javagi/model/ReturnValue.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/ReturnValue.java
@@ -1,13 +1,12 @@
 package io.github.jwharm.javagi.model;
 
-import io.github.jwharm.javagi.generator.Conversions;
 import java.io.IOException;
 import java.io.Writer;
 
 public class ReturnValue extends Parameter {
 
-    public ReturnValue(GirElement parent, String transferOwnership) {
-        super(parent, null, transferOwnership, null, null, null);
+    public ReturnValue(GirElement parent, String transferOwnership, String nullable) {
+        super(parent, null, transferOwnership, nullable, null, null);
     }
 
     public void generateReturnStatement(Writer writer, int indent) throws IOException {

--- a/gtk4/build.gradle.kts
+++ b/gtk4/build.gradle.kts
@@ -17,6 +17,7 @@ java {
     }
     // Temporarily disabled since the generated docs were apparently invalid
 //    withJavadocJar()
+    withSourcesJar()
 }
 
 group = "io.github.jwharm.javagi"

--- a/gtk4/build.gradle.kts
+++ b/gtk4/build.gradle.kts
@@ -27,6 +27,7 @@ repositories {
 }
 
 dependencies {
+    compileOnly("org.jetbrains:annotations:23.0.0")
 }
 
 val generatedPath = buildDir.resolve("generated/sources/javagi/java/main")

--- a/gtk4/src/main/java/io/github/jwharm/javagi/PointerBitfield.java
+++ b/gtk4/src/main/java/io/github/jwharm/javagi/PointerBitfield.java
@@ -17,7 +17,7 @@ public class PointerBitfield<T extends Bitfield> extends Pointer<T> {
     }
 
     /**
-     * Use this mehod to set the value that the pointer points to.
+     * Use this method to set the value that the pointer points to.
      */
     public void set(T value) {
         address.set(ValueLayout.JAVA_INT, 0, value.getValue());

--- a/gtk4/src/main/java/module-info.java
+++ b/gtk4/src/main/java/module-info.java
@@ -1,4 +1,5 @@
 module org.gtk {
+    requires org.jetbrains.annotations;
     exports io.github.jwharm.javagi;
     exports org.cairographics;
     exports org.gnome.adw;


### PR DESCRIPTION
Utilize the jetbrains annotations to provide information about parameter and return value.
These annotations allow IDEs to better understand the methods, but are not needed during runtime and are excluded from the dep jar accordingly.
I have not tested whether nullability is properly supported by the data types, but the gir calls for it.
Another annotation of interest is @MagicConstant with flagsFromClass, which could replace the bitfield class, but it is on you to decide whether you want to implement that.