### PR TITLE
Virtual methods

### DIFF
--- a/buildSrc/src/main/kotlin/java-gi.library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-gi.library-conventions.gradle.kts
@@ -51,5 +51,6 @@ tasks.javadoc {
         addStringOption("source", "19")
         addBooleanOption("-enable-preview", true)
         addStringOption("windowtitle", "java-gi ${project.version}")
+        addStringOption("Xdoclint:none", "-quiet")
     }
 }

--- a/generator/src/main/java/io/github/jwharm/javagi/JavaGI.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/JavaGI.java
@@ -79,10 +79,14 @@ public class JavaGI {
         
         // Parse the GI files into Repository objects
         for (Source source : sources) {
-            System.out.println("PARSE " + source.source());
-            Repository r = parser.parse(source.source(), source.pkg());
-            Conversions.repositoriesLookupTable.put(r.namespace.name, r);
-            parsed.put(r.namespace.name, new Parsed(r, source.generate, source.natives, source.patches));
+            try {
+                System.out.println("PARSE " + source.source());
+                Repository r = parser.parse(source.source(), source.pkg());
+                Conversions.repositoriesLookupTable.put(r.namespace.name, r);
+                parsed.put(r.namespace.name, new Parsed(r, source.generate, source.natives, source.patches));
+            } catch (IOException ioe) {
+                System.err.printf("PARSE %s: NOT FOUND\n", source.source());
+            }
         }
         
         // Link the type references to the GIR type definition across the GI repositories

--- a/generator/src/main/java/io/github/jwharm/javagi/generator/BindingsGenerator.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/generator/BindingsGenerator.java
@@ -1,6 +1,7 @@
 package io.github.jwharm.javagi.generator;
 
 import io.github.jwharm.javagi.model.Class;
+import io.github.jwharm.javagi.model.Record;
 import io.github.jwharm.javagi.model.*;
 
 import java.io.IOException;
@@ -20,6 +21,12 @@ public class BindingsGenerator {
         // Create a java file for each RegisteredType (class, interface, ...)
         for (RegisteredType rt : gir.namespace.registeredTypeMap.values()) {
             
+            // Class type structs are generated as inner classes
+            if (rt instanceof Record rec && rec.isGTypeStructFor != null) {
+                continue;
+            }
+            
+            // Generate the class
             try (SourceWriter writer = new SourceWriter(Files.newBufferedWriter(basePath.resolve(rt.javaName + ".java")))) {
                 rt.generate(writer);
             }
@@ -58,7 +65,7 @@ public class BindingsGenerator {
             }
 
             for (Function function : gir.namespace.functionList) {
-                function.generate(writer, function.parent instanceof Interface, true);
+                function.generate(writer);
             }
             
             if (! gir.namespace.functionList.isEmpty()) {
@@ -66,7 +73,7 @@ public class BindingsGenerator {
                 writer.write("private static class DowncallHandles {\n");
                 writer.increaseIndent();
                 for (Function f : gir.namespace.functionList) {
-                    f.generateMethodHandle(writer, false);
+                    f.generateMethodHandle(writer);
                 }
                 writer.decreaseIndent();
                 writer.write("}\n");

--- a/generator/src/main/java/io/github/jwharm/javagi/generator/Conversions.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/generator/Conversions.java
@@ -130,7 +130,7 @@ public class Conversions {
                 "protected", "throw", "byte", "else", "import", "public", "throws", "case", "enum",
                 "instanceof", "return", "transient", "catch", "extends", "int", "short", "try", "char",
                 "final", "interface", "static", "void", "class", "finally", "long", "strictfp", "volatile",
-                "const", "float", "native", "super", "while", "wait"
+                "const", "float", "native", "super", "while", "wait", "finalize"
         };
         return Arrays.stream(keywords).anyMatch(kw -> kw.equalsIgnoreCase(name)) ? name + "_" : name;
     }
@@ -294,7 +294,7 @@ public class Conversions {
             case "int" -> Numbers.parseInt(value).toString();
             case "long" -> Numbers.parseLong(value) + "L";
             case "short" -> Numbers.parseShort(value).toString();
-            case "java.lang.String" -> '"' + value + '"';
+            case "java.lang.String" -> '"' + value.replace("\\", "\\\\") + '"';
             default -> value;
         };
     }

--- a/generator/src/main/java/io/github/jwharm/javagi/generator/Javadoc.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/generator/Javadoc.java
@@ -5,6 +5,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import io.github.jwharm.javagi.model.*;
+import io.github.jwharm.javagi.model.Record;
 
 public class Javadoc {
 
@@ -274,7 +275,15 @@ public class Javadoc {
         if (rt == null) {
             return "{@code " + ref.substring(1) + "}";
         } else {
-            return "{@link " + formatNS(rt.getNamespace().name) + rt.javaName + "}";
+            String typeName = rt.javaName;
+            // If the link refers to the typestruct for a class, find the enclosing class and add it to the link.
+            if (rt instanceof Record rec && rec.isGTypeStructFor != null) {
+                RegisteredType baseType = rt.getNamespace().registeredTypeMap.get(rec.isGTypeStructFor);
+                if (baseType != null) {
+                    typeName = baseType.javaName + "." + typeName;
+                }
+            }
+            return "{@link " + formatNS(rt.getNamespace().name) + typeName + "}";
         }
     }
 

--- a/generator/src/main/java/io/github/jwharm/javagi/generator/SourceWriter.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/generator/SourceWriter.java
@@ -37,12 +37,18 @@ public class SourceWriter implements AutoCloseable {
     }
 
     /**
-     * Write the provided String. When {@code str} ends with a newline ({@code \n}),
+     * Write the provided String, but when {@code str} ends with a newline ({@code \n}),
      * the next line will be indented with the current indentation level.
-     * @param str
-     * @throws IOException
+     * <p>
+     * If {@code str} is {@code null}, nothing is written.
+     * @param str the String to write
+     * @throws IOException thrown while calling {@link Writer#write(String)}
      */
     public void write(String str) throws IOException {
+        if (str == null) {
+            return;
+        }
+        
         if (writeIndent) {
             writer.write(indent);
             writeIndent = false;
@@ -62,5 +68,14 @@ public class SourceWriter implements AutoCloseable {
     @Override
     public void close() throws IOException {
         writer.close();
+    }
+    
+    /**
+     * Return the {@code toString} of the enclosed {@code Writer} instance
+     * @return the result of calling {@link Writer#toString()} on the enclosed {@code Writer} instance
+     */
+    @Override
+    public String toString() {
+        return writer.toString();
     }
 }

--- a/generator/src/main/java/io/github/jwharm/javagi/model/Bitfield.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/Bitfield.java
@@ -38,10 +38,7 @@ public class Bitfield extends ValueWrapper {
         }
         
         generateValueConstructor(writer, "int");
-        
-        for (Function function : functionList) {
-            function.generate(writer, false, true);
-        }
+        generateMethodsAndSignals(writer);
         
         writer.write("\n");
         writer.write("/**\n");

--- a/generator/src/main/java/io/github/jwharm/javagi/model/Class.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/Class.java
@@ -1,5 +1,6 @@
 package io.github.jwharm.javagi.model;
 
+import io.github.jwharm.javagi.generator.Conversions;
 import io.github.jwharm.javagi.generator.GObjectBuilder;
 import io.github.jwharm.javagi.generator.SourceWriter;
 
@@ -13,6 +14,8 @@ public class Class extends RegisteredType {
     public String typeStruct;
     public String abstract_;
     public String final_;
+    
+    public Record classStruct;
 
     public Class(GirElement parent, String name, String parentClass, String cType, String typeName, String getType,
             String typeStruct, String version, String abstract_, String final_) {
@@ -33,6 +36,8 @@ public class Class extends RegisteredType {
     }
 
     public void generate(SourceWriter writer) throws IOException {
+        classStruct = (Record) Conversions.cTypeLookupTable.get(getNamespace().cIdentifierPrefix + typeStruct);
+        
         generatePackageDeclaration(writer);
         generateImportStatements(writer);
         generateJavadoc(writer);
@@ -87,19 +92,12 @@ public class Class extends RegisteredType {
         generateCType(writer);
         generateMemoryLayout(writer);
         generateConstructors(writer);
+        generateMethodsAndSignals(writer);
 
-        for (Method m : methodList) {
-            m.generate(writer, false, false);
+        if (classStruct != null) {
+            classStruct.generate(writer);
         }
-
-        for (Function function : functionList) {
-            function.generate(writer, false, true);
-        }
-
-        for (Signal s : signalList) {
-            s.generate(writer, false);
-        }
-
+        
         if (isInstanceOf("org.gnome.gobject.GObject")) {
             GObjectBuilder.generateBuilder(writer, this);
         }

--- a/generator/src/main/java/io/github/jwharm/javagi/model/Closure.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/Closure.java
@@ -26,7 +26,7 @@ public interface Closure extends CallableType {
             doc.generate(writer, false);
 
         // Generate run(...) method
-        returnValue.writeType(writer, false);
+        returnValue.writeType(writer, false, true);
         writer.write(" run(");
         if (parameters != null) {
             boolean first = true;

--- a/generator/src/main/java/io/github/jwharm/javagi/model/Enumeration.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/Enumeration.java
@@ -95,12 +95,8 @@ public class Enumeration extends ValueWrapper {
         writer.write("    };\n");
         writer.write("}\n");
         
-        for (Function function : functionList) {
-            function.generate(writer, false, true);
-        }
-
+        generateMethodsAndSignals(writer);
         generateDowncallHandles(writer);
-
         generateInjected(writer);
 
         writer.decreaseIndent();

--- a/generator/src/main/java/io/github/jwharm/javagi/model/Field.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/Field.java
@@ -61,7 +61,7 @@ public class Field extends Variable {
             writer.write(" * @return The value of the field {@code " + this.fieldName + "}\n");
             writer.write(" */\n");
             writer.write("public ");
-            writeType(writer, true);
+            writeType(writer, true, true);
             writer.write(" " + getter + "() {\n");
 
             if ((type != null) && (!type.isPointer()) && (type.isClass() || type.isInterface())) {
@@ -120,17 +120,17 @@ public class Field extends Variable {
         // Regular types (not arrays or callbacks)
         if (type != null) {
             
-            // Bitfields and enumerations are integers
-            if (type.isBitfield() || type.isEnum()) {
-                return "Interop.valueLayout.C_INT.withName(\"" + this.fieldName + "\")";
-            }
-            
             // Pointers, strings and callbacks are memory addresses
             if (type.isPointer()
                     || "java.lang.String".equals(type.qualifiedJavaType)
                     || "java.lang.foreign.MemoryAddress".equals(type.qualifiedJavaType)
                     || type.isCallback()) {
                 return "Interop.valueLayout.ADDRESS.withName(\"" + this.fieldName + "\")";
+            }
+            
+            // Bitfields and enumerations are integers
+            if (type.isBitfield() || type.isEnum()) {
+                return "Interop.valueLayout.C_INT.withName(\"" + this.fieldName + "\")";
             }
             
             // Primitive types and aliases

--- a/generator/src/main/java/io/github/jwharm/javagi/model/Interface.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/Interface.java
@@ -1,5 +1,6 @@
 package io.github.jwharm.javagi.model;
 
+import io.github.jwharm.javagi.generator.Conversions;
 import io.github.jwharm.javagi.generator.GObjectBuilder;
 import io.github.jwharm.javagi.generator.SourceWriter;
 
@@ -7,19 +8,28 @@ import java.io.IOException;
 
 public class Interface extends RegisteredType {
 
-    public String typeName, getType, typeStruct;
+    public String typeName;
+    public String getType;
+    public String typeStruct;
     public Prerequisite prerequisite;
 
+    public Record classStruct;
+    
     public Interface(GirElement parent, String name, String cType, String typeName, String getType,
             String typeStruct, String version) {
         
         super(parent, name, null, cType, version);
+        this.typeName = typeName;
+        this.getType = getType;
+        this.typeStruct = typeStruct;
         
         // Generate a function declaration to retrieve the type of this object.
         registerGetTypeFunction(getType);
     }
 
     public void generate(SourceWriter writer) throws IOException {
+        classStruct = (Record) Conversions.cTypeLookupTable.get(getNamespace().cIdentifierPrefix + typeStruct);
+        
         generatePackageDeclaration(writer);
         generateImportStatements(writer);
         generateJavadoc(writer);
@@ -32,19 +42,12 @@ public class Interface extends RegisteredType {
         writer.increaseIndent();
 
         generateMarshal(writer);
+        generateMethodsAndSignals(writer);
 
-        for (Method m : methodList) {
-            m.generate(writer, true, false);
+        if (classStruct != null) {
+            classStruct.generate(writer);
         }
-
-        for (Function function : functionList) {
-            function.generate(writer, true, true);
-        }
-
-        for (Signal s : signalList) {
-            s.generate(writer, true);
-        }
-
+        
         GObjectBuilder.generateInterfaceBuilder(writer, this);
         generateDowncallHandles(writer);
         generateImplClass(writer);

--- a/generator/src/main/java/io/github/jwharm/javagi/model/Parameter.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/Parameter.java
@@ -309,7 +309,7 @@ public class Parameter extends Variable {
                 }
             }
             if (array != null) {
-                writeType(writer, false);
+                writeType(writer, false, true);
                 writer.write(" " + name + "OUT = new Out<>(");
                 marshalNativeToJava(writer, name, true);
                 writer.write(");\n");

--- a/generator/src/main/java/io/github/jwharm/javagi/model/Parameters.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/Parameters.java
@@ -27,6 +27,19 @@ public class Parameters extends GirElement {
         }
     }
 
+    public void generateJavaParameterTypes(SourceWriter writer, boolean pointerForArray, boolean writeAnnotations) throws IOException {
+        int counter = 0;
+        for (Parameter p : parameterList) {
+            if (p.isInstanceParameter() || p.isUserDataParameter() || p.isArrayLengthParameter()) {
+                continue;
+            }
+            if (counter++ > 0) {
+                writer.write(", ");
+            }
+            p.writeType(writer, pointerForArray, writeAnnotations);
+        }
+    }
+
     public void generateJavaParameterNames(SourceWriter writer) throws IOException {
         int counter = 0;
         for (Parameter p : parameterList) {

--- a/generator/src/main/java/io/github/jwharm/javagi/model/ReturnValue.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/ReturnValue.java
@@ -8,11 +8,13 @@ import io.github.jwharm.javagi.generator.SourceWriter;
 public class ReturnValue extends Parameter {
 
     public boolean returnsFloatingReference;
+    public String overrideReturnValue;
 
     public ReturnValue(GirElement parent, String transferOwnership, String nullable) {
         super(parent, null, transferOwnership, nullable, null, null, null, null);
 
         returnsFloatingReference = false;
+        overrideReturnValue = null;
     }
 
     /**
@@ -61,6 +63,12 @@ public class ReturnValue extends Parameter {
      */
     public void generateReturnStatement(SourceWriter writer) throws IOException {
         if (type != null && type.isVoid()) {
+            return;
+        }
+        
+        // Return value hard-coded in PatchSet?
+        if (overrideReturnValue != null) {
+            writer.write("return " + overrideReturnValue + ";\n");
             return;
         }
 

--- a/generator/src/main/java/io/github/jwharm/javagi/model/Signal.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/Signal.java
@@ -23,7 +23,7 @@ public class Signal extends Method implements Closure {
         qualifiedName = className + "." + signalName;
     }
 
-    public void generate(SourceWriter writer, boolean isDefault) throws IOException {
+    public void generate(SourceWriter writer) throws IOException {
         writer.write("\n");
         generateFunctionalInterface(writer, signalName);
         writer.write("\n");
@@ -32,7 +32,7 @@ public class Signal extends Method implements Closure {
         if (doc != null) {
             doc.generate(writer, true);
         }
-        writer.write("public " + (isDefault ? "default " : "") + "Signal<" + qualifiedName + "> on" + signalName + "(");
+        writer.write("public " + (parent instanceof Interface ? "default " : "") + "Signal<" + qualifiedName + "> on" + signalName + "(");
         
         // For detailed signals like GObject.notify::..., generate a String parameter to specify the detailed signal
         if (detailed) {
@@ -71,8 +71,8 @@ public class Signal extends Method implements Closure {
             writer.write("/**\n");
             writer.write(" * Emits the " + signalName + " signal. See {@link #on" + signalName + "}.\n");
             writer.write(" */\n");
-            writer.write("public " + (isDefault ? "default " : ""));
-            returnValue.writeType(writer, true);
+            writer.write("public " + (parent instanceof Interface ? "default " : ""));
+            returnValue.writeType(writer, true, true);
             writer.write(" emit" + signalName + "(");
             if (detailed) {
                 writer.write("@Nullable String detail");

--- a/generator/src/main/java/io/github/jwharm/javagi/model/Type.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/Type.java
@@ -53,6 +53,11 @@ public class Type extends GirElement {
         this.simpleJavaType = Conversions.convertToJavaType(name, false, getNamespace());
         this.qualifiedJavaType = Conversions.convertToJavaType(name, true, getNamespace());
         this.isPrimitive = Conversions.isPrimitive(simpleJavaType);
+        
+        if (girElementInstance != null && girElementInstance instanceof Record rec && rec.isGTypeStructFor != null) {
+            qualifiedJavaType = Conversions.convertToJavaType(rec.isGTypeStructFor, true, girElementInstance.getNamespace());
+            qualifiedJavaType += "." + simpleJavaType;
+        }
     }
 
     public boolean isAlias() {

--- a/generator/src/main/java/io/github/jwharm/javagi/model/Variable.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/Variable.java
@@ -22,8 +22,8 @@ public class Variable extends GirElement {
                 type.isEnum()));
     }
 
-    public void writeType(SourceWriter writer, boolean pointerForArray) throws IOException {
-        writer.write(getType(pointerForArray));
+    public void writeType(SourceWriter writer, boolean pointerForArray, boolean writeAnnotations) throws IOException {
+        writer.write(getType(pointerForArray, writeAnnotations));
     }
 
     public void writeName(SourceWriter writer) throws IOException {
@@ -31,7 +31,7 @@ public class Variable extends GirElement {
     }
 
     public void writeTypeAndName(SourceWriter writer, boolean pointerForArray) throws IOException {
-        writeType(writer, pointerForArray);
+        writeType(writer, pointerForArray, true);
         writer.write(" ");
         writeName(writer);
     }
@@ -44,23 +44,23 @@ public class Variable extends GirElement {
         writer.write(marshalNativeToJava(identifier, upcall));
     }
 
-    private String getAnnotations(Type type) {
-        if ((! type.isPrimitive) && (!type.isVoid()) && (this instanceof Parameter p))
+    private String getAnnotations(Type type, boolean writeAnnotations) {
+        if (writeAnnotations && (! type.isPrimitive) && (!type.isVoid()) && (this instanceof Parameter p))
             return p.nullable ? "@Nullable " : p.notnull ? "@NotNull " : "";
 
         return "";
     }
 
-    private String getType(boolean pointerForArray) {
+    private String getType(boolean pointerForArray, boolean writeAnnotations) {
 
         if (type != null)
-            return getAnnotations(type) + getType(type);
+            return getAnnotations(type, writeAnnotations) + getType(type);
 
         if (array != null && array.array != null && "gchar***".equals(array.cType))
             return "java.lang.String[][]";
 
         if (array != null && array.type != null)
-            return getAnnotations(array.type)
+            return getAnnotations(array.type, writeAnnotations)
                     + ((array.size(false) != null)
                     ? getArrayType(array.type)
                     : (pointerForArray ? getPointerType(array.type) : getArrayType(array.type)));

--- a/generator/src/main/java/io/github/jwharm/javagi/model/VirtualMethod.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/VirtualMethod.java
@@ -66,6 +66,7 @@ public class VirtualMethod extends Method {
         if (classStruct == null) {
             throw new IOException("Cannot find class struct for " + parent.name);
         }
+        writer.write("MemoryAddress _class = ((MemoryAddress) handle()).get(Interop.valueLayout.ADDRESS, 0);\n");
         writer.write("long _offset = " + classStruct.javaName);
         writer.write(".getMemoryLayout().byteOffset(MemoryLayout.PathElement.groupElement(\"");
         writer.write(name);
@@ -74,6 +75,8 @@ public class VirtualMethod extends Method {
         writer.write("FunctionDescriptor _fdesc = ");
         boolean varargs = generateFunctionDescriptor(writer);
         writer.write(";\n");
+
+        writer.write("MemoryAddress _func = _class.get(Interop.valueLayout.ADDRESS, _offset);\n");
         
         // Generate the return type
         if (! (returnValue.type != null && returnValue.type.isVoid())) {
@@ -83,7 +86,7 @@ public class VirtualMethod extends Method {
         }
 
         // Invoke to the method handle
-        writer.write("Interop.downcallHandle(((MemoryAddress) handle()).addOffset(_offset), _fdesc).invokeExact");
+        writer.write("Interop.downcallHandle(_func, _fdesc).invokeExact");
         
         // Marshall the parameters to the native types
         if (parameters != null) {

--- a/generator/src/main/java/io/github/jwharm/javagi/model/VirtualMethod.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/VirtualMethod.java
@@ -1,8 +1,134 @@
 package io.github.jwharm.javagi.model;
 
+import java.io.IOException;
+
+import io.github.jwharm.javagi.generator.Conversions;
+import io.github.jwharm.javagi.generator.SourceWriter;
+
 public class VirtualMethod extends Method {
 
     public VirtualMethod(GirElement parent, String name, String deprecated, String throws_) {
         super(parent, name, null, deprecated, throws_, null, null, null);
+    }
+    
+    public void generate(SourceWriter writer) throws IOException {
+        writer.write("\n");
+        
+        // Documentation
+        if (doc != null) {
+            doc.generate(writer, false);
+        }
+
+        // Deprecation
+        if ("1".equals(deprecated)) {
+            writer.write("@Deprecated\n");
+        }
+
+        // Declaration
+        writer.write(getMethodDeclaration());
+        
+        writer.write(" {\n");
+        writer.increaseIndent();
+
+        // Generate try-with-resources?
+        boolean hasScope = allocatesMemory();
+        if (hasScope) {
+            writer.write("try (MemorySession SCOPE = MemorySession.openConfined()) {\n");
+            writer.increaseIndent();
+        }
+
+        // Generate preprocessing statements for all parameters
+        if (parameters != null) {
+            parameters.generatePreprocessing(writer);
+        }
+
+        // Allocate GError pointer
+        if (throws_ != null) {
+            writer.write("MemorySegment GERROR = SCOPE.allocate(Interop.valueLayout.ADDRESS);\n");
+        }
+        
+        // Variable declaration for return value
+        String panamaReturnType = Conversions.toPanamaJavaType(getReturnValue().type);
+        if (! (returnValue.type != null && returnValue.type.isVoid())) {
+            writer.write(panamaReturnType + " RESULT;\n");
+        }
+        
+        // The method call is wrapped in a try-catch block
+        writer.write("try {\n");
+        writer.increaseIndent();
+        
+        Record classStruct = null;
+        if (parent instanceof Class c) {
+            classStruct = c.classStruct;
+        } else if (parent instanceof Interface i) {
+            classStruct = i.classStruct;
+        }
+        if (classStruct == null) {
+            throw new IOException("Cannot find class struct for " + parent.name);
+        }
+        writer.write("long _offset = " + classStruct.javaName);
+        writer.write(".getMemoryLayout().byteOffset(MemoryLayout.PathElement.groupElement(\"");
+        writer.write(name);
+        writer.write("\"));\n");
+        
+        writer.write("FunctionDescriptor _fdesc = ");
+        boolean varargs = generateFunctionDescriptor(writer);
+        writer.write(";\n");
+        
+        // Generate the return type
+        if (! (returnValue.type != null && returnValue.type.isVoid())) {
+            writer.write("RESULT = (");
+            writer.write(panamaReturnType);
+            writer.write(") ");
+        }
+
+        // Invoke to the method handle
+        writer.write("Interop.downcallHandle(((MemoryAddress) handle()).addOffset(_offset), _fdesc).invokeExact");
+        
+        // Marshall the parameters to the native types
+        if (parameters != null) {
+            writer.write("(");
+            parameters.marshalJavaToNative(writer, throws_);
+            writer.write(")");
+        } else {
+            writer.write("()");
+        }
+        writer.write(";\n");
+        
+        // If something goes wrong in the invokeExact() call
+        writer.decreaseIndent();
+        writer.write("} catch (Throwable ERR) {\n");
+        writer.write("    throw new AssertionError(\"Unexpected exception occured: \", ERR);\n");
+        writer.write("}\n");
+
+        // Throw GErrorException
+        if (throws_ != null) {
+            writer.write("if (GErrorException.isErrorSet(GERROR)) {\n");
+            writer.write("    throw new GErrorException(GERROR);\n");
+            writer.write("}\n");
+        }
+        
+        // Generate post-processing actions for parameters
+        if (parameters != null) {
+            parameters.generatePostprocessing(writer);
+        }
+
+        // Generate a call to "yieldOwnership" to disable the Cleaner
+        // when a user manually calls "unref"
+        if (name.equals("unref")) {
+            writer.write("this.yieldOwnership();\n");
+        }
+        
+        // Generate code to process and return the result value
+        returnValue.generate(writer, panamaReturnType);
+
+        // End of memory allocation scope
+        if (hasScope) {
+            writer.decreaseIndent();
+            writer.write("}\n");
+        }
+
+        writer.decreaseIndent();
+        writer.write("}\n");
     }
 }

--- a/generator/src/main/java/io/github/jwharm/javagi/model/VirtualMethod.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/VirtualMethod.java
@@ -64,9 +64,12 @@ public class VirtualMethod extends Method {
             classStruct = i.classStruct;
         }
         if (classStruct == null) {
-            throw new IOException("Cannot find class struct for " + parent.name);
+            throw new IOException("Cannot find typestruct for " + parent.name);
         }
-        writer.write("MemoryAddress _class = ((MemoryAddress) handle()).get(Interop.valueLayout.ADDRESS, 0);\n");
+        writer.write("MemoryAddress _struct = ((MemoryAddress) handle()).get(Interop.valueLayout.ADDRESS, 0);\n");
+        if (parent instanceof Interface) {
+            writer.write("_struct = (MemoryAddress) Interop.g_type_interface_peek.invokeExact((Addressable) _struct, getType().getValue().longValue());\n");
+        }
         writer.write("long _offset = " + classStruct.javaName);
         writer.write(".getMemoryLayout().byteOffset(MemoryLayout.PathElement.groupElement(\"");
         writer.write(name);
@@ -76,7 +79,7 @@ public class VirtualMethod extends Method {
         boolean varargs = generateFunctionDescriptor(writer);
         writer.write(";\n");
 
-        writer.write("MemoryAddress _func = _class.get(Interop.valueLayout.ADDRESS, _offset);\n");
+        writer.write("MemoryAddress _func = _struct.get(Interop.valueLayout.ADDRESS, _offset);\n");
         
         // Generate the return type
         if (! (returnValue.type != null && returnValue.type.isVoid())) {

--- a/glib/build.gradle.kts
+++ b/glib/build.gradle.kts
@@ -130,6 +130,12 @@ setupGenSources {
     source("Gio-2.0", "org.gnome.gio", true, "gio-2.0") { repo ->
         // Override with different return type
         renameMethod(repo, "BufferedInputStream", "read_byte", "read_int")
+        renameMethod(repo, "IOModule", "load", "load_module")
+        
+        setReturnType(repo, "ActionGroup", "activate_action", "gboolean", "gboolean", "true", "always %TRUE")
+        
+        // Override of static method
+        removeVirtualMethod(repo, "SocketControlMessage", "get_type")
 
         // g_async_initable_new_finish is a method declaration in the interface AsyncInitable.
         // It is meant to be implemented as a constructor (actually, a static factory method).
@@ -137,7 +143,7 @@ setupGenSources {
         // The current solution is to remove the method from the interface. It is still available in the implementing classes.
         removeMethod(repo, "AsyncInitable", "new_finish")
 
-        // Have these classes implement the AutoCloseable interface, so they can be used in try-with-resources blocks.
+        // Let these classes implement the AutoCloseable interface, so they can be used in try-with-resources blocks.
         makeAutoCloseable(repo, "IOStream")
         makeAutoCloseable(repo, "InputStream")
         makeAutoCloseable(repo, "OutputStream")

--- a/glib/src/main/java/io/github/jwharm/javagi/base/Alias.java
+++ b/glib/src/main/java/io/github/jwharm/javagi/base/Alias.java
@@ -1,5 +1,7 @@
 package io.github.jwharm.javagi.base;
 
+import java.lang.foreign.MemoryAddress;
+
 /**
  * Base class for type aliases of primitive values.
  * @param <T> The primitive value type
@@ -49,6 +51,20 @@ public abstract class Alias<T> {
     @Override
     public int hashCode() {
         return value.hashCode();
+    }
+
+    /**
+     * Convenience function to turn an array of MemoryAddress Aliases into an array
+     * of primitive MemoryAddress values
+     * @param array the array of Alias objects
+     * @return an array of MemoryAddress values
+     */
+    public static MemoryAddress[] getAddressValues(Alias<MemoryAddress>[] array) {
+        MemoryAddress[] values = new MemoryAddress[array.length];
+        for (int i = 0; i < array.length; i++) {
+            values[i] = array[i].getValue();
+        }
+        return values;
     }
 
     /**

--- a/glib/src/main/java/io/github/jwharm/javagi/interop/Interop.java
+++ b/glib/src/main/java/io/github/jwharm/javagi/interop/Interop.java
@@ -116,6 +116,10 @@ public class Interop {
             return variadic ? VarargsInvoker.make(addr, fdesc) : linker.downcallHandle(addr, fdesc);
         }).orElse(null);
     }
+    
+    public static MethodHandle downcallHandle(Addressable symbol, FunctionDescriptor fdesc) {
+        return linker.downcallHandle(symbol, fdesc);
+    }
 
     /**
      * Produce a method handle for a {@code upcall} method in the provided class.

--- a/glib/src/main/java/io/github/jwharm/javagi/interop/Interop.java
+++ b/glib/src/main/java/io/github/jwharm/javagi/interop/Interop.java
@@ -76,7 +76,7 @@ public class Interop {
 
     /**
      * The method handle for g_signal_connect_data is used by all
-     * generated signal methods.
+     * generated signal-connection methods.
      */
     public static final MethodHandle g_signal_connect_data = downcallHandle(
             "g_signal_connect_data",
@@ -94,12 +94,22 @@ public class Interop {
 
     /**
      * The method handle for g_signal_emit_by_name is used by all
-     * generated signal methods.
+     * generated signal-emission methods.
      */
     public static final MethodHandle g_signal_emit_by_name = Interop.downcallHandle(
             "g_signal_emit_by_name",
             FunctionDescriptor.ofVoid(Interop.valueLayout.ADDRESS, Interop.valueLayout.ADDRESS),
             true
+    );
+
+    /**
+     * The method handle for g_type_interface_peek is used by all virtual
+     * method bindings in interfaces to retrieve the interface typestruct.
+     */
+    public static final MethodHandle g_type_interface_peek = Interop.downcallHandle(
+            "g_type_interface_peek",
+            FunctionDescriptor.of(Interop.valueLayout.ADDRESS, Interop.valueLayout.ADDRESS, Interop.valueLayout.C_LONG),
+            false
     );
 
     /**

--- a/glib/src/main/java/io/github/jwharm/javagi/util/ListIndexItem.java
+++ b/glib/src/main/java/io/github/jwharm/javagi/util/ListIndexItem.java
@@ -5,7 +5,6 @@ import io.github.jwharm.javagi.base.Marshal;
 import org.gnome.glib.Type;
 import org.gnome.gobject.GObject;
 import org.gnome.gobject.GObjects;
-import org.gnome.gobject.ObjectClass;
 import org.gnome.gobject.TypeFlags;
 
 import java.lang.foreign.*;

--- a/glib/src/main/java/io/github/jwharm/javagi/util/ListIndexModel.java
+++ b/glib/src/main/java/io/github/jwharm/javagi/util/ListIndexModel.java
@@ -3,7 +3,6 @@ package io.github.jwharm.javagi.util;
 import io.github.jwharm.javagi.interop.Interop;
 import io.github.jwharm.javagi.base.Marshal;
 import org.gnome.gio.ListModel;
-import org.gnome.gio.ListModelInterface;
 import org.gnome.glib.Type;
 import org.gnome.gobject.*;
 

--- a/gstreamer/build.gradle.kts
+++ b/gstreamer/build.gradle.kts
@@ -33,7 +33,10 @@ setupGenSources {
         // Override with different return type
         renameMethod(repo, "AppSrc", "set_caps", "set_capabilities")
     }
-    source("GstAudio-1.0", "org.freedesktop.gstreamer.audio", true, "gstaudio-1.0")
+    source("GstAudio-1.0", "org.freedesktop.gstreamer.audio", true, "gstaudio-1.0") { repo ->
+        // Override with different return type
+        setReturnType(repo, "AudioSink", "stop", "gboolean", "gboolean", "true", "always %TRUE")
+    }
     source("GstBadAudio-1.0", "org.freedesktop.gstreamer.badaudio", true, "gstbadaudio-1.0")
     source("GstCheck-1.0", "org.freedesktop.gstreamer.check", true, "gstcheck-1.0")
     source("GstController-1.0", "org.freedesktop.gstreamer.controller", true, "gstcontroller-1.0")

--- a/gstreamer/build.gradle.kts
+++ b/gstreamer/build.gradle.kts
@@ -31,7 +31,8 @@ setupGenSources {
     source("GstAllocators-1.0", "org.freedesktop.gstreamer.allocators", true, "gstallocators-1.0")
     source("GstApp-1.0", "org.freedesktop.gstreamer.app", true, "gstapp-1.0") { repo ->
         // Override with different return type
-        renameMethod(repo, "AppSrc", "set_caps", "set_capabilities")
+        setReturnType(repo, "AppSrc", "set_caps", "gboolean", "gboolean", "true", "always %TRUE")
+        setReturnType(repo, "AppSink", "set_caps", "gboolean", "gboolean", "true", "always %TRUE")
     }
     source("GstAudio-1.0", "org.freedesktop.gstreamer.audio", true, "gstaudio-1.0") { repo ->
         // Override with different return type

--- a/gtk/build.gradle.kts
+++ b/gtk/build.gradle.kts
@@ -40,13 +40,11 @@ setupGenSources {
     source("Gsk-4.0", "org.gnome.gsk", true)
     source("Gtk-4.0", "org.gnome.gtk", true, "gtk-4") { repo ->
         // Override with different return type
+        renameMethod(repo, "ApplicationWindow", "get_id", "get_window_id")
         renameMethod(repo, "MenuButton", "get_direction", "get_arrow_direction")
-        renameMethod(repo, "PrintUnixDialog", "get_settings", "get_print_settings")
         renameMethod(repo, "PrintSettings", "get", "get_string")
-
-        // This method returns void in interface ActionGroup, but returns boolean in class Widget.
-        // Subclasses from Widget that implement ActionGroup throw a compile error.
-        setReturnVoid(repo, "Widget", "activate_action")
+        renameMethod(repo, "PrintUnixDialog", "get_settings", "get_print_settings")
+        renameMethod(repo, "Widget", "activate", "activate_widget")
 
         // These calls return floating references
         setReturnFloating(findMethod(repo, "FileFilter", "to_gvariant"))


### PR DESCRIPTION
Implemented virtual methods.
GObject classes and interfaces can define virtual methods, instance methods and functions:
* Functions are mapped to static methods in Java
* Instance methods are mapped to instance methods in Java
* Virtual methods were not mapped at all until now. Most virtual methods are already implemented by a regular instance method with the same name and type-signature.

However, not all virtual methods have a corresponding instance method defined in the API, so some of them were not available in the Java classes.
With this change, all virtual methods are generated as Java instance methods. The binding retrieves the function pointer from the class struct (or interface struct) and invokes it.
Regular instance methods are now only generated when they don't have the exact same name and type-signature as a virtual method.
