### PR TITLE
Typeclass inheritance

### DIFF
--- a/example/src/main/java/io/github/jwharm/javagi/example/Gtk4Example.java
+++ b/example/src/main/java/io/github/jwharm/javagi/example/Gtk4Example.java
@@ -1,72 +1,36 @@
 package io.github.jwharm.javagi.example;
 
 import org.gnome.gio.ApplicationFlags;
-import org.gnome.glib.GLib;
 import org.gnome.gtk.*;
 
-import java.util.concurrent.atomic.AtomicInteger;
+public class Gtk4Example extends Application {
 
-public class Gtk4Example {
-
-    private final Application app;
-
-    public void activate() {
-        var window = new ApplicationWindow(app);
-        window.setTitle("Window");
-        window.setDefaultSize(300, 200);
-
-        var box = new Box(Orientation.VERTICAL, 0);
-        box.setHalign(Align.CENTER);
-        box.setValign(Align.CENTER);
-
-        AtomicInteger sec = new AtomicInteger(29);
-
-        var button = Button.newWithLabel("Hello world! 30");
-        button.onClicked(() -> {
-            sec.set(0); // stop the timer
-            MessageDialog dialog = new MessageDialog(
-                    window,
-                    DialogFlags.MODAL.or(DialogFlags.DESTROY_WITH_PARENT),
-                    MessageType.INFO,
-                    ButtonsType.OK_CANCEL,
-                    null
-            );
-            dialog.setTitle("Hello!");
-            dialog.setMarkup("This is some <b>content</b>");
-            dialog.onResponse(responseId -> {
-                switch (ResponseType.of(responseId)) {
-                    case OK -> {
-                        window.close();
-                    }
-                    case CANCEL -> {
-                        System.out.println("Cancel");
-                    }
-                }
-                dialog.close();
-            });
-            dialog.show();
-        });
-
-        GLib.timeoutAddSeconds(1, () -> {
-            button.setLabel("Hello world! " + (sec.getAndDecrement()));
-            if (sec.get() == 0) {
-                button.emitClicked();
-            }
-            return sec.get() >= 0;
-        });
-
-        box.append(button);
-        window.setChild(box);
-
-        window.show();
-
-        window.onCloseRequest(() -> false);
-        System.out.println(window.emitCloseRequest());
+    public static void main(String[] args) {
+        new Gtk4Example(args);
     }
 
     public Gtk4Example(String[] args) {
-        app = new Application("org.gnome.gtk.example", ApplicationFlags.FLAGS_NONE);
-        app.onActivate(this::activate);
-        app.run(args);
+        super("io.github.jwharm.javagi.Example", ApplicationFlags.DEFAULT_FLAGS);
+        onActivate(this::activate);
+        run(args);
+    }
+
+    public void activate() {
+        var window = new ApplicationWindow(this);
+        window.setTitle("GTK from Java");
+        window.setDefaultSize(300, 200);
+
+        var box = Box.builder()
+                .setOrientation(Orientation.VERTICAL)
+                .setHalign(Align.CENTER)
+                .setValign(Align.CENTER)
+                .build();
+
+        var button = Button.newWithLabel("Hello world!");
+        button.onClicked(window::close);
+
+        box.append(button);
+        window.setChild(box);
+        window.show();
     }
 }

--- a/example/src/main/java/io/github/jwharm/javagi/example/Gtk4TimerExample.java
+++ b/example/src/main/java/io/github/jwharm/javagi/example/Gtk4TimerExample.java
@@ -1,0 +1,72 @@
+package io.github.jwharm.javagi.example;
+
+import org.gnome.gio.ApplicationFlags;
+import org.gnome.glib.GLib;
+import org.gnome.gtk.*;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class Gtk4TimerExample {
+
+    private final Application app;
+
+    public void activate() {
+        var window = new ApplicationWindow(app);
+        window.setTitle("Window");
+        window.setDefaultSize(300, 200);
+
+        var box = new Box(Orientation.VERTICAL, 0);
+        box.setHalign(Align.CENTER);
+        box.setValign(Align.CENTER);
+
+        AtomicInteger sec = new AtomicInteger(29);
+
+        var button = Button.newWithLabel("Hello world! 30");
+        button.onClicked(() -> {
+            sec.set(0); // stop the timer
+            MessageDialog dialog = new MessageDialog(
+                    window,
+                    DialogFlags.MODAL.or(DialogFlags.DESTROY_WITH_PARENT),
+                    MessageType.INFO,
+                    ButtonsType.OK_CANCEL,
+                    null
+            );
+            dialog.setTitle("Hello!");
+            dialog.setMarkup("This is some <b>content</b>");
+            dialog.onResponse(responseId -> {
+                switch (ResponseType.of(responseId)) {
+                    case OK -> {
+                        window.close();
+                    }
+                    case CANCEL -> {
+                        System.out.println("Cancel");
+                    }
+                }
+                dialog.close();
+            });
+            dialog.show();
+        });
+
+        GLib.timeoutAddSeconds(1, () -> {
+            button.setLabel("Hello world! " + (sec.getAndDecrement()));
+            if (sec.get() == 0) {
+                button.emitClicked();
+            }
+            return sec.get() >= 0;
+        });
+
+        box.append(button);
+        window.setChild(box);
+
+        window.show();
+
+        window.onCloseRequest(() -> false);
+        System.out.println(window.emitCloseRequest());
+    }
+
+    public Gtk4TimerExample(String[] args) {
+        app = new Application("org.gnome.gtk.example", ApplicationFlags.FLAGS_NONE);
+        app.onActivate(this::activate);
+        app.run(args);
+    }
+}

--- a/example/src/main/java/io/github/jwharm/javagi/example/HelloWorld.java
+++ b/example/src/main/java/io/github/jwharm/javagi/example/HelloWorld.java
@@ -7,11 +7,14 @@ public class HelloWorld {
         // GTK4 simple example
         new Gtk4Example(args);
 
+        // GTK4 timer example
+        // new Gtk4TimerExample(args);
+
         // GTK4 ListView example
-        new Gtk4ListViewExample(args);
+        // new Gtk4ListViewExample(args);
 
         // GStreamer example
         // To run example, provide a valid path to an Ogg Vorbis file:
-        new GStreamerExample(new String[]{"Example.ogg"});
+        // new GStreamerExample(new String[]{"Example.ogg"});
     }
 }

--- a/example/src/main/java/module-info.java
+++ b/example/src/main/java/module-info.java
@@ -1,5 +1,4 @@
 module io.github.jwharm.javagi.example {
-    requires org.gnome.glib;
     requires org.gnome.gtk;
     requires org.freedesktop.gstreamer;
 }


### PR DESCRIPTION
Changed typeclasses in Java to extend the parent typeclass. For example, let `GtkButtonClass` extend `WidgetClass`. This makes it easier to override virtual methods.
