### PR TITLE
Clean up kotlin DSL interface, support javadoc references

### DIFF
--- a/buildSrc/src/main/kotlin/ext/GenSourcesExt.kt
+++ b/buildSrc/src/main/kotlin/ext/GenSourcesExt.kt
@@ -1,0 +1,76 @@
+package ext
+
+import io.github.jwharm.javagi.JavaGI
+import io.github.jwharm.javagi.JavaGI.Source
+import io.github.jwharm.javagi.generator.PatchSet
+import io.github.jwharm.javagi.model.Repository
+import org.gradle.api.Action
+import org.gradle.api.NamedDomainObjectProvider
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.tasks.SourceSet
+import org.gradle.api.tasks.SourceSetContainer
+import org.gradle.api.tasks.TaskContainer
+import org.gradle.api.tasks.TaskProvider
+import org.gradle.api.tasks.compile.JavaCompile
+import org.gradle.kotlin.dsl.*
+import java.io.File
+import java.util.LinkedList
+
+fun Project.setupGenSources(setup: Action<Model>) : TaskProvider<Task> {
+    val generatedPath = buildDir.resolve("generated/sources/javagi/java/main")
+    val girSourcesConvention = File(if (hasProperty("girSources")) property("girSources").toString() else "/usr/share/gir-1.0")
+
+    extensions.configure<SourceSetContainer>("sourceSets") {
+        named<SourceSet>("main") {
+            java {
+                srcDir(generatedPath)
+            }
+        }
+    }
+
+    val genSources by tasks.registering {
+        val model = ModelImpl(girSourcesConvention, generatedPath)
+        setup(model)
+        doLast {
+            val generated = JavaGI.generate(model.generatedPath.toPath(), *model.sources)
+            if (model.moduleInfo != null) generated.writeModuleInfo(model.moduleInfo)
+        }
+    }
+
+    tasks.named<JavaCompile>("compileJava").get().dependsOn(genSources)
+
+    return genSources
+}
+
+interface Model {
+    var sourcePath: File
+    var generatedPath: File
+    var moduleInfo: String?
+    fun source(name: String, pkg: String, generate: Boolean, vararg natives: String, patches: ProtoPatchSet? = null)
+}
+typealias ProtoPatchSet = PatchSet.(repo: Repository) -> Unit
+
+private data class ModelImpl(override var sourcePath: File, override var generatedPath: File) : Model {
+    override var moduleInfo: String? = null
+    override fun source(name: String, pkg: String, generate: Boolean, vararg natives: String, patches: ProtoPatchSet?) {
+        protoSources.add(ProtoSource(name, pkg, generate, arrayOf(*natives), patches))
+    }
+
+    private val protoSources: MutableList<ProtoSource> = LinkedList()
+    val sources: Array<Source> get() = protoSources.map {
+        JavaGI.Source(
+            sourcePath.toPath().resolve("${it.name}.gir"),
+            it.pkg,
+            it.generate,
+            setOf(*it.natives),
+            if (it.patches == null) PatchSet.EMPTY
+            else WrappedPatchSet(it.patches)
+        )
+    }.toTypedArray()
+}
+
+private data class ProtoSource(val name: String, val pkg: String, val generate: Boolean, val natives: Array<String>, val patches: ProtoPatchSet? = null)
+private class WrappedPatchSet(private val patches: ProtoPatchSet) : PatchSet() {
+    override fun patch(repo: Repository) = patches(this, repo)
+}

--- a/buildSrc/src/main/kotlin/ext/JavadocExt.kt
+++ b/buildSrc/src/main/kotlin/ext/JavadocExt.kt
@@ -1,0 +1,13 @@
+package ext
+
+import org.gradle.api.Project
+import org.gradle.api.tasks.javadoc.Javadoc
+import org.gradle.external.javadoc.MinimalJavadocOptions
+import org.gradle.external.javadoc.StandardJavadocDocletOptions
+import org.gradle.kotlin.dsl.named
+
+fun MinimalJavadocOptions.linksOffline(url: String, project: Project) {
+    if (this is StandardJavadocDocletOptions) {
+        linksOffline(url, project.tasks.named<Javadoc>("javadoc").get().destinationDir.toString())
+    } else throw TypeCastException("Unexpected javadoc options type")
+}

