### PR TITLE
Add Value.toString()

### DIFF
--- a/buildSrc/src/main/java/io/github/jwharm/javagi/patches/GObjectPatch.java
+++ b/buildSrc/src/main/java/io/github/jwharm/javagi/patches/GObjectPatch.java
@@ -179,5 +179,21 @@ public class GObjectPatch implements Patch {
                 return Signals.emit(this, detailedSignal, params);
             }
         """);
+
+        inject(repo, "Value", """
+            
+            /**
+             * Return a newly allocated string using {@link GObjects#strdupValueContents(Value)},
+             * which describes the contents of a {@link Value}.
+             * The main purpose of this function is to describe {@link Value}
+             * contents for debugging output, the way in which the contents are
+             * described may change between different GLib versions.
+             * @return Newly allocated string.
+             */
+            @Override
+            public String toString() {
+                return GObjects.strdupValueContents(this);
+            }
+        """);
     }
 }

--- a/modules/gobject/src/test/java/io/github/jwharm/javagi/test/gobject/ValueToStringTest.java
+++ b/modules/gobject/src/test/java/io/github/jwharm/javagi/test/gobject/ValueToStringTest.java
@@ -1,0 +1,33 @@
+package io.github.jwharm.javagi.test.gobject;
+
+import io.github.jwharm.javagi.gobject.types.Types;
+import org.gnome.gobject.Value;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * {@code org.gnome.Value.toString()} is injected with a patch.
+ * Test if it works.
+ * <p>
+ * If this test fails because the actual value is something like
+ * {@code org.gnome.gobject.Value@31e4bb20}, it means the
+ * {@code toString()} method doesn't exist (the patch was not applied).
+ */
+public class ValueToStringTest {
+
+    @Test
+    public void testValueToString() {
+        Value vInt = Value.allocate().init(Types.INT);
+        vInt.setInt(123);
+        assertEquals("123", vInt.toString());
+
+        Value vBool = Value.allocate().init(Types.BOOLEAN);
+        vBool.setBoolean(true);
+        assertEquals("TRUE", vBool.toString());
+
+        Value vStr = Value.allocate().init(Types.STRING);
+        vStr.setString("abc");
+        assertEquals("\"abc\"", vStr.toString());
+    }
+}


### PR DESCRIPTION
Adds a `toString()` method to `org.gnome.gobject.Value` that calls [`g_strdup_value_contents`](https://docs.gtk.org/gobject/func.strdup_value_contents.html).