### PR TITLE
Annotation to define GObject properties

### DIFF
--- a/glib/src/main/java/io/github/jwharm/javagi/annotations/Property.java
+++ b/glib/src/main/java/io/github/jwharm/javagi/annotations/Property.java
@@ -1,0 +1,21 @@
+package io.github.jwharm.javagi.annotations;
+
+import org.gnome.gobject.ParamSpec;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Property {
+    String name();
+    Class<? extends ParamSpec> type() default ParamSpec.class;
+    boolean readable() default true;
+    boolean writable() default true;
+    boolean construct() default false;
+    boolean constructOnly() default false;
+    boolean explicitNotify() default false;
+    boolean deprecated() default false;
+}

--- a/glib/src/main/java/io/github/jwharm/javagi/util/ListIndexModel.java
+++ b/glib/src/main/java/io/github/jwharm/javagi/util/ListIndexModel.java
@@ -3,10 +3,8 @@ package io.github.jwharm.javagi.util;
 import java.lang.foreign.*;
 import java.util.ArrayList;
 
-import io.github.jwharm.javagi.annotations.ClassInit;
+import io.github.jwharm.javagi.annotations.Property;
 import org.gnome.gio.ListModel;
-import org.gnome.glib.GLib;
-import org.gnome.glib.LogLevelFlags;
 import org.gnome.glib.Type;
 import org.gnome.gobject.*;
 
