### PR TITLE
Inferred property names

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,24 +176,24 @@ public class MyWidget extends Widget {
 }
 ```
 
-You can define custom GObject properties and signals using annotations:
+You can define custom GObject properties and signals using annotations. The following example defines an `int` property named `"lives"` and a `"game-over"` signal with a `String` parameter:
 
 ```java
-    @Property(name="lives")
+    @Property
     public int getLives() {
         return lives;
     }
     
-    @Property(name="lives")
+    @Property
     public void setLives(int value) {
         this.lives = value;
-        if (value == 0) emit("game-over", limit);
+        if (value == 0)
+            emit("game-over", player.name());
     }
 
-    @Signal(name="game-over")
-    @FunctionalInterface
+    @Signal
     public interface GameOver {
-        public void apply(int limit);
+        void apply(String playerName);
     }
 ```
 

--- a/modules/gobject/src/main/java/io/github/jwharm/javagi/gobject/annotations/Property.java
+++ b/modules/gobject/src/main/java/io/github/jwharm/javagi/gobject/annotations/Property.java
@@ -29,7 +29,7 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface Property {
-    String name();
+    String name() default "";
     Class<? extends ParamSpec> type() default ParamSpec.class;
     boolean readable() default true;
     boolean writable() default true;

--- a/modules/gobject/src/test/java/io/github/jwharm/javagi/test/gobject/DerivedClassTest.java
+++ b/modules/gobject/src/test/java/io/github/jwharm/javagi/test/gobject/DerivedClassTest.java
@@ -145,12 +145,12 @@ public class DerivedClassTest {
 
         private boolean boolProperty = false;
 
-        @Property(name="bool-property")
+        @Property // name will be inferred: "bool-property"
         public boolean getBoolProperty() {
             return boolProperty;
         }
 
-        @Property(name="bool-property")
+        @Property
         public void setBoolProperty(boolean boolProperty) {
             this.boolProperty = boolProperty;
         }

--- a/website/docs/register.md
+++ b/website/docs/register.md
@@ -117,7 +117,7 @@ The `@Property` annotation accepts the following parameters:
 | explicitNotify | Boolean   | false         |
 | deprecated     | Boolean   | false         |
 
-When the name is not specified, it will be inferred from the name of the method, stripping the "get" or "set" prefix and converting CamelCase to kebab-case. If you do specify a name, it must be present on **both** the getter and setter methods (otherwise Java-GI will create two properties, with different names).
+When the name is not specified, it will be inferred from the name of the method (provided that the method names follow the `getX`/`setX` pattern), stripping the "get" or "set" prefix and converting CamelCase to kebab-case. If you do specify a name, it must be present on **both** the getter and setter methods (otherwise Java-GI will create two properties, with different names).
 
 When the type is not specified, it will be inferred from the parameter or return-type of the method. When the type is specified, it must be one of the subclasses of `GParamSpec`. The boolean parameters are `GParamFlags` arguments, and are documented [here](https://docs.gtk.org/gobject/flags.ParamFlags.html).
 

--- a/website/docs/register.md
+++ b/website/docs/register.md
@@ -43,10 +43,12 @@ Finally, add the default memory-address-constructor for Java-GI Proxy objects:
 
 This constructor must exist in all Java-GI Proxy objects. It enables a Proxy class to be instantiated automatically for new instances returned from native function calls.
 
-If your application is module-based, you must export your package to the `org.gnome.glib` module in your `module-info.java` file, to allow the reflection to work:
+If your application is module-based, you must export your package to the `org.gnome.gobject` module in your `module-info.java` file, to allow the reflection to work:
 
 ```
-exports [package.name] to org.gnome.glib;
+module my.module.name {
+    exports my.package.name to org.gnome.gobject;
+}
 ```
 
 ## Specifying the name of the GType
@@ -84,19 +86,19 @@ public void finalize_() {
 
 ## Properties
 
-You can define GObject properties with the `@Property` annotation on the getter and setter methods. You must annotate both the getter and setter methods (if applicable). The `@Property` annotation must always specify the `name` parameter; all other parameters are optional.
+You can define GObject properties with the `@Property` annotation on the getter and setter methods. You must annotate both the getter and setter methods (if applicable). The `@Property` annotation can optionally specify the `name` parameter; all other parameters are optional.
 
 Example definition of an `int` property with name `n-items`:
 
 ```java
 private int size;
 
-@Property(name="n-items")
+@Property
 public int getNItems() {
     return size;
 }
 
-@Property(name="n-items")
+@Property
 public void setNItems(int nItems) {
     size = nItems;
 }
@@ -106,7 +108,7 @@ The `@Property` annotation accepts the following parameters:
 
 | Parameter      | Type      | Default value |
 |----------------|-----------|---------------|
-| name           | Mandatory | n/a           |
+| name           | String    | inferred      |
 | type           | ParamSpec | inferred      |
 | readable       | Boolean   | true          |
 | writable       | Boolean   | true          |
@@ -114,6 +116,8 @@ The `@Property` annotation accepts the following parameters:
 | constructOnly  | Boolean   | false         |
 | explicitNotify | Boolean   | false         |
 | deprecated     | Boolean   | false         |
+
+When the name is not specified, it will be inferred from the name of the method, stripping the "get" or "set" prefix and converting CamelCase to kebab-case. If you do specify a name, it must be present on **both** the getter and setter methods (otherwise Java-GI will create two properties, with different names).
 
 When the type is not specified, it will be inferred from the parameter or return-type of the method. When the type is specified, it must be one of the subclasses of `GParamSpec`. The boolean parameters are `GParamFlags` arguments, and are documented [here](https://docs.gtk.org/gobject/flags.ParamFlags.html).
 
@@ -163,7 +167,7 @@ public class Counter extends GObject {
 }
 ```
 
-The "limit-reached" signal is defined with a functional interface annotated as `@Signal`. The method signature of the functional interface is used to define the signal parameters and return value. The signal name is inferred from the interface too (converting CamelCase to kebab-case) but can be overridden.
+The "limit-reached" signal in the example is defined with a functional interface annotated as `@Signal`. The method signature of the functional interface is used to define the signal parameters and return value. The signal name is inferred from the interface too (converting CamelCase to kebab-case) but can be overridden.
 
 You can connect to the custom signal, like this:
 
@@ -173,7 +177,7 @@ counter.connect("limit-reached", (Counter.LimitReached) (limit) -> {
 }
 ```
 
-Because the signal declaration is an ordinary functional interface, the declaration in the above example can also be declared as an `IntConsumer`:
+Because the signal declaration is an ordinary functional interface, it is equally valid to extend from a standard functional interface like `Runnable`, `BooleanSupplier`, or any other one, like (in the above example) an `IntConsumer`:
 
 ```
 @Signal


### PR DESCRIPTION
Make the "name" parameter of the `@Property` annotation optional, and infer the property name from the method names.

The following example:

```java
@Property(name="current-angle")
public double getCurrentAngle() {
    return this.angle;
}

@property(name="current-angle")
public double setCurrentAngle(double angle) {
    this.angle = angle;
}
```

is equivalent to:

```java
@Property
public double getCurrentAngle() {
    return this.angle;
}

@property
public double setCurrentAngle(double angle) {
    this.angle = angle;
}
```

The property name will be inferred from the method name:
- Both methods must be regular getters and setters, following the `getX`/`setX` naming pattern
- Java-GI will strip the get/set prefix from the method name and convert the remaining part from CamelCase to kebab-case.
