### PR TITLE
Free structs

### DIFF
--- a/generator/src/main/java/io/github/jwharm/javagi/model/Parameter.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/Parameter.java
@@ -314,8 +314,18 @@ public class Parameter extends Variable {
                 && (! isOutParameter()) 
                 && (type.cType == null || (! type.cType.endsWith("**")))) {
             String param = isInstanceParameter() ? "this" : name;
-            if (nullable) writer.write("if (" + param + " != null) ");
+            if (checkNull()) writer.write("if (" + param + " != null) ");
             writer.write(param + ".ref();\n");
+        }
+
+        // Same, but for structs/unions: Disable the cleaner
+        if (type != null && (type.isUnion() || type.isRecord())
+                && "full".equals(transferOwnership)
+                && (! isOutParameter())
+                && (type.cType == null || (! type.cType.endsWith("**")))) {
+            String param = isInstanceParameter() ? "this" : name;
+            if (checkNull()) writer.write("if (" + param + " != null) ");
+            writer.write(param + ".yieldOwnership();\n");
         }
     }
 

--- a/generator/src/main/java/io/github/jwharm/javagi/model/Record.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/Record.java
@@ -61,6 +61,8 @@ public class Record extends Class {
                     writer.write(" extends " + parentClass);
                 }
             }
+        } else if ("TypeInstance".equals(javaName) && "org.gnome.gobject".equals(getNamespace().packageName)) {
+            writer.write(" extends ProxyInstance");
         } else {
             writer.write(" extends ProxyInstanceCleanable");
         }

--- a/generator/src/main/java/io/github/jwharm/javagi/model/Record.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/Record.java
@@ -62,12 +62,21 @@ public class Record extends Class {
                 }
             }
         } else {
-            writer.write(" extends ProxyInstance");
+            writer.write(" extends ProxyInstanceCleanable");
         }
+
+        boolean impl = false;
 
         // Floating
         if (isFloating()) {
             writer.write(" implements io.github.jwharm.javagi.base.Floating");
+            impl = true;
+        }
+
+        // Has free()
+        if (hasFreeFunc()) {
+            writer.write(impl ? ", " : " implements ");
+            writer.write("io.github.jwharm.javagi.base.FreeFunc");
         }
 
         writer.write(" {\n");

--- a/generator/src/main/java/io/github/jwharm/javagi/model/RegisteredType.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/RegisteredType.java
@@ -64,6 +64,18 @@ public abstract class RegisteredType extends GirElement {
         return false;
     }
 
