### PR TITLE
Unhardcode natives

### DIFF
--- a/generator/src/main/java/io/github/jwharm/javagi/JavaGI.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/JavaGI.java
@@ -7,8 +7,8 @@ import org.xml.sax.helpers.DefaultHandler;
 
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
+import java.nio.file.Path;
 import java.util.*;
-import java.util.stream.Collectors;
 
 public class JavaGI {
 
@@ -35,7 +35,7 @@ public class JavaGI {
             @Override
             public void startElement(String uri, String lName, String qName, Attributes attr) {
                 if ("repository".equals(qName)) {
-                    toGenerate.add(new Source(attr.getValue("path"), attr.getValue("package"), outputDir, PatchSet.EMPTY));
+                    toGenerate.add(new Source(attr.getValue("path"), attr.getValue("package"), Set.of(), Path.of(outputDir), PatchSet.EMPTY));
                 }
             }
         });
@@ -55,7 +55,7 @@ public class JavaGI {
             System.out.println("PARSE " + source.path());
             Repository r = parser.parse(source.path(), source.pkg());
             repositories.put(r.namespace.name, r);
-            parsed.put(r.namespace.name, new Parsed(r, source.outputDir, source.patches));
+            parsed.put(r.namespace.name, new Parsed(r, source.natives, source.outputDir, source.patches));
         }
 
         System.out.println("LINK " + parsed.size() + " REPOSITORIES");
@@ -69,17 +69,14 @@ public class JavaGI {
         }
 
         for (Parsed p : parsed.values()) {
-            String outputDir = p.outputDir;
-            if (!(outputDir.endsWith("/") || outputDir.endsWith("\\"))) {
-                outputDir = outputDir + "/";
-            }
-            System.out.println("GENERATE " + p.repository.namespace.name + " to " + outputDir + p.repository.namespace.pathName);
-            generator.generate(p.repository, outputDir);
+            Path basePath = p.outputDir.resolve(p.repository.namespace.pathName);
+            System.out.println("GENERATE " + p.repository.namespace.name + " to " + basePath);
+            generator.generate(p.repository, p.natives, basePath);
         }
 
         System.out.println("COMPLETED in " + (System.currentTimeMillis() - starttime) + " ms");
     }
 
-    public record Source(String path, String pkg, String outputDir, PatchSet patches) {}
-    private record Parsed(Repository repository, String outputDir, PatchSet patches) {}
+    public record Source(String path, String pkg, Set<String> natives, Path outputDir, PatchSet patches) {}
+    private record Parsed(Repository repository, Set<String> natives, Path outputDir, PatchSet patches) {}
 }