--- a/example/src/main/java/io/github/jwharm/javagi/example/Gtk4ListViewExample.java
+++ b/example/src/main/java/io/github/jwharm/javagi/example/Gtk4ListViewExample.java
@@ -62,8 +62,7 @@ public class Gtk4ListViewExample {
         app = new Application("org.gtk.example", ApplicationFlags.FLAGS_NONE);
 
         list = new ArrayList<>();
-        int len = rnd.nextInt(900, 1000);
-        for (int i = 0; i < len; i++) list.add(randomString());
+        for (int i = 0, len = rnd.nextInt(900, 1000); i < len; i++) list.add(randomString());
         listIndexModel = new ListIndexModel(list.size());
 
         app.onActivate(this::activate);

--- a/generator/src/main/java/io/github/jwharm/javagi/generator/PatchSet.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/generator/PatchSet.java
@@ -7,31 +7,31 @@ public abstract class PatchSet {
 
     public abstract void patch(Repository repo);
 
-    protected static void removeConstant(Repository repo, String constant) {
+    public static void removeConstant(Repository repo, String constant) {
         if (!repo.namespace.constantList.removeIf(f -> constant.equals(f.name))) System.err.println("Did not remove " + constant + ": Not found");
     }
 
-    protected static void removeFunction(Repository repo, String function) {
+    public static void removeFunction(Repository repo, String function) {
         if (!repo.namespace.functionList.removeIf(f -> function.equals(f.name))) System.err.println("Did not remove " + function + ": Not found");
     }
 
-    protected static void removeMethod(Repository repo, String type, String method) {
+    public static void removeMethod(Repository repo, String type, String method) {
         Method m = findMethod(repo, type, method);
         if (m != null) m.parent.methodList.remove(m);
         else System.err.println("Did not remove " + type + "." + method + ": Not found");
     }
 
-    protected static void renameMethod(Repository repo, String type, String oldName, String newName) {
+    public static void renameMethod(Repository repo, String type, String oldName, String newName) {
         Method m = findMethod(repo, type, oldName);
         if (m != null) m.name = newName;
         else System.err.println("Did not rename " + type + "." + oldName + ": Not found");
     }
 
-    protected static void removeType(Repository repo, String type) {
+    public static void removeType(Repository repo, String type) {
         if (repo.namespace.registeredTypeMap.remove(type) == null) System.err.println("Did not remove " + type + ": Not found");
     }
 
-    protected static void setReturnVoid(Repository repo, String type, String name) {
+    public static void setReturnVoid(Repository repo, String type, String name) {
         Method m = findMethod(repo, type, name);
         if (m != null) {
             ReturnValue rv = m.returnValue;
@@ -41,7 +41,7 @@ public abstract class PatchSet {
             System.err.println("Did not change return type of " + type + "." + name + ": Not found");
     }
 
-    protected static Method findMethod(Repository repo, String type, String method) {
+    public static Method findMethod(Repository repo, String type, String method) {
         try {
             for (Method m : repo.namespace.registeredTypeMap.get(type).methodList) {
                 if (method.equals(m.name)) return m;
@@ -52,7 +52,7 @@ public abstract class PatchSet {
         }
     }
 
-    protected static void removeEnumMember(Repository repo, String type, String member) {
+    public static void removeEnumMember(Repository repo, String type, String member) {
         RegisteredType rt = repo.namespace.registeredTypeMap.get(type);
         if (rt == null) {
             System.err.println("Did not remove " + member + " in " + type + ": Enumeration not found");
@@ -73,7 +73,7 @@ public abstract class PatchSet {
         else e.memberList.remove(found);
     }
 
-    protected static void inject(Repository repo, String type, String code) {
+    public static void inject(Repository repo, String type, String code) {
         RegisteredType inst = repo.namespace.registeredTypeMap.get(type);
         if (inst == null) {
             System.err.println("Did not inject code into " + type + ": Type not found");

--- a/glib/build.gradle.kts
+++ b/glib/build.gradle.kts
@@ -1,132 +1,107 @@
-import io.github.jwharm.javagi.JavaGI
-import io.github.jwharm.javagi.generator.PatchSet
-import io.github.jwharm.javagi.model.Repository
-import java.nio.file.Path
+import ext.*
+import io.github.jwharm.javagi.generator.PatchSet.*
 
 plugins {
     id("java-gi.library-conventions")
 }
 
-val generatedPath = buildDir.resolve("generated/sources/javagi/java/main")
-
-sourceSets {
-    main {
-        java {
-            srcDir(generatedPath)
+setupGenSources {
+    moduleInfo = """
+        module org.glib {
+            requires static org.jetbrains.annotations;
+            exports io.github.jwharm.javagi;
+            %s
         }
-    }
-}
+    """.trimIndent()
 
-val genSources by tasks.registering {
-    doLast {
-        val sourcePath = Path.of(if (project.hasProperty("girSources")) project.property("girSources").toString() else "/usr/share/gir-1.0")
-        fun source(name: String, pkg: String, generate: Boolean, vararg natives: String, patches: PatchSet? = null) = JavaGI.Source(sourcePath.resolve("$name.gir"), pkg, generate, setOf(*natives), patches ?: PatchSet.EMPTY)
-        JavaGI.generate(generatedPath.toPath(),
-            source("GLib-2.0", "org.gtk.glib", true, "glib-2.0", patches = object: PatchSet() {
-                override fun patch(repo: Repository?) {
-                    // This method has parameters that jextract does not support
-                    removeFunction(repo, "assertion_message_cmpnum")
-                    // Incompletely defined
-                    removeFunction(repo, "clear_error")
-                    // Old typo
-                    removeEnumMember(repo, "UnicodeBreakType", "close_paranthesis")
+    source("GLib-2.0", "org.gtk.glib", true, "glib-2.0") { repo ->
+        // This method has parameters that jextract does not support
+        removeFunction(repo, "assertion_message_cmpnum")
+        // Incompletely defined
+        removeFunction(repo, "clear_error")
+        // Old typo
+        removeEnumMember(repo, "UnicodeBreakType", "close_paranthesis")
 
-                    inject(repo, "Type", """
+        inject(repo, "Type", """
                         
-                        public static final long G_TYPE_FUNDAMENTAL_SHIFT = 2;
-                        public static final Type G_TYPE_INVALID = new Type(0L << G_TYPE_FUNDAMENTAL_SHIFT);
-                        public static final Type G_TYPE_NONE = new Type(1L << G_TYPE_FUNDAMENTAL_SHIFT);
-                        public static final Type G_TYPE_INTERFACE = new Type(2L << G_TYPE_FUNDAMENTAL_SHIFT);
-                        public static final Type G_TYPE_CHAR = new Type(3L << G_TYPE_FUNDAMENTAL_SHIFT);
-                        public static final Type G_TYPE_UCHAR = new Type(4L << G_TYPE_FUNDAMENTAL_SHIFT);
-                        public static final Type G_TYPE_BOOLEAN = new Type(5L << G_TYPE_FUNDAMENTAL_SHIFT);
-                        public static final Type G_TYPE_INT = new Type(6L << G_TYPE_FUNDAMENTAL_SHIFT);
-                        public static final Type G_TYPE_UINT = new Type(7L << G_TYPE_FUNDAMENTAL_SHIFT);
-                        public static final Type G_TYPE_LONG = new Type(8L << G_TYPE_FUNDAMENTAL_SHIFT);
-                        public static final Type G_TYPE_ULONG = new Type(9L << G_TYPE_FUNDAMENTAL_SHIFT);
-                        public static final Type G_TYPE_INT64 = new Type(10L << G_TYPE_FUNDAMENTAL_SHIFT);
-                        public static final Type G_TYPE_UINT64 = new Type(11L << G_TYPE_FUNDAMENTAL_SHIFT);
-                        public static final Type G_TYPE_ENUM = new Type(12L << G_TYPE_FUNDAMENTAL_SHIFT);
-                        public static final Type G_TYPE_FLAGS = new Type(13L << G_TYPE_FUNDAMENTAL_SHIFT);
-                        public static final Type G_TYPE_FLOAT = new Type(14L << G_TYPE_FUNDAMENTAL_SHIFT);
-                        public static final Type G_TYPE_DOUBLE = new Type(15L << G_TYPE_FUNDAMENTAL_SHIFT);
-                        public static final Type G_TYPE_STRING = new Type(16L << G_TYPE_FUNDAMENTAL_SHIFT);
-                        public static final Type G_TYPE_POINTER = new Type(17L << G_TYPE_FUNDAMENTAL_SHIFT);
-                        public static final Type G_TYPE_BOXED = new Type(18L << G_TYPE_FUNDAMENTAL_SHIFT);
-                        public static final Type G_TYPE_PARAM = new Type(19L << G_TYPE_FUNDAMENTAL_SHIFT);
-                        public static final Type G_TYPE_OBJECT = new Type(20L << G_TYPE_FUNDAMENTAL_SHIFT);
-                        public static final Type G_TYPE_VARIANT = new Type(21L << G_TYPE_FUNDAMENTAL_SHIFT);
-                    """.replaceIndent("    ") + "\n")
-                }
-            }),
-            source("GObject-2.0", "org.gtk.gobject", true, "gobject-2.0", patches = object: PatchSet() {
-                override fun patch(repo: Repository?) {
-                    // This is an alias for Callback type
-                    removeType(repo, "VaClosureMarshal")
-                    removeType(repo, "SignalCVaMarshaller")
-                    removeFunction(repo, "signal_set_va_marshaller")
-                    // Override with different return type
-                    renameMethod(repo, "TypeModule", "use", "use_type_module")
-                    // These functions have two Callback parameters, this isn't supported yet
-                    removeFunction(repo, "signal_new_valist")
-                    removeFunction(repo, "signal_newv")
-                    removeFunction(repo, "signal_new")
-                    removeFunction(repo, "signal_new_class_handler")
-
-                    fun StringBuilder.template(javatype: String, gtype: String, method: String) = appendLine("""
-                            
-                            /**
-                             * Create a {@link Value} of with the provided {@code $javatype} value.
-                             * @param  arg The initial value to set
-                             * @return The new {@link Value}
-                             */
-                            public static Value create($javatype arg) {
-                                Value v = allocate();
-                                v.init($gtype);
-                                v.$method;
-                                return v;
-                            }
-                        """.trimIndent())
-
-                    inject(repo, "Value", StringBuilder().run {
-                        template("boolean", "org.gtk.glib.Type.G_TYPE_BOOLEAN", "setBoolean(arg)")
-                        template("byte", "org.gtk.glib.Type.G_TYPE_CHAR", "setSchar(arg)")
-                        template("double", "org.gtk.glib.Type.G_TYPE_DOUBLE", "setDouble(arg)")
-                        template("float", "org.gtk.glib.Type.G_TYPE_FLOAT", "setFloat(arg)")
-                        template("int", "org.gtk.glib.Type.G_TYPE_INT", "setInt(arg)")
-                        template("long", "org.gtk.glib.Type.G_TYPE_LONG", "setLong(arg)")
-                        template("String", "org.gtk.glib.Type.G_TYPE_STRING", "setString(arg)")
-                        template("Enumeration", "org.gtk.glib.Type.G_TYPE_ENUM", "setEnum(arg.getValue())")
-                        template("Bitfield", "org.gtk.glib.Type.G_TYPE_FLAGS", "setFlags(arg.getValue())")
-                        template("org.gtk.gobject.GObject", "org.gtk.glib.Type.G_TYPE_OBJECT", "setObject(arg)")
-                        template("org.gtk.glib.Type", "org.gtk.gobject.GObjects.gtypeGetType()", "setGtype(arg)")
-                        template("Struct", "org.gtk.glib.Type.G_TYPE_BOXED", "setBoxed((MemoryAddress) arg.handle())")
-                        template("MemoryAddress", "org.gtk.glib.Type.G_TYPE_POINTER", "setPointer(arg)")
-                        template("ParamSpec", "org.gtk.glib.Type.G_TYPE_PARAM", "setParam(arg)")
-                        template("Proxy", "org.gtk.glib.Type.G_TYPE_OBJECT", "setObject((org.gtk.gobject.GObject) arg)")
-                    }.toString().replaceIndent("    ") + "\n")
-                }
-            }),
-            source("Gio-2.0", "org.gtk.gio", true, "gio-2.0", patches = object: PatchSet() {
-                override fun patch(repo: Repository?) {
-                    // Override with different return type
-                    renameMethod(repo, "BufferedInputStream", "read_byte", "read_int")
-                    // g_async_initable_new_finish is a method declaration in the interface AsyncInitable.
-                    // It is meant to be implemented as a constructor (actually, a static factory method).
-                    // However, Java does not allow a (non-static) method to be implemented/overridden by a static method.
-                    // The current solution is to remove the method from the interface. It is still available in the implementing classes.
-                    removeMethod(repo, "AsyncInitable", "new_finish")
-                }
-            }),
-            source("GModule-2.0", "org.gtk.gmodule", true)
-        ).writeModuleInfo("""
-            module org.glib {
-                requires static org.jetbrains.annotations;
-                exports io.github.jwharm.javagi;
-                %s
-            }
-        """.trimIndent())
+            public static final long G_TYPE_FUNDAMENTAL_SHIFT = 2;
+            public static final Type G_TYPE_INVALID = new Type(0L << G_TYPE_FUNDAMENTAL_SHIFT);
+            public static final Type G_TYPE_NONE = new Type(1L << G_TYPE_FUNDAMENTAL_SHIFT);
+            public static final Type G_TYPE_INTERFACE = new Type(2L << G_TYPE_FUNDAMENTAL_SHIFT);
+            public static final Type G_TYPE_CHAR = new Type(3L << G_TYPE_FUNDAMENTAL_SHIFT);
+            public static final Type G_TYPE_UCHAR = new Type(4L << G_TYPE_FUNDAMENTAL_SHIFT);
+            public static final Type G_TYPE_BOOLEAN = new Type(5L << G_TYPE_FUNDAMENTAL_SHIFT);
+            public static final Type G_TYPE_INT = new Type(6L << G_TYPE_FUNDAMENTAL_SHIFT);
+            public static final Type G_TYPE_UINT = new Type(7L << G_TYPE_FUNDAMENTAL_SHIFT);
+            public static final Type G_TYPE_LONG = new Type(8L << G_TYPE_FUNDAMENTAL_SHIFT);
+            public static final Type G_TYPE_ULONG = new Type(9L << G_TYPE_FUNDAMENTAL_SHIFT);
+            public static final Type G_TYPE_INT64 = new Type(10L << G_TYPE_FUNDAMENTAL_SHIFT);
+            public static final Type G_TYPE_UINT64 = new Type(11L << G_TYPE_FUNDAMENTAL_SHIFT);
+            public static final Type G_TYPE_ENUM = new Type(12L << G_TYPE_FUNDAMENTAL_SHIFT);
+            public static final Type G_TYPE_FLAGS = new Type(13L << G_TYPE_FUNDAMENTAL_SHIFT);
+            public static final Type G_TYPE_FLOAT = new Type(14L << G_TYPE_FUNDAMENTAL_SHIFT);
+            public static final Type G_TYPE_DOUBLE = new Type(15L << G_TYPE_FUNDAMENTAL_SHIFT);
+            public static final Type G_TYPE_STRING = new Type(16L << G_TYPE_FUNDAMENTAL_SHIFT);
+            public static final Type G_TYPE_POINTER = new Type(17L << G_TYPE_FUNDAMENTAL_SHIFT);
+            public static final Type G_TYPE_BOXED = new Type(18L << G_TYPE_FUNDAMENTAL_SHIFT);
+            public static final Type G_TYPE_PARAM = new Type(19L << G_TYPE_FUNDAMENTAL_SHIFT);
+            public static final Type G_TYPE_OBJECT = new Type(20L << G_TYPE_FUNDAMENTAL_SHIFT);
+            public static final Type G_TYPE_VARIANT = new Type(21L << G_TYPE_FUNDAMENTAL_SHIFT);
+        """.replaceIndent("    ") + "\n")
     }
-}
+    source("GObject-2.0", "org.gtk.gobject", true, "gobject-2.0") { repo ->
+        // This is an alias for Callback type
+        removeType(repo, "VaClosureMarshal")
+        removeType(repo, "SignalCVaMarshaller")
+        removeFunction(repo, "signal_set_va_marshaller")
+        // Override with different return type
+        renameMethod(repo, "TypeModule", "use", "use_type_module")
+        // These functions have two Callback parameters, this isn't supported yet
+        removeFunction(repo, "signal_new_valist")
+        removeFunction(repo, "signal_newv")
+        removeFunction(repo, "signal_new")
+        removeFunction(repo, "signal_new_class_handler")
 
-tasks.compileJava.get().dependsOn(genSources)
+        fun StringBuilder.template(javatype: String, gtype: String, method: String) = appendLine("""
+                            
+                    /**
+                     * Create a {@link Value} of with the provided {@code $javatype} value.
+                     * @param  arg The initial value to set
+                     * @return The new {@link Value}
+                     */
+                    public static Value create($javatype arg) {
+                        Value v = allocate();
+                        v.init($gtype);
+                        v.$method;
+                        return v;
+                    }
+                """.trimIndent())
+
+        inject(repo, "Value", StringBuilder().run {
+            template("boolean", "org.gtk.glib.Type.G_TYPE_BOOLEAN", "setBoolean(arg)")
+            template("byte", "org.gtk.glib.Type.G_TYPE_CHAR", "setSchar(arg)")
+            template("double", "org.gtk.glib.Type.G_TYPE_DOUBLE", "setDouble(arg)")
+            template("float", "org.gtk.glib.Type.G_TYPE_FLOAT", "setFloat(arg)")
+            template("int", "org.gtk.glib.Type.G_TYPE_INT", "setInt(arg)")
+            template("long", "org.gtk.glib.Type.G_TYPE_LONG", "setLong(arg)")
+            template("String", "org.gtk.glib.Type.G_TYPE_STRING", "setString(arg)")
+            template("Enumeration", "org.gtk.glib.Type.G_TYPE_ENUM", "setEnum(arg.getValue())")
+            template("Bitfield", "org.gtk.glib.Type.G_TYPE_FLAGS", "setFlags(arg.getValue())")
+            template("org.gtk.gobject.GObject", "org.gtk.glib.Type.G_TYPE_OBJECT", "setObject(arg)")
+            template("org.gtk.glib.Type", "org.gtk.gobject.GObjects.gtypeGetType()", "setGtype(arg)")
+            template("Struct", "org.gtk.glib.Type.G_TYPE_BOXED", "setBoxed((MemoryAddress) arg.handle())")
+            template("MemoryAddress", "org.gtk.glib.Type.G_TYPE_POINTER", "setPointer(arg)")
+            template("ParamSpec", "org.gtk.glib.Type.G_TYPE_PARAM", "setParam(arg)")
+            template("Proxy", "org.gtk.glib.Type.G_TYPE_OBJECT", "setObject((org.gtk.gobject.GObject) arg)")
+        }.toString().replaceIndent("    ") + "\n")
+    }
+    source("Gio-2.0", "org.gtk.gio", true, "gio-2.0") { repo ->
+        // Override with different return type
+        renameMethod(repo, "BufferedInputStream", "read_byte", "read_int")
+        // g_async_initable_new_finish is a method declaration in the interface AsyncInitable.
+        // It is meant to be implemented as a constructor (actually, a static factory method).
+        // However, Java does not allow a (non-static) method to be implemented/overridden by a static method.
+        // The current solution is to remove the method from the interface. It is still available in the implementing classes.
+        removeMethod(repo, "AsyncInitable", "new_finish")}
+    source("GModule-2.0", "org.gtk.gmodule", true)
+}

--- a/gstreamer/build.gradle.kts
+++ b/gstreamer/build.gradle.kts
@@ -1,113 +1,89 @@
-import io.github.jwharm.javagi.JavaGI
-import io.github.jwharm.javagi.generator.PatchSet
-import io.github.jwharm.javagi.model.Repository
-import java.nio.file.Path
+import ext.*
+import io.github.jwharm.javagi.generator.PatchSet.*
 
 plugins {
     id("java-gi.library-conventions")
 }
 
-val generatedPath = buildDir.resolve("generated/sources/javagi/java/main")
-
 dependencies {
     api(project(":glib"))
 }
 
-sourceSets {
-    main {
-        java {
-            srcDir(generatedPath)
+setupGenSources {
+    moduleInfo = """
+        module org.gstreamer {
+            requires static org.jetbrains.annotations;
+            requires transitive org.glib;
+            %s
         }
+    """.trimIndent()
+
+    source("GLib-2.0", "org.gtk.glib", false, "glib-2.0") { repo ->
+        // This method has parameters that jextract does not support
+        removeFunction(repo, "assertion_message_cmpnum")
+        // Incompletely defined
+        removeFunction(repo, "clear_error")
     }
+    source("GObject-2.0", "org.gtk.gobject", false, "gobject-2.0") { repo ->
+        // This is an alias for Callback type
+        removeType(repo, "VaClosureMarshal")
+        removeType(repo, "SignalCVaMarshaller")
+        removeFunction(repo, "signal_set_va_marshaller")
+        // Override with different return type
+        renameMethod(repo, "TypeModule", "use", "use_type_module")
+        // These functions have two Callback parameters, this isn't supported yet
+        removeFunction(repo, "signal_new_valist")
+        removeFunction(repo, "signal_newv")
+        removeFunction(repo, "signal_new")
+        removeFunction(repo, "signal_new_class_handler")
+    }
+    source("Gio-2.0", "org.gtk.gio", false, "gio-2.0") { repo ->
+        // Override with different return type
+        renameMethod(repo, "BufferedInputStream", "read_byte", "read_int")
+        // g_async_initable_new_finish is a method declaration in the interface AsyncInitable.
+        // It is meant to be implemented as a constructor (actually, a static factory method).
+        // However, Java does not allow a (non-static) method to be implemented/overridden by a static method.
+        // The current solution is to remove the method from the interface. It is still available in the implementing classes.
+        removeMethod(repo, "AsyncInitable", "new_finish")
+    }
+    source("GModule-2.0", "org.gtk.gmodule", false)
+    source("Gst-1.0", "org.gstreamer.gst", true, "gstreamer-1.0")
+    source("GstBase-1.0", "org.gstreamer.base", true, "gstbase-1.0")
+    source("GstAllocators-1.0", "org.gstreamer.allocators", true, "gstallocators-1.0")
+    source("GstApp-1.0", "org.gstreamer.app", true, "gstapp-1.0") { repo ->
+        // Override with different return type
+        renameMethod(repo, "AppSrc", "set_caps", "set_capabilities")
+    }
+    source("GstAudio-1.0", "org.gstreamer.audio", true, "gstaudio-1.0")
+    source("GstBadAudio-1.0", "org.gstreamer.badaudio", true, "gstbadaudio-1.0")
+    source("GstCheck-1.0", "org.gstreamer.check", true, "gstcheck-1.0")
+    source("GstController-1.0", "org.gstreamer.controller", true, "gstcontroller-1.0")
+    source("GstGL-1.0", "org.gstreamer.gl", true, "gstgl-1.0")
+    source("GstGLEGL-1.0", "org.gstreamer.gl.egl", true)
+    source("GstGLWayland-1.0", "org.gstreamer.gl.wayland", true)
+    source("GstGLX11-1.0", "org.gstreamer.gl.x11", true)
+    source("GstInsertBin-1.0", "org.gstreamer.insertbin", true, "gstinsertbin-1.0")
+    source("GstMpegts-1.0", "org.gstreamer.mpegts", true, "gstmpegts-1.0")
+    source("GstNet-1.0", "org.gstreamer.net", true, "gstnet-1.0")
+    source("GstPbutils-1.0", "org.gstreamer.pbutils", true, "gstpbutils-1.0")
+    source("GstPlay-1.0", "org.gstreamer.play", true, "gstplay-1.0")
+    source("GstPlayer-1.0", "org.gstreamer.player", true, "gstplayer-1.0")
+    source("GstRtp-1.0", "org.gstreamer.rtp", true, "gstrtp-1.0")
+    source("GstRtsp-1.0", "org.gstreamer.rtsp", true, "gstrtsp-1.0")
+    source("GstSdp-1.0", "org.gstreamer.sdp", true, "gstsdp-1.0")
+    source("GstTag-1.0", "org.gstreamer.tag", true, "gsttag-1.0")
+    source("GstTranscoder-1.0", "org.gstreamer.transcoder", true, "gsttranscoder-1.0")
+    source("GstVideo-1.0", "org.gstreamer.video", true, "gstvideo-1.0")
+    source("Vulkan-1.0", "org.vulkan", true, "vulkan")
+    source("GstVulkan-1.0", "org.gstreamer.vulkan", true, "gstvulkan-1.0") { repo ->
+        // Override with different return type
+        renameMethod(repo, "VulkanDescriptorCache", "acquire", "acquireDescriptorSet")
+    }
+    source("GstVulkanWayland-1.0", "org.gstreamer.vulkan.wayland", true)
+    source("GstWebRTC-1.0", "org.gstreamer.webrtc", true, "gstwebrtc-1.0")
+    source("GstCodecs-1.0", "org.gstreamer.codecs", true, "gstcodecs-1.0")
 }
 
-val genSources by tasks.registering {
-    doLast {
-        val sourcePath = Path.of(if (project.hasProperty("girSources")) project.property("girSources").toString() else "/usr/share/gir-1.0")
-        fun source(name: String, pkg: String, generate: Boolean, vararg natives: String, patches: PatchSet? = null) = JavaGI.Source(sourcePath.resolve("$name.gir"), pkg, generate, setOf(*natives), patches ?: PatchSet.EMPTY)
-        JavaGI.generate(generatedPath.toPath(),
-            source("GLib-2.0", "org.gtk.glib", false, "glib-2.0", patches = object: PatchSet() {
-                override fun patch(repo: Repository?) {
-                    // This method has parameters that jextract does not support
-                    removeFunction(repo, "assertion_message_cmpnum")
-                    // Incompletely defined
-                    removeFunction(repo, "clear_error")
-                }
-            }),
-            source("GObject-2.0", "org.gtk.gobject", false, "gobject-2.0", patches = object: PatchSet() {
-                override fun patch(repo: Repository?) {
-                    // This is an alias for Callback type
-                    removeType(repo, "VaClosureMarshal")
-                    removeType(repo, "SignalCVaMarshaller")
-                    removeFunction(repo, "signal_set_va_marshaller")
-                    // Override with different return type
-                    renameMethod(repo, "TypeModule", "use", "use_type_module")
-                    // These functions have two Callback parameters, this isn't supported yet
-                    removeFunction(repo, "signal_new_valist")
-                    removeFunction(repo, "signal_newv")
-                    removeFunction(repo, "signal_new")
-                    removeFunction(repo, "signal_new_class_handler")
-                }
-            }),
-            source("Gio-2.0", "org.gtk.gio", false, "gio-2.0", patches = object: PatchSet() {
-                override fun patch(repo: Repository?) {
-                    // Override with different return type
-                    renameMethod(repo, "BufferedInputStream", "read_byte", "read_int")
-                    // g_async_initable_new_finish is a method declaration in the interface AsyncInitable.
-                    // It is meant to be implemented as a constructor (actually, a static factory method).
-                    // However, Java does not allow a (non-static) method to be implemented/overridden by a static method.
-                    // The current solution is to remove the method from the interface. It is still available in the implementing classes.
-                    removeMethod(repo, "AsyncInitable", "new_finish")
-                }
-            }),
-            source("GModule-2.0", "org.gtk.gmodule", false),
-            source("Gst-1.0", "org.gstreamer.gst", true, "gstreamer-1.0"),
-            source("GstBase-1.0", "org.gstreamer.base", true, "gstbase-1.0"),
-            source("GstAllocators-1.0", "org.gstreamer.allocators", true, "gstallocators-1.0"),
-            source("GstApp-1.0", "org.gstreamer.app", true, "gstapp-1.0", patches = object: PatchSet() {
-                override fun patch(repo: Repository?) {
-                    // Override with different return type
-                    renameMethod(repo, "AppSrc", "set_caps", "set_capabilities")
-                }
-            }),
-            source("GstAudio-1.0", "org.gstreamer.audio", true, "gstaudio-1.0"),
-            source("GstBadAudio-1.0", "org.gstreamer.badaudio", true, "gstbadaudio-1.0"),
-            source("GstCheck-1.0", "org.gstreamer.check", true, "gstcheck-1.0"),
-            source("GstController-1.0", "org.gstreamer.controller", true, "gstcontroller-1.0"),
-            source("GstGL-1.0", "org.gstreamer.gl", true, "gstgl-1.0"),
-            source("GstGLEGL-1.0", "org.gstreamer.gl.egl", true),
-            source("GstGLWayland-1.0", "org.gstreamer.gl.wayland", true),
-            source("GstGLX11-1.0", "org.gstreamer.gl.x11", true),
-            source("GstInsertBin-1.0", "org.gstreamer.insertbin", true, "gstinsertbin-1.0"),
-            source("GstMpegts-1.0", "org.gstreamer.mpegts", true, "gstmpegts-1.0"),
-            source("GstNet-1.0", "org.gstreamer.net", true, "gstnet-1.0"),
-            source("GstPbutils-1.0", "org.gstreamer.pbutils", true, "gstpbutils-1.0"),
-            source("GstPlay-1.0", "org.gstreamer.play", true, "gstplay-1.0"),
-            source("GstPlayer-1.0", "org.gstreamer.player", true, "gstplayer-1.0"),
-            source("GstRtp-1.0", "org.gstreamer.rtp", true, "gstrtp-1.0"),
-            source("GstRtsp-1.0", "org.gstreamer.rtsp", true, "gstrtsp-1.0"),
-            source("GstSdp-1.0", "org.gstreamer.sdp", true, "gstsdp-1.0"),
-            source("GstTag-1.0", "org.gstreamer.tag", true, "gsttag-1.0"),
-            source("GstTranscoder-1.0", "org.gstreamer.transcoder", true, "gsttranscoder-1.0"),
-            source("GstVideo-1.0", "org.gstreamer.video", true, "gstvideo-1.0"),
-            source("Vulkan-1.0", "org.vulkan", true, "vulkan"),
-            source("GstVulkan-1.0", "org.gstreamer.vulkan", true, "gstvulkan-1.0", patches = object: PatchSet() {
-                override fun patch(repo: Repository?) {
-                    // Override with different return type
-                    renameMethod(repo, "VulkanDescriptorCache", "acquire", "acquireDescriptorSet")
-                }
-            }),
-            source("GstVulkanWayland-1.0", "org.gstreamer.vulkan.wayland", true),
-            source("GstWebRTC-1.0", "org.gstreamer.webrtc", true, "gstwebrtc-1.0"),
-            source("GstCodecs-1.0", "org.gstreamer.codecs", true, "gstcodecs-1.0")
-        ).writeModuleInfo("""
-            module org.gstreamer {
-                requires static org.jetbrains.annotations;
-                requires transitive org.glib;
-                %s
-            }
-        """.trimIndent())
-    }
+tasks.javadoc {
+    options.linksOffline("https://jwharm.github.io/java-gi/glib", project(":glib"))
 }
-
-tasks.compileJava.get().dependsOn(genSources)

--- a/gtk4/build.gradle.kts
+++ b/gtk4/build.gradle.kts
@@ -1,111 +1,83 @@
-import io.github.jwharm.javagi.JavaGI
-import io.github.jwharm.javagi.generator.PatchSet
-import io.github.jwharm.javagi.model.Repository
-import java.nio.file.Path
+import ext.*
+import io.github.jwharm.javagi.generator.PatchSet.*
 
 plugins {
     id("java-gi.library-conventions")
 }
 
-val generatedPath = buildDir.resolve("generated/sources/javagi/java/main")
-
 dependencies {
     api(project(":glib"))
 }
 
-sourceSets {
-    main {
-        java {
-            srcDir(generatedPath)
+setupGenSources {
+    moduleInfo = """
+        module org.gtk {
+            requires static org.jetbrains.annotations;
+            requires transitive org.glib;
+            %s
         }
+    """.trimIndent()
+
+    source("GLib-2.0", "org.gtk.glib", false, "glib-2.0") { repo ->
+        // This method has parameters that jextract does not support
+        removeFunction(repo, "assertion_message_cmpnum")
+        // Incompletely defined
+        removeFunction(repo, "clear_error")
+    }
+    source("GObject-2.0", "org.gtk.gobject", false, "gobject-2.0") { repo ->
+        // This is an alias for Callback type
+        removeType(repo, "VaClosureMarshal")
+        removeType(repo, "SignalCVaMarshaller")
+        removeFunction(repo, "signal_set_va_marshaller")
+        // Override with different return type
+        renameMethod(repo, "TypeModule", "use", "use_type_module")
+        // These functions have two Callback parameters, this isn't supported yet
+        removeFunction(repo, "signal_new_valist")
+        removeFunction(repo, "signal_newv")
+        removeFunction(repo, "signal_new")
+        removeFunction(repo, "signal_new_class_handler")
+    }
+    source("Gio-2.0", "org.gtk.gio", false, "gio-2.0") { repo ->
+        // Override with different return type
+        renameMethod(repo, "BufferedInputStream", "read_byte", "read_int")
+        // g_async_initable_new_finish is a method declaration in the interface AsyncInitable.
+        // It is meant to be implemented as a constructor (actually, a static factory method).
+        // However, Java does not allow a (non-static) method to be implemented/overridden by a static method.
+        // The current solution is to remove the method from the interface. It is still available in the implementing classes.
+        removeMethod(repo, "AsyncInitable", "new_finish")
+    }
+    source("GModule-2.0", "org.gtk.gmodule", false)
+    source("cairo-1.0", "org.cairographics", true, "cairo", "cairo-gobject") { repo ->
+        // Incompletely defined
+        removeFunction(repo, "image_surface_create")
+    }
+    source("freetype2-2.0", "org.freetype", true)
+    source("HarfBuzz-0.0", "org.harfbuzz", true, "harfbuzz") { repo ->
+        // This constant has type "language_t" which cannot be instantiated
+        removeConstant(repo, "LANGUAGE_INVALID")
+    }
+    source("Pango-1.0", "org.pango", true, "pango-1.0")
+    source("PangoCairo-1.0", "org.pango.cairo", true, "pangocairo-1.0")
+    source("GdkPixbuf-2.0", "org.gtk.gdkpixbuf", true, "gdk_pixbuf-2.0")
+    source("Gdk-4.0", "org.gtk.gdk", true)
+    source("Graphene-1.0", "org.gtk.graphene", true, "graphene-1.0")
+    source("Gsk-4.0", "org.gtk.gsk", true)
+    source("Gtk-4.0", "org.gtk.gtk", true, "gtk-4") { repo ->
+        // Override with different return type
+        renameMethod(repo, "MenuButton", "get_direction", "get_arrow_direction")
+        renameMethod(repo, "PrintUnixDialog", "get_settings", "get_print_settings")
+        renameMethod(repo, "PrintSettings", "get", "get_string")
+        // This method returns void in interface ActionGroup, but returns boolean in class Widget.
+        // Subclasses from Widget that implement ActionGroup throw a compile error.
+        setReturnVoid(repo, "Widget", "activate_action")
+    }
+    source("Adw-1", "org.gnome.adw", true, "adwaita-1") { repo ->
+        // Override with different return type
+        renameMethod(repo, "ActionRow", "activate", "activate_row")
+        renameMethod(repo, "SplitButton", "get_direction", "get_arrow_direction")
     }
 }
 
-val genSources by tasks.registering {
-    doLast {
-        val sourcePath = Path.of(if (project.hasProperty("girSources")) project.property("girSources").toString() else "/usr/share/gir-1.0")
-        fun source(name: String, pkg: String, generate: Boolean, vararg natives: String, patches: PatchSet? = null) = JavaGI.Source(sourcePath.resolve("$name.gir"), pkg, generate, setOf(*natives), patches ?: PatchSet.EMPTY)
-        JavaGI.generate(generatedPath.toPath(),
-            source("GLib-2.0", "org.gtk.glib", false, "glib-2.0", patches = object: PatchSet() {
-                override fun patch(repo: Repository?) {
-                    // This method has parameters that jextract does not support
-                    removeFunction(repo, "assertion_message_cmpnum")
-                    // Incompletely defined
-                    removeFunction(repo, "clear_error")
-                }
-            }),
-            source("GObject-2.0", "org.gtk.gobject", false, "gobject-2.0", patches = object: PatchSet() {
-                override fun patch(repo: Repository?) {
-                    // This is an alias for Callback type
-                    removeType(repo, "VaClosureMarshal")
-                    removeType(repo, "SignalCVaMarshaller")
-                    removeFunction(repo, "signal_set_va_marshaller")
-                    // Override with different return type
-                    renameMethod(repo, "TypeModule", "use", "use_type_module")
-                    // These functions have two Callback parameters, this isn't supported yet
-                    removeFunction(repo, "signal_new_valist")
-                    removeFunction(repo, "signal_newv")
-                    removeFunction(repo, "signal_new")
-                    removeFunction(repo, "signal_new_class_handler")
-                }
-            }),
-            source("Gio-2.0", "org.gtk.gio", false, "gio-2.0", patches = object: PatchSet() {
-                override fun patch(repo: Repository?) {
-                    // Override with different return type
-                    renameMethod(repo, "BufferedInputStream", "read_byte", "read_int")
-                    // g_async_initable_new_finish is a method declaration in the interface AsyncInitable.
-                    // It is meant to be implemented as a constructor (actually, a static factory method).
-                    // However, Java does not allow a (non-static) method to be implemented/overridden by a static method.
-                    // The current solution is to remove the method from the interface. It is still available in the implementing classes.
-                    removeMethod(repo, "AsyncInitable", "new_finish")
-                }
-            }),
-            source("GModule-2.0", "org.gtk.gmodule", false),
-            source("cairo-1.0", "org.cairographics", true, "cairo", "cairo-gobject", patches = object: PatchSet() {
-                override fun patch(repo: Repository?) {
-                    // Incompletely defined
-                    removeFunction(repo, "image_surface_create")
-                }
-            }),
-            source("freetype2-2.0", "org.freetype", true),
-            source("HarfBuzz-0.0", "org.harfbuzz", true, "harfbuzz", patches = object: PatchSet() {
-                override fun patch(repo: Repository?) {
-                    // This constant has type "language_t" which cannot be instantiated
-                    removeConstant(repo, "LANGUAGE_INVALID")
-                }
-            }),
-            source("Pango-1.0", "org.pango", true, "pango-1.0"),
-            source("PangoCairo-1.0", "org.pango.cairo", true, "pangocairo-1.0"),
-            source("GdkPixbuf-2.0", "org.gtk.gdkpixbuf", true, "gdk_pixbuf-2.0"),
-            source("Gdk-4.0", "org.gtk.gdk", true),
-            source("Graphene-1.0", "org.gtk.graphene", true, "graphene-1.0"),
-            source("Gsk-4.0", "org.gtk.gsk", true),
-            source("Gtk-4.0", "org.gtk.gtk", true, "gtk-4", patches = object: PatchSet() {
-                override fun patch(repo: Repository?) {
-                    // Override with different return type
-                    renameMethod(repo, "MenuButton", "get_direction", "get_arrow_direction")
-                    renameMethod(repo, "PrintUnixDialog", "get_settings", "get_print_settings")
-                    renameMethod(repo, "PrintSettings", "get", "get_string")
-                    // This method returns void in interface ActionGroup, but returns boolean in class Widget.
-                    // Subclasses from Widget that implement ActionGroup throw a compile error.
-                    setReturnVoid(repo, "Widget", "activate_action");
-                }
-            }),
-            source("Adw-1", "org.gnome.adw", true, "adwaita-1", patches = object: PatchSet() {
-                override fun patch(repo: Repository?) {
-                    // Override with different return type
-                    renameMethod(repo, "ActionRow", "activate", "activate_row")
-                    renameMethod(repo, "SplitButton", "get_direction", "get_arrow_direction")
-                }
-            })
-        ).writeModuleInfo("""
-            module org.gtk {
-                requires static org.jetbrains.annotations;
-                requires transitive org.glib;
-                %s
-            }
-        """.trimIndent())
-    }
+tasks.javadoc {
+    options.linksOffline("https://jwharm.github.io/java-gi/glib", project(":glib"))
 }
-
-tasks.compileJava.get().dependsOn(genSources)


### PR DESCRIPTION
This adds references to the glib Javadoc to the gtk4/gstreamer Javadocs.
These references are generated locally (the version online is not used).
Additionally, I moved some common logic for JavaGI invocation/gradle configuration to buildSrc.