+    public boolean hasFreeFunc() {
+        for (Method method : methodList) {
+            if ("free".equals(method.name)
+                    && method.parameters.parameterList.size() == 1
+                    && method.parameters.parameterList.get(0) instanceof InstanceParameter
+                    && (method.returnValue.type == null || method.returnValue.type.isVoid())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public abstract void generate(SourceWriter writer) throws IOException;
 
     protected void generatePackageDeclaration(SourceWriter writer) throws IOException {

--- a/generator/src/main/java/io/github/jwharm/javagi/model/ReturnValue.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/ReturnValue.java
@@ -85,6 +85,17 @@ public class ReturnValue extends Parameter {
             writer.write("}\n");
             writer.write("return _object;\n");
 
+        } else if (type != null && (type.isUnion() || type.isRecord())) {
+
+            writer.write("var _instance = ");
+            marshalNativeToJava(writer, "_result", false);
+            writer.write(";\n");
+            writer.write("if (_instance != null) {\n");
+
+            writer.write("    _instance.takeOwnership();\n");
+            writer.write("}\n");
+            writer.write("return _instance;\n");
+
         } else {
 
             writer.write("return ");

--- a/generator/src/main/java/io/github/jwharm/javagi/model/ReturnValue.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/ReturnValue.java
@@ -85,7 +85,9 @@ public class ReturnValue extends Parameter {
             writer.write("}\n");
             writer.write("return _object;\n");
 
-        } else if (type != null && (type.isUnion() || type.isRecord())) {
+        } else if (type != null
+                && (type.isUnion() || type.isRecord())
+                && (! "org.gnome.gobject.TypeInstance".equals(type.qualifiedJavaType))) {
 
             writer.write("var _instance = ");
             marshalNativeToJava(writer, "_result", false);

--- a/generator/src/main/java/io/github/jwharm/javagi/model/Union.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/model/Union.java
@@ -18,7 +18,14 @@ public class Union extends RegisteredType {
         writer.write("public class " + javaName);
         if (generic)
             writer.write("<T extends org.gnome.gobject.GObject>");
-        writer.write(" extends ProxyInstance {\n");
+        writer.write(" extends ProxyInstanceCleanable");
+
+        // Has free()
+        if (hasFreeFunc()) {
+            writer.write(" implements io.github.jwharm.javagi.base.FreeFunc");
+        }
+
+        writer.write(" {\n");
         writer.increaseIndent();
         generateEnsureInitialized(writer);
         generateMemoryLayout(writer);

--- a/glib/src/main/java/io/github/jwharm/javagi/base/Floating.java
+++ b/glib/src/main/java/io/github/jwharm/javagi/base/Floating.java
@@ -1,5 +1,8 @@
 package io.github.jwharm.javagi.base;
 
+/**
+ * Classes that implement the Floating interface, have a refSink method
+ */
 public interface Floating extends Proxy {
 
     Floating refSink();

--- a/glib/src/main/java/io/github/jwharm/javagi/base/FreeFunc.java
+++ b/glib/src/main/java/io/github/jwharm/javagi/base/FreeFunc.java
@@ -1,0 +1,13 @@
+package io.github.jwharm.javagi.base;
+
+/**
+ * Classes that implement the FreeFunc interface, have a free() method
+ */
+public interface FreeFunc {
+
+    /**
+     * Free native memory
+     */
+    void free();
+
+}

--- a/glib/src/main/java/io/github/jwharm/javagi/base/ProxyInstanceCleanable.java
+++ b/glib/src/main/java/io/github/jwharm/javagi/base/ProxyInstanceCleanable.java
@@ -22,6 +22,13 @@ public class ProxyInstanceCleanable extends ProxyInstance {
     public ProxyInstanceCleanable(Addressable address) {
         super(address);
 
+        // Null check the address
+        if (address == null || address.equals(MemoryAddress.NULL)) {
+            this.finalizer = null;
+            return;
+        }
+
+        // Use free() method (if any)
         Method freeFunc = null;
         if (this instanceof FreeFunc) {
             try {

--- a/glib/src/main/java/io/github/jwharm/javagi/base/ProxyInstanceCleanable.java
+++ b/glib/src/main/java/io/github/jwharm/javagi/base/ProxyInstanceCleanable.java
@@ -1,0 +1,88 @@
+package io.github.jwharm.javagi.base;
+
+import org.gnome.glib.GLib;
+
+import java.lang.foreign.Addressable;
+import java.lang.foreign.MemoryAddress;
+import java.lang.ref.Cleaner;
+import java.lang.reflect.Method;
+
+/**
+ * A ProxyInstance subclass on which a {@link Cleaner} can be attached to
+ * automatically free native memory when the object is not used anymore.
+ */
+public class ProxyInstanceCleanable extends ProxyInstance {
+
+    private final StructFinalizer finalizer;
+
+    /**
+     * Create a new {@code ProxyInstanceCleanable} object for an instance in native memory.
+     * @param address the memory address of the instance
+     */
+    public ProxyInstanceCleanable(Addressable address) {
+        super(address);
+
+        Method freeFunc = null;
+        if (this instanceof FreeFunc) {
+            try {
+                freeFunc = getClass().getDeclaredMethod("free");
+            } catch (NoSuchMethodException ignored) {}
+        }
+
+        this.finalizer = new StructFinalizer((MemoryAddress) address, freeFunc);
+    }
+
+    /**
+     * Enable the {@link Cleaner} to free the native memory
+     */
+    public void takeOwnership() {
+        finalizer.setEnabled(true);
+    }
+
+    /**
+     * Disable the {@link Cleaner} to free the native memory
+     */
+    public void yieldOwnership() {
+        finalizer.setEnabled(false);
+    }
+
+    /**
+     * Return the callback that the {@link Cleaner} will run to free native memory
+     */
+    public Runnable getFinalizer() {
+        return finalizer;
+    }
+
+    /**
+     * This callback is run by the {@link Cleaner} when a struct or union instance
+     * has become unreachable, to free the native memory using {@link GLib#free(MemoryAddress)}.
+     */
+    private static class StructFinalizer implements Runnable {
+
+        private final MemoryAddress address;
+        private final Method freeFunc;
+        private boolean enabled;
+
+        public StructFinalizer(MemoryAddress address, Method freeFunc) {
+            this.address = address;
+            this.freeFunc = freeFunc;
+            this.enabled = false;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public void run() {
+            if (enabled) {
+                if (freeFunc == null) {
+                    GLib.free(address);
+                } else {
+                    try {
+                        freeFunc.invoke(address);
+                    } catch (Exception ignored) {}
+                }
+            }
+        }
+    }
+}

--- a/glib/src/main/java/io/github/jwharm/javagi/interop/InstanceCache.java
+++ b/glib/src/main/java/io/github/jwharm/javagi/interop/InstanceCache.java
@@ -8,7 +8,10 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 
+import io.github.jwharm.javagi.base.FreeFunc;
+import io.github.jwharm.javagi.base.ProxyInstanceCleanable;
 import io.github.jwharm.javagi.util.Types;
+import org.gnome.glib.GLib;
 import org.gnome.glib.Type;
 import org.gnome.gobject.GObject;
 import org.gnome.gobject.ToggleNotify;
@@ -16,6 +19,7 @@ import org.gnome.gobject.TypeClass;
 
 import io.github.jwharm.javagi.base.Floating;
 import io.github.jwharm.javagi.base.Proxy;
+import org.gnome.gobject.TypeInstance;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -201,6 +205,11 @@ public class InstanceCache {
 
             // Register a cleaner that will remove the toggle reference
             CLEANER.register(gobject, new ToggleRefFinalizer(address, notify));
+        }
+
+        // Setup a cleaner on structs/unions
+        if (newInstance instanceof ProxyInstanceCleanable struct) {
+            CLEANER.register(newInstance, struct.getFinalizer());
         }
 
         // Return the new instance.

--- a/glib/src/main/java/io/github/jwharm/javagi/interop/InstanceCache.java
+++ b/glib/src/main/java/io/github/jwharm/javagi/interop/InstanceCache.java
@@ -208,7 +208,7 @@ public class InstanceCache {
         }
 
         // Setup a cleaner on structs/unions
-        if (newInstance instanceof ProxyInstanceCleanable struct) {
+        if (newInstance instanceof ProxyInstanceCleanable struct && struct.getFinalizer() != null) {
             CLEANER.register(newInstance, struct.getFinalizer());
         }
 


### PR DESCRIPTION
Use a Cleaner to call `g_free`, or `[struct_name]_free` when it exists, on structs when the Proxy object is garbage-collected.
