### PR TITLE
Implement instance cache

### DIFF
--- a/generator/src/main/java/io/github/jwharm/javagi/generator/BindingsGenerator.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/generator/BindingsGenerator.java
@@ -88,15 +88,23 @@ public class BindingsGenerator {
             writer.write("private static void registerTypes() {\n");
             writer.increaseIndent();
 
-            for (Class c : gir.namespace.classList)
-                writer.write("if (" + c.javaName + ".isAvailable()) Interop.register(" + c.javaName + ".getType(), " + c.javaName + "::fromAddress);\n");
+            for (Class c : gir.namespace.classList) {
+                writer.write("if (" + c.javaName + ".isAvailable()) TypeCache.register(" + c.javaName + ".getType(), " + c.getConstructorString() + ");\n");
+            }
+            
+            for (Interface i : gir.namespace.interfaceList) {
+                writer.write("if (" + i.javaName + ".isAvailable()) TypeCache.register(" + i.javaName + ".getType(), " + i.getConstructorString() + ");\n");
+            }
 
-            for (Interface c : gir.namespace.interfaceList)
-                writer.write("if (" + c.javaName + ".isAvailable()) Interop.register(" + c.javaName + ".getType(), " + c.javaName + "::fromAddress);\n");
-
-            for (Alias c : gir.namespace.aliasList)
-                if (c.getTargetType() == Alias.TargetType.CLASS || c.getTargetType() == Alias.TargetType.INTERFACE)
-                    writer.write("if (" + c.javaName + ".isAvailable()) Interop.register(" + c.javaName + ".getType(), " + c.javaName + "::fromAddress);\n");
+            for (Alias a : gir.namespace.aliasList) {
+                if (a.getTargetType() == Alias.TargetType.CLASS) {
+                    Class c = (Class) a.type.girElementInstance;
+                    writer.write("if (" + a.javaName + ".isAvailable()) TypeCache.register(" + a.javaName + ".getType(), " + c.getConstructorString() + ");\n");
+                } else if (a.getTargetType() == Alias.TargetType.INTERFACE) {
+                    Interface i = (Interface) a.type.girElementInstance;
+                    writer.write("if (" + a.javaName + ".isAvailable()) TypeCache.register(" + a.javaName + ".getType(), " + i.getConstructorString() + ");\n");
+                }
+            }
 
             writer.decreaseIndent();
             writer.write("}\n");

--- a/generator/src/main/java/io/github/jwharm/javagi/model/Alias.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/Alias.java
@@ -60,7 +60,6 @@ public class Alias extends ValueWrapper {
                 }
                 writer.increaseIndent();
                 generateMemoryAddressConstructor(writer);
-                generateMarshal(writer);
             }
             case INTERFACE, CALLBACK -> {
                 writer.write("public interface " + javaName);

--- a/generator/src/main/java/io/github/jwharm/javagi/model/Bitfield.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/Bitfield.java
@@ -21,7 +21,6 @@ public class Bitfield extends ValueWrapper {
         writer.write("public class " + javaName + " extends io.github.jwharm.javagi.base.Bitfield {\n");
         writer.increaseIndent();
 
-        generateCType(writer);
         generateMemoryLayout(writer);
 
         // Filter duplicate members

--- a/generator/src/main/java/io/github/jwharm/javagi/model/Callback.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/Callback.java
@@ -54,4 +54,8 @@ public class Callback extends RegisteredType implements CallableType, Closure {
     public String getThrows() {
         return null;
     }
+    
+    public String getConstructorString() {
+        return this.javaName + "::new";
+    }
 }

--- a/generator/src/main/java/io/github/jwharm/javagi/model/Class.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/Class.java
@@ -127,6 +127,9 @@ public class Class extends RegisteredType {
     }
 
     public String getConstructorString() {
-        return ("1".equals(abstract_) ? this.javaName + "." + this.javaName + "Impl::new" : this.javaName + "::new");
+        String qName = Conversions.convertToJavaType(this.javaName, true, getNamespace());
+        return ("1".equals(abstract_)
+                ? qName + "." + this.javaName + "Impl::new"
+                : qName + "::new");
     }
 }

--- a/generator/src/main/java/io/github/jwharm/javagi/model/Class.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/Class.java
@@ -87,9 +87,7 @@ public class Class extends RegisteredType {
         writer.increaseIndent();
 
         generateMemoryAddressConstructor(writer);
-        generateMarshal(writer);
         generateEnsureInitialized(writer);
-        generateCType(writer);
         generateMemoryLayout(writer);
         generateConstructors(writer);
         generateMethodsAndSignals(writer);
@@ -126,5 +124,9 @@ public class Class extends RegisteredType {
 
         writer.decreaseIndent();
         writer.write("}\n");
+    }
+
+    public String getConstructorString() {
+        return ("1".equals(abstract_) ? this.javaName + "." + this.javaName + "Impl::new" : this.javaName + "::new");
     }
 }

--- a/generator/src/main/java/io/github/jwharm/javagi/model/Constructor.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/Constructor.java
@@ -73,9 +73,9 @@ public class Constructor extends Method {
         // one of its parent types. For example, button#newWithLabel returns a Widget instead of a Button.
         // We override this for constructors, to always return the constructed type.
         returnValue.type = new Type(returnValue, constructed.name, constructed.cType + "*");
-        returnValue.type.init(constructed.name);
         returnValue.type.girElementInstance = constructed;
         returnValue.type.girElementType = constructed.getClass().getSimpleName();
+        returnValue.type.init(constructed.name);
 
         writer.write("    \n");
         if (doc != null) {

--- a/generator/src/main/java/io/github/jwharm/javagi/model/Enumeration.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/Enumeration.java
@@ -58,7 +58,6 @@ public class Enumeration extends ValueWrapper {
             }
         }
 
-        generateCType(writer);
         generateMemoryLayout(writer);
 
         writer.write("\n");

--- a/generator/src/main/java/io/github/jwharm/javagi/model/Interface.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/Interface.java
@@ -60,6 +60,7 @@ public class Interface extends RegisteredType {
     }
 
     public String getConstructorString() {
-        return this.javaName + "." + this.javaName + "Impl::new";
+        String qName = Conversions.convertToJavaType(this.javaName, true, getNamespace());
+        return qName + "." + this.javaName + "Impl::new";
     }
 }

--- a/generator/src/main/java/io/github/jwharm/javagi/model/Interface.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/Interface.java
@@ -41,7 +41,6 @@ public class Interface extends RegisteredType {
         writer.write(" extends io.github.jwharm.javagi.base.Proxy {\n");
         writer.increaseIndent();
 
-        generateMarshal(writer);
         generateMethodsAndSignals(writer);
 
         if (classStruct != null) {
@@ -58,5 +57,9 @@ public class Interface extends RegisteredType {
 
         writer.decreaseIndent();
         writer.write("}\n");
+    }
+
+    public String getConstructorString() {
+        return this.javaName + "." + this.javaName + "Impl::new";
     }
 }

--- a/generator/src/main/java/io/github/jwharm/javagi/model/Record.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/Record.java
@@ -53,8 +53,6 @@ public class Record extends Class {
         if (isGTypeStructFor == null) {
             generateEnsureInitialized(writer);
         }
-        
-        generateCType(writer);
 
         // Opaque structs have unknown memory layout and should not have an allocator
         if (! (isOpaqueStruct() || hasOpaqueStructFields())) {
@@ -72,7 +70,6 @@ public class Record extends Class {
         }
 
         generateMemoryAddressConstructor(writer);
-        generateMarshal(writer);
         generateConstructors(writer);
         generateMethodsAndSignals(writer);
 

--- a/generator/src/main/java/io/github/jwharm/javagi/model/RegisteredType.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/RegisteredType.java
@@ -75,12 +75,6 @@ public abstract class RegisteredType extends GirElement {
         }
     }
     
-    protected void generateCType(SourceWriter writer) throws IOException {
-        String typeLiteral = Conversions.literal("java.lang.String", cType);
-        writer.write("\n");
-        writer.write("private static final java.lang.String C_TYPE_NAME = " + typeLiteral + ";\n");
-    }
-    
     /**
      * Generate a function declaration to retrieve the type of this object.
      * @param getType the name of the function
@@ -190,7 +184,7 @@ public abstract class RegisteredType extends GirElement {
         }
         // Write the name of the struct
         writer.write("\n");
-        writer.write(").withName(C_TYPE_NAME);\n");
+        writer.write(").withName(" + Conversions.literal("java.lang.String", cType) + ");\n");
         writer.decreaseIndent();
         writer.write("}\n");
     }
@@ -201,7 +195,7 @@ public abstract class RegisteredType extends GirElement {
         writer.write(" * Create a " + javaName + " proxy instance for the provided memory address.\n");
         writer.write(" * @param address the memory address of the native object\n");
         writer.write(" */\n");
-        writer.write("protected " + javaName + "(Addressable address) {\n");
+        writer.write("public " + javaName + "(Addressable address) {\n");
         writer.write("    super(address);\n");
 
         // If this class has a custom "unref" method, pass it to the Cleaner.
@@ -215,34 +209,6 @@ public abstract class RegisteredType extends GirElement {
         writer.write("}\n");
     }
 
-    protected void generateMarshal(SourceWriter writer) throws IOException {
-        writer.write("\n");
-        writer.write("/**\n");
-        writer.write(" * The marshal function from a native memory address to a Java proxy instance\n");
-        writer.write(" * @param address the native memory address of the object instance\n");
-        writer.write(" * @return an instance of {@code " + javaName + "}, or {@code null} if the ");
-        writer.write("address is a NULL pointer\n");
-        writer.write(" */\n");
-
-        String name = javaName;
-        if (this instanceof Interface)
-            name += "Impl";
-        else if (this instanceof Class c && "1".equals(c.abstract_))
-            name += "Impl";
-
-        writer.write("public static " + javaName);
-        if (generic)
-            writer.write("<org.gnome.gobject.GObject>");
-        writer.write(" fromAddress(Addressable address) {\n");
-        writer.increaseIndent();
-        writer.write("return address.equals(MemoryAddress.NULL) ? null : new " + name);
-        if (generic)
-            writer.write("<>");
-        writer.write("(address);\n");
-        writer.decreaseIndent();
-        writer.write("}\n");
-    }
-    
     protected void generateMethodsAndSignals(SourceWriter writer) throws IOException {
         HashSet<String> generatedMethods = new HashSet<>();
         

--- a/generator/src/main/java/io/github/jwharm/javagi/model/Type.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/Type.java
@@ -19,6 +19,8 @@ public class Type extends GirElement {
     public String simpleJavaType;
     /** This type is used on the Java side. Example: boolean, java.lang.String, org.gdk.gtk.Rectangle */
     public String qualifiedJavaType;
+    /** The name of the memory-address constructor. Example: Button.new, FileImpl.new */
+    public String constructorName;
 
     /** Used when this type refers to another namespace. Excluding the trailing dot. Example: org.gnome.gdk */
     public String girNamespace;
@@ -57,6 +59,11 @@ public class Type extends GirElement {
         if (girElementInstance != null && girElementInstance instanceof Record rec && rec.isGTypeStructFor != null) {
             qualifiedJavaType = Conversions.convertToJavaType(rec.isGTypeStructFor, true, girElementInstance.getNamespace());
             qualifiedJavaType += "." + simpleJavaType;
+        }
+        
+        this.constructorName = qualifiedJavaType + "::new";
+        if (girElementInstance != null && girElementInstance instanceof Class cls) {
+            this.constructorName = cls.getConstructorString();
         }
     }
 

--- a/generator/src/main/java/io/github/jwharm/javagi/model/Type.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/Type.java
@@ -60,10 +60,23 @@ public class Type extends GirElement {
             qualifiedJavaType = Conversions.convertToJavaType(rec.isGTypeStructFor, true, girElementInstance.getNamespace());
             qualifiedJavaType += "." + simpleJavaType;
         }
-        
+
+        // Get constructor name from class, interface, and alias for class or interface
         this.constructorName = qualifiedJavaType + "::new";
-        if (girElementInstance != null && girElementInstance instanceof Class cls) {
-            this.constructorName = cls.getConstructorString();
+        if (girElementInstance != null) {
+            if (girElementInstance instanceof Class cls) {
+                this.constructorName = cls.getConstructorString();
+            } else if (girElementInstance instanceof Interface iface) {
+                this.constructorName = iface.getConstructorString();
+            } else if (girElementInstance instanceof Alias alias) {
+                if (alias.getTargetType() == Alias.TargetType.CLASS) {
+                    Class cls = (Class) alias.type.girElementInstance;
+                    this.constructorName = cls.getConstructorString();
+                } else if (alias.getTargetType() == Alias.TargetType.INTERFACE) {
+                    Interface iface = (Interface) alias.type.girElementInstance;
+                    this.constructorName = iface.getConstructorString();
+                }
+            }
         }
     }
 

--- a/generator/src/main/java/io/github/jwharm/javagi/model/Union.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/Union.java
@@ -21,10 +21,8 @@ public class Union extends RegisteredType {
         writer.write(" extends StructProxy {\n");
         writer.increaseIndent();
         generateEnsureInitialized(writer);
-        generateCType(writer);
         generateMemoryLayout(writer);
         generateMemoryAddressConstructor(writer);
-        generateMarshal(writer);
         generateInjected(writer);
         writer.decreaseIndent();
         writer.write("}\n");

--- a/generator/src/main/java/io/github/jwharm/javagi/model/Variable.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/Variable.java
@@ -269,11 +269,11 @@ public class Variable extends GirElement {
                     + ", _scope).toArray(" + Conversions.getValueLayout(array.type) + ")";
 
         if (type.girElementInstance instanceof Record && (! type.isPointer()))
-            return "new PointerProxy<" + type.qualifiedJavaType + ">(" + identifier + ")"
+            return "new PointerProxy<" + type.qualifiedJavaType + ">(" + identifier + ", " + type.constructorName + ")"
                     + ".toArrayOfStructs((int) " + array.size(upcall) + ", " + type.qualifiedJavaType + ".class, "
                     + type.qualifiedJavaType + ".getMemoryLayout())";
 
-        return "new PointerProxy<" + type.qualifiedJavaType + ">(" + identifier + ")"
+        return "new PointerProxy<" + type.qualifiedJavaType + ">(" + identifier + ", " + type.constructorName + ")"
                 + ".toArray((int) " + array.size(upcall) + ", " + type.qualifiedJavaType + ".class)";
     }
 
@@ -299,6 +299,6 @@ public class Variable extends GirElement {
         if (type.isPrimitive)
             return "new Pointer" + Conversions.primitiveClassName(type.simpleJavaType) + "(" + identifier + ")";
 
-        return "new PointerProxy<" + type.qualifiedJavaType + ">(" + identifier + ")";
+        return "new PointerProxy<" + type.qualifiedJavaType + ">(" + identifier + ", " + type.constructorName + ")";
     }
 }

--- a/generator/src/main/java/io/github/jwharm/javagi/model/Variable.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/Variable.java
@@ -236,7 +236,7 @@ public class Variable extends GirElement {
             return "null /* Unsupported parameter type */";
 
         if (type.isClass() || type.isInterface() || type.isAlias())
-            return "(" + type.qualifiedJavaType + ") InstanceCache.get(" + identifier + ")";
+            return "(" + type.qualifiedJavaType + ") InstanceCache.get(" + identifier + ", " + type.constructorName + ")";
 
         if (type.isBoolean())
             return identifier + " != 0";

--- a/generator/src/main/java/io/github/jwharm/javagi/model/Variable.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/Variable.java
@@ -229,18 +229,14 @@ public class Variable extends GirElement {
         if (type.isEnum())
             return type.qualifiedJavaType + ".of(" + identifier + ")";
 
-        if (type.isBitfield() || type.isAliasForPrimitive())
+        if (type.isBitfield() || type.isAliasForPrimitive() || type.isRecord() || type.isUnion())
             return "new " + type.qualifiedJavaType + "(" + identifier + ")";
 
         if (type.isCallback())
             return "null /* Unsupported parameter type */";
 
-        if (type.isRecord() || type.isUnion())
-            return type.qualifiedJavaType + ".fromAddress(" + identifier + ")";
-
         if (type.isClass() || type.isInterface() || type.isAlias())
-            return "(" + type.qualifiedJavaType + ") Interop.register(" + identifier
-                    + ", " + type.qualifiedJavaType + "::fromAddress)" + ".apply(" + identifier + ")";
+            return "(" + type.qualifiedJavaType + ") InstanceCache.get(" + identifier + ")";
 
         if (type.isBoolean())
             return identifier + " != 0";
@@ -273,11 +269,11 @@ public class Variable extends GirElement {
                     + ", _scope).toArray(" + Conversions.getValueLayout(array.type) + ")";
 
         if (type.girElementInstance instanceof Record && (! type.isPointer()))
-            return "new PointerProxy<" + type.qualifiedJavaType + ">(" + identifier + ", " + type.qualifiedJavaType + "::fromAddress)"
+            return "new PointerProxy<" + type.qualifiedJavaType + ">(" + identifier + ")"
                     + ".toArrayOfStructs((int) " + array.size(upcall) + ", " + type.qualifiedJavaType + ".class, "
                     + type.qualifiedJavaType + ".getMemoryLayout())";
 
-        return "new PointerProxy<" + type.qualifiedJavaType + ">(" + identifier + ", " + type.qualifiedJavaType + "::fromAddress)"
+        return "new PointerProxy<" + type.qualifiedJavaType + ">(" + identifier + ")"
                 + ".toArray((int) " + array.size(upcall) + ", " + type.qualifiedJavaType + ".class)";
     }
 
@@ -303,6 +299,6 @@ public class Variable extends GirElement {
         if (type.isPrimitive)
             return "new Pointer" + Conversions.primitiveClassName(type.simpleJavaType) + "(" + identifier + ")";
 
-        return "new PointerProxy<" + type.qualifiedJavaType + ">(" + identifier + ", " + type.qualifiedJavaType + "::fromAddress)";
+        return "new PointerProxy<" + type.qualifiedJavaType + ">(" + identifier + ")";
     }
 }

--- a/glib/src/main/java/io/github/jwharm/javagi/base/GErrorException.java
+++ b/glib/src/main/java/io/github/jwharm/javagi/base/GErrorException.java
@@ -26,7 +26,7 @@ public class GErrorException extends Exception {
 
     // Dereference the GError instance from the pointer
     private static org.gnome.glib.Error dereference(MemorySegment pointer) {
-        return (org.gnome.glib.Error) org.gnome.glib.Error.fromAddress(pointer.get(Interop.valueLayout.ADDRESS, 0));
+        return new org.gnome.glib.Error(pointer.get(Interop.valueLayout.ADDRESS, 0));
     }
     
     // Get the message from the GError instance (used by the GErrorException constructor)

--- a/glib/src/main/java/io/github/jwharm/javagi/base/Signal.java
+++ b/glib/src/main/java/io/github/jwharm/javagi/base/Signal.java
@@ -24,7 +24,7 @@ public class Signal<T> {
      * @param handlerId the handler ID of the signal
      */
     public Signal(Addressable instance, long handlerId) {
-        this.instance = (GObject) InstanceCache.get(instance);
+        this.instance = (GObject) InstanceCache.get(instance, GObject::new);
         this.handlerId = handlerId;
     }
 

--- a/glib/src/main/java/io/github/jwharm/javagi/base/Signal.java
+++ b/glib/src/main/java/io/github/jwharm/javagi/base/Signal.java
@@ -3,6 +3,8 @@ package io.github.jwharm.javagi.base;
 import org.gnome.gobject.GObject;
 import org.gnome.gobject.GObjects;
 
+import io.github.jwharm.javagi.interop.InstanceCache;
+
 import java.lang.foreign.Addressable;
 
 /**
@@ -22,7 +24,7 @@ public class Signal<T> {
      * @param handlerId the handler ID of the signal
      */
     public Signal(Addressable instance, long handlerId) {
-        this.instance = GObject.fromAddress(instance);
+        this.instance = (GObject) InstanceCache.get(instance);
         this.handlerId = handlerId;
     }
 

--- a/glib/src/main/java/io/github/jwharm/javagi/interop/InstanceCache.java
+++ b/glib/src/main/java/io/github/jwharm/javagi/interop/InstanceCache.java
@@ -1,0 +1,67 @@
+package io.github.jwharm.javagi.interop;
+
+import java.lang.foreign.Addressable;
+import java.lang.foreign.MemoryAddress;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+
+import org.gnome.gobject.GObject;
+
+import io.github.jwharm.javagi.base.Proxy;
+
+/**
+ * Caches Proxy instances so the same instance is used for the same memory address.
+ */
+public class InstanceCache {
+    
+    private final static Map<Addressable, Proxy> instanceCache = new HashMap<>();
+
+    /**
+     * Get a {@link Proxy} object for the provided native memory address. If a Proxy object does  
+     * not yet exist for this address, a new Proxy object is instantiated and added to the cache. 
+     * Invalid references are removed from the cache using a GObject toggle reference.
+     * @param address memory address of the native object
+     * @return        a Proxy instance for the provided memory address
+     */
+    public static Proxy get(Addressable address) {
+        // Null check on the memory address
+        if (address == null || address.equals(MemoryAddress.NULL)) {
+            return null;
+        }
+        
+        // Get instance from cache
+        Proxy instance = instanceCache.get(address);
+        if (instance != null) {
+            return instance;
+        }
+        
+        // Get constructor from the type registry
+        Function<Addressable, ? extends Proxy> ctor = TypeCache.getConstructor((MemoryAddress) address);
+        
+        // No instance in cache: Create a new instance
+        Proxy newInstance = ctor.apply(address);
+        
+        // Null check on the new instance
+        if (newInstance == null) {
+            return null;
+        }
+        
+        // If the Proxy is a GObject instance, register a toggle reference
+        if (newInstance instanceof GObject gobject) {
+            gobject.addToggleRef((data, object, isLastRef) -> {
+                if (isLastRef) {
+                    instanceCache.remove(object.handle());
+                }
+            });
+        }
+        
+        // Put the instance in the cache. If another thread did this (while we were creating a new 
+        // instance), putIfAbsent() will return that instance.
+        Proxy instanceFromAnotherThread = instanceCache.putIfAbsent(address, newInstance);
+        
+        // Return the instance that was already in the cache, or else the new instance.
+        return Objects.requireNonNullElse(instanceFromAnotherThread, newInstance);
+    }
+}

--- a/glib/src/main/java/io/github/jwharm/javagi/interop/InstanceCache.java
+++ b/glib/src/main/java/io/github/jwharm/javagi/interop/InstanceCache.java
@@ -22,10 +22,11 @@ public class InstanceCache {
      * Get a {@link Proxy} object for the provided native memory address. If a Proxy object does  
      * not yet exist for this address, a new Proxy object is instantiated and added to the cache. 
      * Invalid references are removed from the cache using a GObject toggle reference.
-     * @param address memory address of the native object
-     * @return        a Proxy instance for the provided memory address
+     * @param address  memory address of the native object
+     * @param fallback fallback constructor to use when the type is not found in the TypeCache
+     * @return         a Proxy instance for the provided memory address
      */
-    public static Proxy get(Addressable address) {
+    public static Proxy get(Addressable address, Function<Addressable, ? extends Proxy> fallback) {
         // Null check on the memory address
         if (address == null || address.equals(MemoryAddress.NULL)) {
             return null;
@@ -38,8 +39,8 @@ public class InstanceCache {
         }
         
         // Get constructor from the type registry
-        Function<Addressable, ? extends Proxy> ctor = TypeCache.getConstructor((MemoryAddress) address);
-        
+        Function<Addressable, ? extends Proxy> ctor = TypeCache.getConstructor((MemoryAddress) address, fallback);
+
         // No instance in cache: Create a new instance
         Proxy newInstance = ctor.apply(address);
         

--- a/glib/src/main/java/io/github/jwharm/javagi/interop/TypeCache.java
+++ b/glib/src/main/java/io/github/jwharm/javagi/interop/TypeCache.java
@@ -1,0 +1,46 @@
+package io.github.jwharm.javagi.interop;
+
+import java.lang.foreign.Addressable;
+import java.lang.foreign.MemoryAddress;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.gnome.glib.Type;
+
+import io.github.jwharm.javagi.base.Proxy;
+
+/**
+ * A register of GTypes with a Java constructor for each GType.
+ * Using this register, the correct Java class is always instantiated, based on the GType of 
+ * the native object instance.
+ */
+public class TypeCache {
+    
+    private final static Map<Type, Function<Addressable, ? extends Proxy>> typeRegister = new HashMap<>();
+
+    /**
+     * Get the constructor from the type registry for the native object instance at the given 
+     * memory address. The applicable constructor is determined based on the GType of the native 
+     * object (as it was registered using {@link #register(Type, Function)}).
+     * @param address Address of Proxy object to obtain the type from
+     * @return the constructor, or {@code null} if address is {@null} or a null-pointer
+     */
+    public static Function<Addressable, ? extends Proxy> getConstructor(MemoryAddress address) {
+        if (address == null || address.equals(MemoryAddress.NULL)) return null;
+        Type type = Interop.getType(address);
+        return typeRegister.get(type);
+    }
+
+    /**
+     * Register the provided marshal function for the provided type
+     * @param type Type to use as key in the type register
+     * @param marshal Marshal function for this type
+     */
+    public static void register(Type type, Function<Addressable, ? extends Proxy> marshal) {
+        typeRegister.put(type, marshal);
+    }
+    
+
+
+}

--- a/glib/src/main/java/io/github/jwharm/javagi/pointer/PointerProxy.java
+++ b/glib/src/main/java/io/github/jwharm/javagi/pointer/PointerProxy.java
@@ -82,7 +82,7 @@ public class PointerProxy<T extends Proxy> extends Pointer<T> {
     // The unchecked warning is suppressed because the constructors are explicitly registered for the correct type.
     @SuppressWarnings("unchecked")
     private T makeInstance(Addressable ref) {
-        Function<Addressable, T> ctor = (Function<Addressable, T>) TypeCache.getConstructor((MemoryAddress) ref);
+        Function<Addressable, T> ctor = (Function<Addressable, T>) TypeCache.getConstructor((MemoryAddress) ref, null);
         return ctor.apply(ref);
     }
 }

--- a/glib/src/main/java/io/github/jwharm/javagi/pointer/PointerProxy.java
+++ b/glib/src/main/java/io/github/jwharm/javagi/pointer/PointerProxy.java
@@ -20,12 +20,15 @@ import io.github.jwharm.javagi.interop.TypeCache;
  */
 public class PointerProxy<T extends Proxy> extends Pointer<T> {
 
+    private final Function<Addressable, T> constructor;
+
     /**
      * Create a pointer to an existing memory address.
      * @param address the memory address
      */
-    public PointerProxy(MemoryAddress address) {
+    public PointerProxy(MemoryAddress address, Function<Addressable, T> constructor) {
         super(address);
+        this.constructor = constructor;
     }
 
     /**
@@ -82,7 +85,7 @@ public class PointerProxy<T extends Proxy> extends Pointer<T> {
     // The unchecked warning is suppressed because the constructors are explicitly registered for the correct type.
     @SuppressWarnings("unchecked")
     private T makeInstance(Addressable ref) {
-        Function<Addressable, T> ctor = (Function<Addressable, T>) TypeCache.getConstructor((MemoryAddress) ref, null);
+        Function<Addressable, T> ctor = (Function<Addressable, T>) TypeCache.getConstructor((MemoryAddress) ref, constructor);
         return ctor.apply(ref);
     }
 }

--- a/glib/src/main/java/io/github/jwharm/javagi/pointer/PointerProxy.java
+++ b/glib/src/main/java/io/github/jwharm/javagi/pointer/PointerProxy.java
@@ -1,12 +1,17 @@
 package io.github.jwharm.javagi.pointer;
 
-import io.github.jwharm.javagi.base.Proxy;
-import io.github.jwharm.javagi.interop.Interop;
-
-import java.lang.foreign.*;
+import java.lang.foreign.Addressable;
+import java.lang.foreign.MemoryAddress;
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.MemorySession;
 import java.lang.reflect.Array;
 import java.util.List;
 import java.util.function.Function;
+
+import io.github.jwharm.javagi.base.Proxy;
+import io.github.jwharm.javagi.interop.Interop;
+import io.github.jwharm.javagi.interop.TypeCache;
 
 /**
  * This type of Pointer object points to a GObject-derived object 
@@ -15,16 +20,12 @@ import java.util.function.Function;
  */
 public class PointerProxy<T extends Proxy> extends Pointer<T> {
 
-    private final Function<Addressable, ? extends T> make;
-
     /**
      * Create a pointer to an existing memory address.
      * @param address the memory address
-     * @param make a function to create an instance
      */
-    public PointerProxy(MemoryAddress address, Function<Addressable, ? extends T> make) {
+    public PointerProxy(MemoryAddress address) {
         super(address);
-        this.make = make;
     }
 
     /**
@@ -57,8 +58,7 @@ public class PointerProxy<T extends Proxy> extends Pointer<T> {
                 Interop.valueLayout.ADDRESS.byteSize() * index
         );
         // Call the constructor of the proxy object and return the created instance.
-        // TODO: What about ownership of the object?
-        return make.apply(ref);
+        return makeInstance(ref);
     }
 
     /**
@@ -73,8 +73,16 @@ public class PointerProxy<T extends Proxy> extends Pointer<T> {
         var segment = MemorySegment.ofAddress(address, length * layout.byteSize(), MemorySession.openImplicit());
         List<MemorySegment> elements = segment.elements(layout).toList();
         for (int i = 0; i < length; i++) {
-            array[i] = make.apply(elements.get(i).address());
+            array[i] = makeInstance(elements.get(i).address());
         }
         return array;
+    }
+    
+    // Get the constructor and create a new instance.
+    // The unchecked warning is suppressed because the constructors are explicitly registered for the correct type.
+    @SuppressWarnings("unchecked")
+    private T makeInstance(Addressable ref) {
+        Function<Addressable, T> ctor = (Function<Addressable, T>) TypeCache.getConstructor((MemoryAddress) ref);
+        return ctor.apply(ref);
     }
 }

--- a/glib/src/main/java/io/github/jwharm/javagi/util/JavaClosure.java
+++ b/glib/src/main/java/io/github/jwharm/javagi/util/JavaClosure.java
@@ -65,25 +65,29 @@ public class JavaClosure extends Closure {
         setMarshal(new ClosureMarshal() {
             public void run(Closure closure, Value returnValue, Value[] paramValues, MemoryAddress invocationHint) {
                 try {
-                    // Convert the parameter Values into Java Objects
-                    Object[] parameterObjects = new Object[paramValues.length];
-                    for (int v = 0; v < paramValues.length; v++) {
-                        parameterObjects[v] = ValueUtil.valueToObject(paramValues[v]);
+                    Object[] parameterObjects;
+                    if (paramValues == null || paramValues.length == 0) {
+                        parameterObjects = new Object[0];
+                    } else {
+                        // Convert the parameter Values into Java Objects
+                        parameterObjects = new Object[paramValues.length - 1];
+                        for (int v = 1; v < paramValues.length; v++) {
+                            parameterObjects[v - 1] = ValueUtil.valueToObject(paramValues[v]);
+                        }
                     }
-                    
                     // Invoke the method
                     Object result = method.invoke(instance, parameterObjects);
-                    
+
                     // Convert the returned Object to a GValue
                     ValueUtil.objectToValue(result, returnValue);
-                    
+
                 } catch (Exception e) {
                     GLib.log(
-                            LOG_DOMAIN, 
-                            LogLevelFlags.LEVEL_CRITICAL, 
-                            "JavaClosure: Cannot invoke method %s in class %s: %s\n", 
+                            LOG_DOMAIN,
+                            LogLevelFlags.LEVEL_CRITICAL,
+                            "JavaClosure: Cannot invoke method %s in class %s: %s\n",
                             method.getName(),
-                            instance.getClass().getName(), 
+                            instance.getClass().getName(),
                             e.getMessage()
                     );
                 }

--- a/glib/src/main/java/io/github/jwharm/javagi/util/ListIndexItem.java
+++ b/glib/src/main/java/io/github/jwharm/javagi/util/ListIndexItem.java
@@ -1,12 +1,14 @@
 package io.github.jwharm.javagi.util;
 
-import io.github.jwharm.javagi.interop.Interop;
+import java.lang.foreign.*;
+
 import org.gnome.glib.Type;
 import org.gnome.gobject.GObject;
 import org.gnome.gobject.GObjects;
 import org.gnome.gobject.TypeFlags;
 
-import java.lang.foreign.*;
+import io.github.jwharm.javagi.interop.Interop;
+import io.github.jwharm.javagi.interop.TypeCache;
 
 /**
  * Represents an item in the {@link ListIndexModel}
@@ -17,15 +19,8 @@ public class ListIndexItem extends GObject {
      * Construct a ListIndexItem for the provided memory address.
      * @param address the memory address of the instance in native memory
      */
-    protected ListIndexItem(Addressable address) {
+    public ListIndexItem(Addressable address) {
         super(address);
-    }
-
-    /**
-     * Marshaller from a memory address to a ListIndexItem instance.
-     */
-    public static ListIndexItem fromAddress(Addressable address) {
-        return address.equals(MemoryAddress.NULL) ? null : new ListIndexItem(address);
     }
 
     /**
@@ -59,7 +54,7 @@ public class ListIndexItem extends GObject {
                     TypeFlags.NONE
             );
         }
-        Interop.register(type, ListIndexItem::fromAddress);
+        TypeCache.register(type, ListIndexItem::new);
         return type;
     }
 

--- a/glib/src/main/java/io/github/jwharm/javagi/util/ListIndexModel.java
+++ b/glib/src/main/java/io/github/jwharm/javagi/util/ListIndexModel.java
@@ -1,11 +1,16 @@
 package io.github.jwharm.javagi.util;
 
-import io.github.jwharm.javagi.interop.Interop;
+import java.lang.foreign.*;
+
 import org.gnome.gio.ListModel;
 import org.gnome.glib.Type;
-import org.gnome.gobject.*;
+import org.gnome.gobject.GObject;
+import org.gnome.gobject.GObjects;
+import org.gnome.gobject.InterfaceInfo;
+import org.gnome.gobject.TypeFlags;
 
-import java.lang.foreign.*;
+import io.github.jwharm.javagi.interop.Interop;
+import io.github.jwharm.javagi.interop.TypeCache;
 
 /**
  * An implementation of the {@link ListModel} that returns the index of
@@ -19,15 +24,8 @@ public class ListIndexModel extends GObject implements ListModel {
      * Construct a ListIndexModel for the provided memory address.
      * @param address the memory address of the instance in native memory
      */
-    protected ListIndexModel(Addressable address) {
+    public ListIndexModel(Addressable address) {
         super(address);
-    }
-
-    /**
-     * Marshaller from a memory address to a ListIndexModel instance.
-     */
-    public static ListIndexModel fromAddress(Addressable address) {
-        return address.equals(MemoryAddress.NULL) ? null : new ListIndexModel(address);
     }
 
     /**
@@ -63,14 +61,14 @@ public class ListIndexModel extends GObject implements ListModel {
             // Implement the ListModel interface
             InterfaceInfo interfaceInfo = InterfaceInfo.allocate();
             interfaceInfo.writeInterfaceInit((iface, data) -> {
-                ListModelInterface lmi = ListModelInterface.fromAddress(iface.handle());
+                ListModelInterface lmi = new ListModelInterface(iface.handle());
                 lmi.overrideGetItemType(ListModel::getItemType);
                 lmi.overrideGetNItems(ListModel::getNItems);
                 lmi.overrideGetItem(ListModel::getItem);
             });
             GObjects.typeAddInterfaceStatic(type, ListModel.getType(), interfaceInfo);
         }
-        Interop.register(type, ListIndexModel::fromAddress);
+        TypeCache.register(type, ListIndexModel::new);
         return type;
     }
 

--- a/glib/src/main/java/io/github/jwharm/javagi/util/ValueUtil.java
+++ b/glib/src/main/java/io/github/jwharm/javagi/util/ValueUtil.java
@@ -56,14 +56,13 @@ public class ValueUtil {
             return src.getObject();
         } else if (type.equals(GObjects.gtypeGetType())) {
             return src.getGtype();
-        } else if (type.equals(Type.G_TYPE_BOXED)) {
-            return src.getBoxed();
         } else if (type.equals(Type.G_TYPE_POINTER)) {
             return src.getPointer();
         } else if (type.equals(Type.G_TYPE_PARAM)) {
             return src.getParam();
         } else {
-            return null;
+            // Boxed value
+            return src.getBoxed();
         }
     }
     
@@ -107,12 +106,13 @@ public class ValueUtil {
             dest.setObject((GObject) src);
         } else if (type.equals(GObjects.gtypeGetType())) {
             dest.setGtype((Type) src);
-        } else if (type.equals(Type.G_TYPE_BOXED)) {
-            dest.setBoxed((MemoryAddress) src);
         } else if (type.equals(Type.G_TYPE_POINTER)) {
             dest.setPointer((MemoryAddress) src);
         } else if (type.equals(Type.G_TYPE_PARAM)) {
             dest.setParam((ParamSpec) src);
+        } else {
+            // Boxed value
+            dest.setBoxed((MemoryAddress) src);
         }
     }
 }


### PR DESCRIPTION
Add an InstanceCache class that saves a mapping of memory addresses with proxy object instances in a HashMap. Expired entries are removed with toggle references.

This also removes the `fromAddress` method from the generated class definitions. Proxy objects can now simply be instantiated with `InstanceCache.get(address, fallbackConstructor)` or if you don't want to have a cached object, simply with the default MemoryAddress constructor in the proxy class.
