### PR TITLE
Add native library version to jar filename

### DIFF
--- a/adwaita/build.gradle.kts
+++ b/adwaita/build.gradle.kts
@@ -10,6 +10,9 @@ dependencies {
     api(project(":gtk"))
 }
 
+val pkgVersion = "pkg-config --modversion libadwaita-1".runCommand(project)
+version = "$pkgVersion-$version"
+
 setupGenSources {
     moduleInfo = """
         module org.gnome.adwaita {

--- a/buildSrc/src/main/kotlin/ext/RunCommandExt.kt
+++ b/buildSrc/src/main/kotlin/ext/RunCommandExt.kt
@@ -1,0 +1,13 @@
+package ext
+
+import org.gradle.api.Project
+import java.io.ByteArrayOutputStream
+
+fun String.runCommand(project: Project): String {
+    val byteOut = ByteArrayOutputStream()
+    project.exec {
+        commandLine = this@runCommand.split("\\s".toRegex())
+        standardOutput = byteOut
+    }
+    return String(byteOut.toByteArray()).trim()
+}

--- a/buildSrc/src/main/kotlin/java-gi.library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-gi.library-conventions.gradle.kts
@@ -50,7 +50,6 @@ tasks.javadoc {
     (options as CoreJavadocOptions).run {
         addStringOption("source", "19")
         addBooleanOption("-enable-preview", true)
-        addStringOption("windowtitle", "java-gi ${project.version}")
         addStringOption("Xdoclint:none", "-quiet")
     }
 }

--- a/glib/build.gradle.kts
+++ b/glib/build.gradle.kts
@@ -5,6 +5,9 @@ plugins {
     id("java-gi.library-conventions")
 }
 
+val pkgVersion = "pkg-config --modversion glib".runCommand(project)
+version = "$pkgVersion-$version"
+
 setupGenSources {
     moduleInfo = """
         module org.gnome.glib {

--- a/gstreamer/build.gradle.kts
+++ b/gstreamer/build.gradle.kts
@@ -9,6 +9,9 @@ dependencies {
     api(project(":glib"))
 }
 
+val pkgVersion = "pkg-config --modversion gstreamer-1.0".runCommand(project)
+version = "$pkgVersion-$version"
+
 setupGenSources {
     moduleInfo = """
         module org.freedesktop.gstreamer {

--- a/gtk/build.gradle.kts
+++ b/gtk/build.gradle.kts
@@ -9,6 +9,9 @@ dependencies {
     api(project(":glib"))
 }
 
+val pkgVersion = "pkg-config --modversion gtk4".runCommand(project)
+version = "$pkgVersion-$version"
+
 setupGenSources {
     moduleInfo = """
         module org.gnome.gtk {


### PR DESCRIPTION
Jar files will have two versions: [native library version]-[java-gi version]
For example: `adwaita-1.2.0-0.4.jar`
Javadoc and Sources jars will also change to this naming scheme.
