### PR TITLE
Detect user_data parameters using 'closure' attribute

### DIFF
--- a/example/src/main/java/io/github/jwharm/javagi/example/GStreamerExample.java
+++ b/example/src/main/java/io/github/jwharm/javagi/example/GStreamerExample.java
@@ -86,7 +86,7 @@ public class GStreamerExample {
 
         // We add a message handler
         bus = pipeline.getBus();
-        busWatchId = bus.addWatch(0, this::busCall, () -> {});
+        busWatchId = bus.addWatch(0, this::busCall, null);
 
         // We add all elements into the pipeline
         // file-source | ogg-demuxer | vorbis-decoder | converter | alsa-output

--- a/example/src/main/java/io/github/jwharm/javagi/example/Gtk4Example.java
+++ b/example/src/main/java/io/github/jwharm/javagi/example/Gtk4Example.java
@@ -61,7 +61,7 @@ public class Gtk4Example {
                 widget.queueDraw();
             }
             return GLib.SOURCE_CONTINUE;
-        }, () -> {});
+        }, null);
 
         box.append(button);
         window.setChild(box);

--- a/example/src/main/java/io/github/jwharm/javagi/example/ListIndexItem.java
+++ b/example/src/main/java/io/github/jwharm/javagi/example/ListIndexItem.java
@@ -34,7 +34,7 @@ public class ListIndexItem extends GObject {
                     GObject.getType(),
                     "ListIndexItem",
                     (short) ObjectClass.getMemoryLayout().byteSize(),
-                    gclass -> {},
+                    (gclass, data) -> {},
                     (short) getMemoryLayout().byteSize(),
                     (inst, gclass) -> {},
                     TypeFlags.NONE

--- a/example/src/main/java/io/github/jwharm/javagi/example/ListIndexModel.java
+++ b/example/src/main/java/io/github/jwharm/javagi/example/ListIndexModel.java
@@ -33,13 +33,13 @@ public class ListIndexModel extends GObject implements ListModel {
                     GObject.getType(),
                     "ListIndexModel",
                     (short) ObjectClass.getMemoryLayout().byteSize(),
-                    gclass -> {},
+                    (gclass, data) -> {},
                     (short) getMemoryLayout().byteSize(),
                     (inst, gclass) -> {},
                     TypeFlags.NONE
             );
             GObjects.typeAddInterfaceStatic(type, ListModel.getType(), InterfaceInfo.builder()
-                    .setInterfaceInit(iface -> {
+                    .setInterfaceInit((iface, data) -> {
                         ListModelInterface lmi = ListModelInterface.fromAddress.marshal(iface.handle(), null);
                         lmi.setGetItemType(ListModel::getItemType);
                         lmi.setGetNItems(ListModel::getNItems);

--- a/generator/src/main/java/io/github/jwharm/javagi/generator/GirParser.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/generator/GirParser.java
@@ -218,7 +218,7 @@ public class GirParser extends DefaultHandler {
                 Parameter newParameter = new Parameter(current, attr.getValue("name"),
                         attr.getValue("transfer-ownership"), attr.getValue("nullable"),
                         attr.getValue("allow-none"), attr.getValue("optional"),
-                        attr.getValue("direction"));
+                        attr.getValue("direction"), attr.getValue("closure"));
                 ((Parameters) current).parameterList.add(newParameter);
                 current = newParameter;
             }

--- a/generator/src/main/java/io/github/jwharm/javagi/model/InstanceParameter.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/InstanceParameter.java
@@ -3,6 +3,6 @@ package io.github.jwharm.javagi.model;
 public class InstanceParameter extends Parameter {
 
     public InstanceParameter(GirElement parent, String name, String transferOwnership, String nullable, String allowNone) {
-        super(parent, name, transferOwnership, nullable, allowNone, null, null);
+        super(parent, name, transferOwnership, nullable, allowNone, null, null, null);
     }
 }

--- a/generator/src/main/java/io/github/jwharm/javagi/model/Parameter.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/Parameter.java
@@ -11,17 +11,21 @@ public class Parameter extends Variable {
     public final boolean nullable;
     public final boolean notnull;
     public final String direction;
+    public final String closure;
 
     public boolean varargs = false;
     public boolean signalSource = false;
 
-    public Parameter(GirElement parent, String name, String transferOwnership, String nullable, String allowNone, String optional, String direction) {
+    public Parameter(GirElement parent, String name, String transferOwnership, String nullable,
+                     String allowNone, String optional, String direction, String closure) {
+
         super(parent);
         this.name = Conversions.toLowerCaseJavaName(name);
         this.transferOwnership = transferOwnership;
         this.nullable = "1".equals(nullable) || "1".equals(allowNone) || "1".equals(optional);
         this.notnull = "0".equals(nullable) || "0".equals(allowNone) || "0".equals(optional);
         this.direction = direction;
+        this.closure = closure;
     }
 
     /**
@@ -100,9 +104,37 @@ public class Parameter extends Variable {
     }
 
     public boolean isUserDataParameter() {
-        return (type != null)
-                && (name.toLowerCase().endsWith("data") || name.equalsIgnoreCase("userdata2"))
-                && ("gpointer".equals(type.cType) || "gconstpointer".equals(type.cType));
+        // Closure parameters: the user_data parameter has attribute "closure" set
+        if (parent.parent instanceof Closure) {
+            return (closure != null);
+        }
+
+        // Method parameters that pass a user_data pointer to a closure
+        else {
+            // A user_data parameter must have a type (pointer)
+            if (type == null)
+                return false;
+
+            // The c:type must be a gpointer or gconstpointer
+            if (! ("gpointer".equals(type.cType) || "gconstpointer".equals(type.cType)))
+                return false;
+
+            // Loop through the callback parameter(s)
+            Parameters parameters = (Parameters) parent;
+            for (Parameter p : parameters.parameterList) {
+                if (p.type != null && p.type.isCallback()) {
+
+                    // The closure attribute points to the user_data parameter
+                    if (p.closure != null) {
+                        Parameter userData = getParameterAt(p.closure);
+                        // Is this the user_data parameter that is referred to?
+                        return userData.name.equals(this.name);
+                    }
+
+                }
+            }
+            return false;
+        }
     }
 
     public boolean isErrorParameter() {

--- a/generator/src/main/java/io/github/jwharm/javagi/model/ReturnValue.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/ReturnValue.java
@@ -8,7 +8,7 @@ import io.github.jwharm.javagi.generator.SourceWriter;
 public class ReturnValue extends Parameter {
 
     public ReturnValue(GirElement parent, String transferOwnership, String nullable) {
-        super(parent, null, transferOwnership, nullable, null, null, null);
+        super(parent, null, transferOwnership, nullable, null, null, null, null);
     }
 
     /**

--- a/generator/src/main/java/io/github/jwharm/javagi/model/Signal.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/Signal.java
@@ -27,7 +27,7 @@ public class Signal extends Method implements Closure {
             parameters = new Parameters(this);
         }
         String paramName = "source" + className;
-        Parameter p = new Parameter(parameters, paramName, "none", "0", "0", "0", null);
+        Parameter p = new Parameter(parameters, paramName, "none", "0", "0", "0", null, null);
         p.type = new Type(p, className, ((RegisteredType) parent).cType);
         p.signalSource = true;
         parameters.parameterList.add(0, p);


### PR DESCRIPTION
Fixes #35 

Please review; this should improve the detection of `user_data` parameters that can be omitted from the Java API.

The old functionality filters all parameters with type `gpointer` and name ending with `data`, but that resulted in a lot of false positives (for example in `g_list_append`).
