### PR TITLE
Implement function shadowing

### DIFF
--- a/example/src/main/java/io/github/jwharm/javagi/example/GStreamerExample.java
+++ b/example/src/main/java/io/github/jwharm/javagi/example/GStreamerExample.java
@@ -86,7 +86,7 @@ public class GStreamerExample {
 
         // We add a message handler
         bus = pipeline.getBus();
-        busWatchId = bus.addWatch(this::busCall);
+        busWatchId = bus.addWatch(0, this::busCall, () -> {});
 
         // We add all elements into the pipeline
         // file-source | ogg-demuxer | vorbis-decoder | converter | alsa-output

--- a/generator/src/main/java/io/github/jwharm/javagi/generator/GirParser.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/generator/GirParser.java
@@ -190,11 +190,17 @@ public class GirParser extends DefaultHandler {
                 current = newMember;
             }
             case "method" -> {
-                Method newMethod = new Method(current, attr.getValue("name"),
-                        attr.getValue("c:identifier"), attr.getValue("deprecated"),
-                        attr.getValue("throws"));
-                current.methodList.add(newMethod);
-                current = newMethod;
+                if (attr.getValue("shadowed-by") != null) {
+                    // Do not generate shadowed methods
+                    skip = qName;
+                } else {
+                    Method newMethod = new Method(current, attr.getValue("name"),
+                            attr.getValue("c:identifier"), attr.getValue("deprecated"),
+                            attr.getValue("throws"), attr.getValue("shadowed-by"),
+                            attr.getValue("shadows"));
+                    current.methodList.add(newMethod);
+                    current = newMethod;
+                }
             }
             case "namespace" -> {
                 Namespace newNamespace = new Namespace(current, attr.getValue("name"), attr.getValue("version"),

--- a/generator/src/main/java/io/github/jwharm/javagi/generator/PatchSet.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/generator/PatchSet.java
@@ -31,6 +31,16 @@ public abstract class PatchSet {
         if (repo.namespace.registeredTypeMap.remove(type) == null) System.err.println("Did not remove " + type + ": Not found");
     }
 
+    protected static void setReturnVoid(Repository repo, String type, String name) {
+        Method m = findMethod(repo, type, name);
+        if (m != null) {
+            ReturnValue rv = m.returnValue;
+            rv.type = new Type(rv, "none", "void");
+            rv.doc = null;
+        } else
+            System.err.println("Did not change return type of " + type + "." + name + ": Not found");
+    }
+
     protected static Method findMethod(Repository repo, String type, String method) {
         try {
             for (Method m : repo.namespace.registeredTypeMap.get(type).methodList) {

--- a/generator/src/main/java/io/github/jwharm/javagi/model/Constructor.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/Constructor.java
@@ -8,7 +8,7 @@ import java.io.Writer;
 public class Constructor extends Method {
 
     public Constructor(GirElement parent, String name, String cIdentifier, String deprecated, String throws_) {
-        super(parent, name, cIdentifier, deprecated, throws_);
+        super(parent, name, cIdentifier, deprecated, throws_, null, null);
     }
 
     public void generate(Writer writer, boolean isInterface) throws IOException {

--- a/generator/src/main/java/io/github/jwharm/javagi/model/Function.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/Function.java
@@ -3,6 +3,6 @@ package io.github.jwharm.javagi.model;
 public class Function extends Method {
 
     public Function(GirElement parent, String name, String cIdentifier, String deprecated, String throws_) {
-        super(parent, name, cIdentifier, deprecated, throws_);
+        super(parent, name, cIdentifier, deprecated, throws_, null, null);
     }
 }

--- a/generator/src/main/java/io/github/jwharm/javagi/model/Method.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/Method.java
@@ -7,16 +7,23 @@ import io.github.jwharm.javagi.generator.Conversions;
 
 public class Method extends GirElement implements CallableType {
 
-    public final String cIdentifier, deprecated, throws_;
+    public final String cIdentifier;
+    public final String deprecated;
+    public final String throws_;
+    public final String shadowedBy;
+    public final String shadows;
     public ReturnValue returnValue;
     public Parameters parameters;
 
-    public Method(GirElement parent, String name, String cIdentifier, String deprecated, String throws_) {
+    public Method(GirElement parent, String name, String cIdentifier, String deprecated,
+                  String throws_, String shadowedBy, String shadows) {
         super(parent);
-        this.name = name;
+        this.name = shadows == null ? name : shadows; // Language bindings are expected to rename a function to the shadowed function
         this.cIdentifier = cIdentifier;
         this.deprecated = deprecated;
         this.throws_ = throws_;
+        this.shadowedBy = shadowedBy;
+        this.shadows = shadows;
 
         // Handle empty names. (For example, GLib.g_iconv is named "".)
         if ("".equals(name)) {

--- a/generator/src/main/java/io/github/jwharm/javagi/model/Signal.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/Signal.java
@@ -14,7 +14,7 @@ public class Signal extends Method implements Closure {
     
 
     public Signal(GirElement parent, String name, String when, String detailed, String deprecated, String throws_) {
-        super(parent, name, null, deprecated, throws_);
+        super(parent, name, null, deprecated, throws_, null, null);
         this.when = when;
         this.detailed = "1".equals(detailed);
 

--- a/generator/src/main/java/io/github/jwharm/javagi/model/Type.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/Type.java
@@ -11,7 +11,7 @@ public class Type extends GirElement {
     public String girElementType;
 
     /** Example: gboolean, const char*, GdkRectangle* */
-    public final String cType;
+    public String cType;
 
     /** This is the type name from the gir file. For example: Gdk.Rectangle */
     public String qualifiedName;

--- a/generator/src/main/java/io/github/jwharm/javagi/model/VirtualMethod.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/VirtualMethod.java
@@ -3,6 +3,6 @@ package io.github.jwharm.javagi.model;
 public class VirtualMethod extends Method {
 
     public VirtualMethod(GirElement parent, String name, String deprecated, String throws_) {
-        super(parent, name, null, deprecated, throws_);
+        super(parent, name, null, deprecated, throws_, null, null);
     }
 }

--- a/gtk4/build.gradle.kts
+++ b/gtk4/build.gradle.kts
@@ -92,6 +92,9 @@ val genSources by tasks.registering {
                     renameMethod(repo, "MenuButton", "get_direction", "get_arrow_direction")
                     renameMethod(repo, "PrintUnixDialog", "get_settings", "get_print_settings")
                     renameMethod(repo, "PrintSettings", "get", "get_string")
+                    // This method returns void in interface ActionGroup, but returns boolean in class Widget.
+                    // Subclasses from Widget that implement ActionGroup throw a compile error.
+                    setReturnVoid(repo, "Widget", "activate_action");
                 }
             }),
             source("Adw-1", "org.gnome.adw", true, "adwaita-1", patches = object: PatchSet() {


### PR DESCRIPTION
Some methods have an attribute `shadows` or `shadowed-by`. Language bindings are expected to rename the shadowing method to the name of the shadowed method. The original, shadowed method is not exposed in the bindings.

This uncovered a small issue in the Gtk library, so I added a patch on `GtkWidget` to change the return type of a method from `boolean` to `void` to fix it.