### PR TITLE
Implement interfaces when registering new GTypes

### DIFF
--- a/generator/src/main/java/io/github/jwharm/javagi/model/Record.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/Record.java
@@ -46,7 +46,9 @@ public class Record extends Class {
         if (isGTypeStructFor != null) {
             // parent_class is always the first field, unless the struct is disguised
             if (fieldList.isEmpty()) {
-                writer.write(" extends org.gnome.gobject.TypeClass");
+                RegisteredType outerClass = Conversions.cTypeLookupTable.get(isGTypeStructFor);
+                writer.write(" extends org.gnome.gobject."
+                        + (outerClass instanceof Interface ? "TypeInterface" : "TypeClass"));
             } else {
                 String parentCType = fieldList.get(0).type.cType;
                 Record parentRec = (Record) Conversions.cTypeLookupTable.get(parentCType);
@@ -55,8 +57,8 @@ public class Record extends Class {
                     String parentStr = parentClass + "." + parentRec.javaName;
                     writer.write(" extends " + parentStr);
                 } else {
-                    // Fallback to TypeClass
-                    writer.write(" extends org.gnome.gobject.TypeClass");
+                    String parentClass = Conversions.toQualifiedJavaType(parentRec.name, parentRec.getNamespace());
+                    writer.write(" extends " + parentClass);
                 }
             }
         } else {

--- a/glib/src/main/java/io/github/jwharm/javagi/annotations/InterfaceInit.java
+++ b/glib/src/main/java/io/github/jwharm/javagi/annotations/InterfaceInit.java
@@ -1,0 +1,11 @@
+package io.github.jwharm.javagi.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface InterfaceInit {
+}

--- a/glib/src/main/java/io/github/jwharm/javagi/util/ListIndexModel.java
+++ b/glib/src/main/java/io/github/jwharm/javagi/util/ListIndexModel.java
@@ -42,16 +42,6 @@ public class ListIndexModel extends GObject implements ListModel {
     public static Type getType() {
         if (type == null) {
             type = Types.register(ListIndexModel.class);
-
-            // Implement the ListModel interface
-            InterfaceInfo interfaceInfo = InterfaceInfo.allocate();
-            interfaceInfo.writeInterfaceInit((iface, data) -> {
-                ListModelInterface lmi = new ListModelInterface(iface.handle());
-                lmi.overrideGetItemType(ListModel::getItemType);
-                lmi.overrideGetNItems(ListModel::getNItems);
-                lmi.overrideGetItem(ListModel::getItem);
-            });
-            GObjects.typeAddInterfaceStatic(type, ListModel.getType(), interfaceInfo);
         }
         return type;
     }
@@ -64,8 +54,6 @@ public class ListIndexModel extends GObject implements ListModel {
                 ParamFlags.CONSTRUCT_ONLY.or(ParamFlags.READWRITE, ParamFlags.STATIC_NAME, ParamFlags.STATIC_BLURB, ParamFlags.STATIC_NICK));
         pspecs[PROP_N_ITEMS] = GObjects.paramSpecUint("n-items", "", "", 0, GLib.MAXUINT32, 0,
                 ParamFlags.READABLE.or(ParamFlags.STATIC_NAME, ParamFlags.STATIC_BLURB, ParamFlags.STATIC_NICK));
-        objectClass.overrideGetProperty(GObject::getProperty);
-        objectClass.overrideSetProperty(GObject::setProperty);
         objectClass.installProperties(pspecs);
     }
 

--- a/glib/src/main/java/io/github/jwharm/javagi/util/Types.java
+++ b/glib/src/main/java/io/github/jwharm/javagi/util/Types.java
@@ -261,7 +261,6 @@ public class Types {
             } catch (NoSuchMethodException e) {
                 continue;
             }
-            System.out.println("Override superclass method " + method.getName());
             methods.add(method);
         }
         if (methods.isEmpty()) {

--- a/glib/src/main/java/io/github/jwharm/javagi/util/Types.java
+++ b/glib/src/main/java/io/github/jwharm/javagi/util/Types.java
@@ -13,7 +13,6 @@ import org.gnome.gobject.*;
 
 import java.lang.foreign.Addressable;
 import java.lang.foreign.MemoryLayout;
-import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;


### PR DESCRIPTION
When calling `Types.register(my.class)`, and the class implements interfaces with a `TypeInterface` definition, the methods from the interface will automatically be overridden with the Java method implementations in the class.

For every implemented interface, an interface init method can be defined, analogous to class initializers. For example, when implementing `ListModel`:
```java
@InterfaceInit
public static void initialize(ListModelInterface iface) {
    ...
}
```