--- a/generator/src/main/java/io/github/jwharm/javagi/model/Alias.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/Alias.java
@@ -34,12 +34,11 @@ public class Alias extends ValueWrapper {
     // Aliases (typedefs) don't exist in Java. We can emulate this using inheritance.
     // For primitives and Strings, we wrap the value.
     public void generate(Writer writer) throws IOException {
-        
         generatePackageDeclaration(writer);
         generateJavadoc(writer);
-        
+
         switch (aliasFor()) {
-            case CLASS_ALIAS:
+            case CLASS_ALIAS -> {
                 writer.write("public class " + javaName);
                 if (type.qualifiedJavaType.equals("void")) {
                     writer.write(" extends org.gtk.gobject.Object {\n");
@@ -50,28 +49,29 @@ public class Alias extends ValueWrapper {
                 generateMemoryAddressConstructor(writer);
                 generateCastFromGObject(writer);
                 writer.write("}\n");
-                break;
-            case INTERFACE_ALIAS:
+            }
+            case INTERFACE_ALIAS -> {
                 writer.write("public interface " + javaName + " extends " + type.qualifiedJavaType + " {\n");
                 writer.write("}\n");
-                break;
-            case CALLBACK_ALIAS:
+            }
+            case CALLBACK_ALIAS -> {
                 writer.write("public interface " + javaName + " {\n");
                 writer.write("}\n");
-                break;
-            case VALUE_ALIAS:
+            }
+            case VALUE_ALIAS -> {
                 String genericType = Conversions.primitiveClassName(type.qualifiedJavaType);
                 if ("utf8".equals(type.name)) {
                     genericType = "java.lang.String";
                 }
-                writer.write("public class " + javaName +  " extends io.github.jwharm.javagi.Alias<" + genericType + "> {");
+                writer.write("public class " + javaName + " extends io.github.jwharm.javagi.Alias<" + genericType + "> {");
                 writer.write("\n");
                 generateValueConstructor(writer, type.qualifiedJavaType);
                 writer.write("}\n");
-                break;
-            case UNKNOWN_ALIAS:
+            }
+            case UNKNOWN_ALIAS -> {
                 writer.write("public class " + javaName + " {\n");
                 writer.write("}\n");
+            }
         }
     }
 

--- a/generator/src/main/java/io/github/jwharm/javagi/model/Class.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/Class.java
@@ -35,6 +35,7 @@ public class Class extends RegisteredType {
         writer.write(" {\n");
         writer.write("\n");
 
+        generateEnsureInitialized(writer);
         generateMemoryAddressConstructor(writer);
         generateCastFromGObject(writer);
         generateConstructors(writer);

--- a/generator/src/main/java/io/github/jwharm/javagi/model/Interface.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/Interface.java
@@ -56,6 +56,7 @@ public class Interface extends RegisteredType {
 
     public void generateImplClass(Writer writer) throws IOException {
         writer.write("    class " + javaName + "Impl extends org.gtk.gobject.Object implements " + javaName + " {\n");
+        generateEnsureInitialized(writer);
         writer.write("        public " + javaName + "Impl(io.github.jwharm.javagi.Refcounted ref) {\n");
         writer.write("            super(ref);\n");
         writer.write("        }\n");

--- a/generator/src/main/java/io/github/jwharm/javagi/model/Interface.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/Interface.java
@@ -56,7 +56,7 @@ public class Interface extends RegisteredType {
 
     public void generateImplClass(Writer writer) throws IOException {
         writer.write("    class " + javaName + "Impl extends org.gtk.gobject.Object implements " + javaName + " {\n");
-        generateEnsureInitialized(writer);
+        generateEnsureInitialized(writer, "        ");
         writer.write("        public " + javaName + "Impl(io.github.jwharm.javagi.Refcounted ref) {\n");
         writer.write("            super(ref);\n");
         writer.write("        }\n");

--- a/generator/src/main/java/io/github/jwharm/javagi/model/Record.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/Record.java
@@ -43,8 +43,8 @@ public class Record extends Class {
         generateJavadoc(writer);
 
         writer.write("public class " + javaName + " extends io.github.jwharm.javagi.ResourceBase {\n");
-        writer.write("\n");
 
+        generateEnsureInitialized(writer);
         generateMemoryAddressConstructor(writer);
 
         if (constructorList.isEmpty()) {

--- a/generator/src/main/java/io/github/jwharm/javagi/model/RegisteredType.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/RegisteredType.java
@@ -57,10 +57,18 @@ public abstract class RegisteredType extends GirElement {
     }
 
     protected void generateEnsureInitialized(Writer writer) throws IOException {
-        writer.write("    static {\n");
-        writer.write("        " + Conversions.toSimpleJavaType(getNamespace().name) + ".javagi$ensureInitialized();\n");
-        writer.write("    }\n");
-        writer.write("    \n");
+        generateEnsureInitialized(writer, "    ");
+    }
+
+    protected void generateEnsureInitialized(Writer writer, String indent) throws IOException {
+        writer.write(indent);
+        writer.write("static {\n");
+        writer.write(indent);
+        writer.write("    " + Conversions.toSimpleJavaType(getNamespace().name) + ".javagi$ensureInitialized();\n");
+        writer.write(indent);
+        writer.write("}\n");
+        writer.write(indent);
+        writer.write("\n");
     }
 
     /**

--- a/generator/src/main/java/io/github/jwharm/javagi/model/RegisteredType.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/RegisteredType.java
@@ -56,6 +56,13 @@ public abstract class RegisteredType extends GirElement {
         writer.write("    \n");
     }
 
+    protected void generateEnsureInitialized(Writer writer) throws IOException {
+        writer.write("    static {\n");
+        writer.write("        " + Conversions.toSimpleJavaType(getNamespace().name) + ".javagi$ensureInitialized();\n");
+        writer.write("    }\n");
+        writer.write("    \n");
+    }
+
     /**
      * Generates all constructors listed for this type. When the constructor is not named "new", a static
      * factory method is generated with the provided name.

--- a/generator/src/main/java/io/github/jwharm/javagi/model/Union.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/Union.java
@@ -19,7 +19,7 @@ public class Union extends RegisteredType {
         generateJavadoc(writer);
 
         writer.write("public class " + javaName + " extends io.github.jwharm.javagi.ResourceBase {\n");
-        writer.write("    \n");
+        generateEnsureInitialized(writer);
         generateMemoryAddressConstructor(writer);
         writer.write("}\n");
         writer.write("\n");

--- a/gtk4/src/main/java/io/github/jwharm/javagi/Interop.java
+++ b/gtk4/src/main/java/io/github/jwharm/javagi/Interop.java
@@ -16,18 +16,6 @@ public class Interop {
     public final static HashMap<Integer, Object> signalRegistry = new HashMap<>();
 
     static {
-        System.loadLibrary("adwaita-1");
-        System.loadLibrary("gtk-4");
-        System.loadLibrary("pangocairo-1.0");
-        System.loadLibrary("pango-1.0");
-        System.loadLibrary("harfbuzz");
-        System.loadLibrary("gdk_pixbuf-2.0");
-        System.loadLibrary("cairo-gobject");
-        System.loadLibrary("cairo");
-        System.loadLibrary("graphene-1.0");
-        System.loadLibrary("gio-2.0");
-        System.loadLibrary("gobject-2.0");
-        System.loadLibrary("glib-2.0");
         SymbolLookup loaderLookup = SymbolLookup.loaderLookup();
         symbolLookup = name -> loaderLookup.lookup(name).or(() -> linker.defaultLookup().lookup(name));
     }


### PR DESCRIPTION
Currently, the Interop class contains explicit references to libraries, which is undesirable if you want to use multiple libraries based on java-gi.
This PR generates a static initializer in the main class of the namespace, which is referenced from static initializers in other classes, and loads the library instead.