### PR TITLE
Add package-info to bindings

### DIFF
--- a/.github/workflows/publish-maven.yml
+++ b/.github/workflows/publish-maven.yml
@@ -20,30 +20,31 @@ jobs:
         uses: actions/checkout@v3
       - name: Setup Pages
         uses: actions/configure-pages@v2
-      - uses: actions/setup-java@v3
+      - name: Setup Java
+        uses: actions/setup-java@v3
         with:
           java-version: '19'
           distribution: 'temurin'
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v1
-      - name: Install dependencies
+      - name: Install Dependencies
         run: |
           dnf install -y gtk4-devel glib-devel libadwaita-devel gobject-introspection-devel
           dnf install -y gstreamer1-devel gstreamer1-plugins-base-devel gstreamer1-plugins-bad-free-devel
-      - name: Publish package
+      - name: Publish Maven Packages
         uses: gradle/gradle-build-action@v2
         with:
           arguments: publish javadoc --stacktrace
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Create javadoc package
+      - name: Create Javadoc Artifact
         run: |
           mkdir javadoc
           mv generator/build/docs/javadoc javadoc/generator
           mv glib/build/docs/javadoc javadoc/glib
           mv gstreamer/build/docs/javadoc javadoc/gstreamer
           mv gtk4/build/docs/javadoc javadoc/gtk4
-      - name: Create pages artifact
+      - name: Upload Javadoc Artifact
         uses: actions/upload-pages-artifact@v1
         with:
           path: 'javadoc'

--- a/.github/workflows/publish-maven.yml
+++ b/.github/workflows/publish-maven.yml
@@ -48,8 +48,9 @@ jobs:
         with:
           path: 'javadoc'
   pages:
-    needs: publish
     runs-on: ubuntu-latest
+    needs: publish
+    if: event_name == 'release'
     permissions:
       pages: write
       id-token: write

--- a/.github/workflows/publish-maven.yml
+++ b/.github/workflows/publish-maven.yml
@@ -50,7 +50,7 @@ jobs:
   pages:
     runs-on: ubuntu-latest
     needs: publish
-    if: event_name == 'release'
+    if: github.event_name == 'release'
     permissions:
       pages: write
       id-token: write

--- a/.github/workflows/publish-maven.yml
+++ b/.github/workflows/publish-maven.yml
@@ -51,7 +51,7 @@ jobs:
   pages:
     runs-on: ubuntu-latest
     needs: publish
-    if: github.event_name == 'release'
+    if: github.event_name == 'push'
     permissions:
       pages: write
       id-token: write

--- a/.github/workflows/publish-maven.yml
+++ b/.github/workflows/publish-maven.yml
@@ -16,7 +16,10 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v2
       - uses: actions/setup-java@v3
         with:
           java-version: '19'
@@ -30,6 +33,30 @@ jobs:
       - name: Publish package
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: publish --stacktrace
+          arguments: publish javadoc --stacktrace
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create javadoc package
+        run: |
+          mkdir javadoc
+          mv generator/build/docs/javadoc javadoc/generator
+          mv glib/build/docs/javadoc javadoc/glib
+          mv gstreamer/build/docs/javadoc javadoc/gstreamer
+          mv gtk4/build/docs/javadoc javadoc/gtk4
+      - name: Create pages artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: 'javadoc'
+  pages:
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,6 +10,10 @@ tasks.register("publish") {
     dependsOn(gradle.includedBuild("generator").task(":publish"))
 }
 
+tasks.register("javadoc") {
+    dependsOn(gradle.includedBuild("generator").task(":javadoc"))
+}
+
 tasks.register("example") {
     dependsOn(project(":example").tasks["run"])
 }

--- a/generator/src/main/java/io/github/jwharm/javagi/generator/BindingsGenerator.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/generator/BindingsGenerator.java
@@ -38,7 +38,7 @@ public class BindingsGenerator {
     }
 
     /**
-     * Generate the contents for the class with the namespace-global declarations.
+     * Generate the contents for the class with the namespace-global declarations and a package-info.
      * The name of the class is the namespace identifier.
      */
     public static void generateGlobals(Repository gir, Set<String> natives, Path basePath) throws IOException {
@@ -101,6 +101,16 @@ public class BindingsGenerator {
 
             writer.write("    }\n");
             writer.write("}\n");
+        }
+
+        try (SourceWriter writer = new SourceWriter(Files.newBufferedWriter(basePath.resolve("package-info.java")))) {
+            writer.write("/**\n");
+            writer.write(" * This package contains the generated bindings for " + gir.namespace.name + ".\n");
+            writer.write(" * The following natives are required and will be loaded:");
+            for (String libraryName : natives) writer.write(" \"" + libraryName + "\"");
+            writer.write(" * For namespace-global declarations, please view {@link " + className + "}\n");
+            writer.write(" */\n");
+            writer.write("package " + gir.namespace.packageName + ";\n");
         }
     }
 }

--- a/glib/src/main/java/io/github/jwharm/javagi/package-info.java
+++ b/glib/src/main/java/io/github/jwharm/javagi/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * This package contains general-purpose interop utilities.
+ */
+package io.github.jwharm.javagi;


### PR DESCRIPTION
This PR sets up automatic publishing of Javadoc to GitHub Pages.
Specifically, this includes [generator](https://jfronny.github.io/java-gi-experimentation/generator), [glib](https://jfronny.github.io/java-gi-experimentation/glib), [gstreamer](https://jfronny.github.io/java-gi-experimentation/gstreamer), [gtk4](https://jfronny.github.io/java-gi-experimentation/gtk4).
Additionally, a package-info.java file is generated with a reference to the libraries "main" class.
Currently, this is set up to run on every commit, due to a [GitHub Actions issue](https://github.com/actions/deploy-pages/issues/76).
Once that is fixed, this can be changed easily by updating the condition in line 54 to `if: github.event_name == 'release'` (IE revert 7cd475ae303dbdc82e4202e1e75eab3ccc221495).
I failed to find a good description for the `io.github.jwharm.javagi` package in `glib`, but that should probably be split into subpackages anyways.
(Maybe `.interop` for Interop, LibLoad, ..., `.interop.pointer` for Pointer*, `.interop.base` for Alias, Bitfield, ..., `.util` for Out and things like the ListIndex)