### PR TITLE
Upgrade cairo to 1.18.0

### DIFF
--- a/buildSrc/src/main/java/io/github/jwharm/javagi/GenerateSources.java
+++ b/buildSrc/src/main/java/io/github/jwharm/javagi/GenerateSources.java
@@ -60,14 +60,14 @@ public abstract class GenerateSources extends DefaultTask {
     @TaskAction
     void execute() {
         try {
-            Module windows = parse(Platform.WINDOWS, getInputDirectory().get(), getGirFile().get(),
-                    getUrlPrefix().getOrElse(null), getPatch().getOrElse(null));
             Module linux = parse(Platform.LINUX, getInputDirectory().get(), getGirFile().get(),
+                    getUrlPrefix().getOrElse(null), getPatch().getOrElse(null));
+            Module windows = parse(Platform.WINDOWS, getInputDirectory().get(), getGirFile().get(),
                     getUrlPrefix().getOrElse(null), getPatch().getOrElse(null));
             Module macos = parse(Platform.MACOS, getInputDirectory().get(), getGirFile().get(),
                     getUrlPrefix().getOrElse(null), getPatch().getOrElse(null));
 
-            Module module = new Merge().merge(windows, linux, macos);
+            Module module = new Merge().merge(linux, windows, macos);
 
             for (Repository repository : module.repositories.values()) {
                 if (repository.generate) {

--- a/buildSrc/src/main/java/io/github/jwharm/javagi/generator/Merge.java
+++ b/buildSrc/src/main/java/io/github/jwharm/javagi/generator/Merge.java
@@ -21,6 +21,7 @@ package io.github.jwharm.javagi.generator;
 
 import io.github.jwharm.javagi.model.*;
 import io.github.jwharm.javagi.model.Class;
+import io.github.jwharm.javagi.model.Enumeration;
 import io.github.jwharm.javagi.model.Module;
 import io.github.jwharm.javagi.model.Record;
 
@@ -153,6 +154,10 @@ public class Merge {
                     multi.aliasList.add(alias);
                 } else if (rt instanceof Class cls) {
                     multi.classList.add(cls);
+                } else if (rt instanceof Bitfield flag) {
+                    multi.bitfieldList.add(flag);
+                } else if (rt instanceof Enumeration enu) {
+                    multi.enumerationList.add(enu);
                 }
             }
         }

--- a/modules/gdk/build.gradle
+++ b/modules/gdk/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     api project(':gio')
     api project(':pango')
     api project(':pangocairo')
-    api 'io.github.jwharm.cairobindings:cairo:1.16.2'
+    api 'io.github.jwharm.cairobindings:cairo:1.18.0'
 }
 
 tasks.named('generateSources') {

--- a/modules/harfbuzz/build.gradle
+++ b/modules/harfbuzz/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 dependencies {
     api project(':gobject')
-    api 'io.github.jwharm.cairobindings:cairo:1.16.2'
+    api 'io.github.jwharm.cairobindings:cairo:1.18.0'
 }
 
 tasks.named('generateSources') {

--- a/modules/pango/build.gradle
+++ b/modules/pango/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     api project(':gobject')
     api project(':gio')
     api project(':harfbuzz')
-    api 'io.github.jwharm.cairobindings:cairo:1.16.2'
+    api 'io.github.jwharm.cairobindings:cairo:1.18.0'
 }
 
 tasks.named('generateSources') {

--- a/modules/pangocairo/build.gradle
+++ b/modules/pangocairo/build.gradle
@@ -5,7 +5,7 @@ plugins {
 dependencies {
     api project(':gobject')
     api project(':pango')
-    api 'io.github.jwharm.cairobindings:cairo:1.16.2'
+    api 'io.github.jwharm.cairobindings:cairo:1.18.0'
 }
 
 tasks.named('generateSources') {


### PR DESCRIPTION
The dependency on the cairo java bindings is upgraded from 1.16.2 to 1.18.0.
As of release 1.18.0 of the cairo java bindings, the `get_type()` functions from cairo-gobject are included. This fixes an issue when compiling Java-GI with gir files from GNOME 45.