@@ -19,9 +17,6 @@ import org.gnome.gobject.*;
 public class ListIndexModel extends GObject implements ListModel {
 
     private static final String LOG_DOMAIN = "java-gi";
-
-    private static final int PROP_ITEM_TYPE = 1;
-    private static final int PROP_N_ITEMS = 2;
 
     /**
      * Construct a ListIndexModel for the provided memory address.
@@ -44,31 +39,6 @@ public class ListIndexModel extends GObject implements ListModel {
             type = Types.register(ListIndexModel.class);
         }
         return type;
-    }
-
-    @ClassInit
-    public static void classInit(GObject.ObjectClass objectClass) {
-        // Install properties "item-type" and "n-items"
-        ParamSpec[] pspecs = new ParamSpec[3];
-        pspecs[PROP_ITEM_TYPE] = GObjects.paramSpecGtype("item-type", "", "", Type.G_TYPE_OBJECT,
-                ParamFlags.CONSTRUCT_ONLY.or(ParamFlags.READWRITE, ParamFlags.STATIC_NAME, ParamFlags.STATIC_BLURB, ParamFlags.STATIC_NICK));
-        pspecs[PROP_N_ITEMS] = GObjects.paramSpecUint("n-items", "", "", 0, GLib.MAXUINT32, 0,
-                ParamFlags.READABLE.or(ParamFlags.STATIC_NAME, ParamFlags.STATIC_BLURB, ParamFlags.STATIC_NICK));
-        objectClass.installProperties(pspecs);
-    }
-
-    @Override
-    public void getProperty(int propertyId, org.gnome.gobject.Value value, org.gnome.gobject.ParamSpec pspec) {
-        switch(propertyId) {
-            case PROP_ITEM_TYPE -> value.setGtype(ListIndex.getType());
-            case PROP_N_ITEMS -> value.setUint(getNItems());
-            default -> GLib.log(LOG_DOMAIN, LogLevelFlags.LEVEL_WARNING, "Invalid property id %d\n", propertyId);
-        }
-    }
-
-    @Override
-    public void setProperty(int propertyId, org.gnome.gobject.Value value, org.gnome.gobject.ParamSpec pspec) {
-        // Ignore
     }
 
     /**
@@ -97,6 +67,7 @@ public class ListIndexModel extends GObject implements ListModel {
      * Returns the gtype of {@link ListIndex}
      * @return always returns the value of {@link ListIndex#getType()}
      */
+    @Property(name = "item-type", type = ParamSpecGType.class, constructOnly = true)
     @Override
     public Type getItemType() {
         return ListIndex.getType();
@@ -106,6 +77,7 @@ public class ListIndexModel extends GObject implements ListModel {
      * Returns the size of the list model
      * @return the value of the size field
      */
+    @Property(name = "n-items", type = ParamSpecUInt.class, writable = false)
     @Override
     public int getNItems() {
         return items.size();

--- a/glib/src/main/java/io/github/jwharm/javagi/util/ValueUtil.java
+++ b/glib/src/main/java/io/github/jwharm/javagi/util/ValueUtil.java
@@ -6,10 +6,8 @@ import java.lang.reflect.Method;
 import org.gnome.glib.GLib;
 import org.gnome.glib.LogLevelFlags;
 import org.gnome.glib.Type;
-import org.gnome.gobject.GObject;
-import org.gnome.gobject.GObjects;
-import org.gnome.gobject.ParamSpec;
-import org.gnome.gobject.Value;
+import org.gnome.glib.Variant;
+import org.gnome.gobject.*;
 
 import io.github.jwharm.javagi.base.Bitfield;
 import io.github.jwharm.javagi.base.Enumeration;
@@ -25,8 +23,8 @@ public class ValueUtil {
      * Read the GType from the GValue, call the corresponding getter (using the methods defined 
      * in the {@link Value} proxy class), and return the result.
      * @param  src a GValue instance.
-     * @return a Java object (or boxed primitive value) that has been marshaled from the GValue, 
-     *         or {@code null} if {@code src} is null.
+     * @return     a Java object (or boxed primitive value) that has been marshaled from the
+     *             GValue, or {@code null} if {@code src} is null.
      */
     public static Object valueToObject(Value src) {
         if (src == null) {
@@ -70,13 +68,68 @@ public class ValueUtil {
             return src.getBoxed();
         }
     }
-    
+
+    /**
+     * Call the getter of the GValue that corresponds to the type of the GParamSpec, and return
+     * the result.
+     * @param src   a GValue instance.
+     * @param pspec the GParamSpec that specifies the type of the GValue. Should not be {@code null}
+     * @return      a Java object (or boxed primitive value) that has been marshaled from the GValue,
+     *              or {@code null} if {@code src} is null.
+     */
+    public static Object valueToObject(Value src, ParamSpec pspec) {
+        if (pspec instanceof ParamSpecBoolean) {
+            return src.getBoolean();
+        } else if (pspec instanceof ParamSpecBoxed) {
+            return src.getBoxed();
+        } else if (pspec instanceof ParamSpecChar) {
+            return src.getSchar();
+        } else if (pspec instanceof ParamSpecUChar) {
+            return src.getUchar();
+        } else if (pspec instanceof ParamSpecDouble) {
+            return src.getDouble();
+        } else if (pspec instanceof ParamSpecEnum) {
+            return src.getEnum();
+        } else if (pspec instanceof ParamSpecFlags) {
+            return src.getFlags();
+        } else if (pspec instanceof ParamSpecFloat) {
+            return src.getFloat();
+        } else if (pspec instanceof ParamSpecGType) {
+            return src.getGtype();
+        } else if (pspec instanceof ParamSpecInt) {
+            return src.getInt();
+        } else if (pspec instanceof ParamSpecUInt) {
+            return src.getUint();
+        } else if (pspec instanceof ParamSpecUnichar) {
+            return src.getUint();
+        } else if (pspec instanceof ParamSpecInt64) {
+            return src.getInt64();
+        } else if (pspec instanceof ParamSpecUInt64) {
+            return src.getUint64();
+        } else if (pspec instanceof ParamSpecLong) {
+            return src.getLong();
+        } else if (pspec instanceof ParamSpecULong) {
+            return src.getUlong();
+        } else if (pspec instanceof ParamSpecObject) {
+            return src.getObject();
+        } else if (pspec instanceof ParamSpecParam) {
+            return src.getParam();
+        } else if (pspec instanceof ParamSpecPointer) {
+            return src.getPointer();
+        } else if (pspec instanceof ParamSpecString) {
+            return src.getString();
+        } else if (pspec instanceof ParamSpecVariant) {
+            return src.getVariant();
+        }
+        return null;
+    }
+
     /**
      * Read the GType of the {@code dest} GValue and set the {@code src} object (or boxed primitive 
      * value) as its value using the corresponding setter in the {@link Value} proxy class.
      * @param src  the Java Object (or boxed primitive value) to put in the GValue. Should not be 
      *             {@code null}
-     * @param dest the GValue to write to. Should not be {@code null}.
+     * @param dest the GValue to write to. Should not be {@code null}
      */
     public static void objectToValue(Object src, Value dest) {
         if (src == null || dest == null) {
@@ -136,6 +189,60 @@ public class ValueUtil {
                     GObjects.typeName(type),
                     e.toString()
             );
+        }
+    }
+
+    /**
+     * Set the {@code src} object (or boxed primitive value) to the GValue using the setter that
+     * corresponds to the type of ParamSpec.
+     * @param src   the Java Object (or boxed primitive value) to put in the GValue. Should not be
+     *              {@code null}
+     * @param dest  the GValue to write to. Should not be {@code null}
+     * @param pspec the GParamSpec that specifies the type of the GValue. Should not be {@code null}
+     */
+    public static void objectToValue(Object src, Value dest, ParamSpec pspec) {
+        if (pspec instanceof ParamSpecBoolean) {
+            dest.setBoolean((Boolean) src);
+        } else if (pspec instanceof ParamSpecBoxed) {
+            dest.setBoxed((MemorySegment) src);
+        } else if (pspec instanceof ParamSpecChar) {
+            dest.setSchar((Byte) src);
+        } else if (pspec instanceof ParamSpecUChar) {
+            dest.setUchar((Byte) src);
+        } else if (pspec instanceof ParamSpecDouble) {
+            dest.setDouble((Double) src);
+        } else if (pspec instanceof ParamSpecEnum) {
+            dest.setEnum(((Enumeration) src).getValue());
+        } else if (pspec instanceof ParamSpecFlags) {
+            dest.setFlags(((Bitfield) src).getValue());
+        } else if (pspec instanceof ParamSpecFloat) {
+            dest.setFloat((Float) src);
+        } else if (pspec instanceof ParamSpecGType) {
+            dest.setGtype((Type) src);
+        } else if (pspec instanceof ParamSpecInt) {
+            dest.setInt((Integer) src);
+        } else if (pspec instanceof ParamSpecUInt) {
+            dest.setUint((Integer) src);
+        } else if (pspec instanceof ParamSpecUnichar) {
+            dest.setUint((Integer) src);
+        } else if (pspec instanceof ParamSpecInt64) {
+            dest.setLong((Long) src);
+        } else if (pspec instanceof ParamSpecUInt64) {
+            dest.setUint64((Long) src);
+        } else if (pspec instanceof ParamSpecLong) {
+            dest.setLong((Long) src);
+        } else if (pspec instanceof ParamSpecULong) {
+            dest.setLong((Long) src);
+        } else if (pspec instanceof ParamSpecObject) {
+            dest.setObject((GObject) src);
+        } else if (pspec instanceof ParamSpecParam) {
+            dest.setParam((ParamSpec) src);
+        } else if (pspec instanceof ParamSpecPointer) {
+            dest.setPointer((MemorySegment) src);
+        } else if (pspec instanceof ParamSpecString) {
+            dest.setString((String) src);
+        } else if (pspec instanceof ParamSpecVariant) {
+            dest.setVariant((Variant) src);
         }
     }
 }

--- a/gtk/src/main/java/io/github/jwharm/javagi/gtk/util/Types.java
+++ b/gtk/src/main/java/io/github/jwharm/javagi/gtk/util/Types.java
@@ -7,7 +7,6 @@ import org.gnome.glib.GLib;
 import org.gnome.glib.LogLevelFlags;
 import org.gnome.glib.Type;
 import org.gnome.gobject.GObject;
-import org.gnome.gobject.TypeClass;
 import org.gnome.gobject.TypeFlags;
 import org.gnome.gtk.Widget;
 
@@ -108,7 +107,7 @@ public class Types {
         return size + s;
     }
 
-    private static <T extends Widget> Consumer<TypeClass> getTemplateClassInit(Class<T> cls, MemoryLayout layout) {
+    private static <T extends Widget> Consumer<GObject.ObjectClass> getTemplateClassInit(Class<T> cls, MemoryLayout layout) {
         var annotation = cls.getAnnotation(GtkTemplate.class);
         String ui = annotation.ui();
 
@@ -166,8 +165,8 @@ public class Types {
             TypeFlags flags = getTypeFlags(cls);
 
             // Chain template class init with user-defined class init function
-            Consumer<TypeClass> classInit = getTemplateClassInit(cls, instanceLayout);
-            Consumer<TypeClass> userDefinedClassInit = getClassInit(cls);
+            Consumer<GObject.ObjectClass> classInit = getTemplateClassInit(cls, instanceLayout);
+            Consumer<GObject.ObjectClass> userDefinedClassInit = getClassInit(cls);
             if (userDefinedClassInit != null)
                 classInit = classInit.andThen(userDefinedClassInit);
 
@@ -205,7 +204,7 @@ public class Types {
             org.gnome.glib.Type parentType,
             String typeName,
             MemoryLayout classLayout,
-            Consumer<TypeClass> classInit,
+            Consumer<GObject.ObjectClass> classInit,
             MemoryLayout instanceLayout,
             Consumer<T> instanceInit,
             Function<MemorySegment, T> constructor,


### PR DESCRIPTION
This adds a new `@Property` annotation that can be used with getter and setter methods in Java code to define GObject properties.

Example usage:

```java
@Property(name = "n-items", type = ParamSpecInt.class, writable = false)
public int getNItems() {
    return items.size();
}
```

The property definitions in the `ListIndexModel` utility class now use this annotation.
