### PR TITLE
Use setter syntax in builder classes

### DIFF
--- a/buildSrc/src/main/java/io/github/jwharm/javagi/generator/Conversions.java
+++ b/buildSrc/src/main/java/io/github/jwharm/javagi/generator/Conversions.java
@@ -46,6 +46,13 @@ public class Conversions {
     }
 
     /**
+     * Convert "identifier_name" to "IdentifierName"
+     */
+    public static String toUpperCaseJavaName(String typeName) {
+        return prefixDigits(replaceKeywords(toCamelCase(typeName, true)));
+    }
+
+    /**
      * Convert "GLib.type_name" to "TypeName"
      */
     public static String toSimpleJavaType(String typeName, Namespace ns) {
@@ -245,8 +252,6 @@ public class Conversions {
         return switch(primitive) {
             case "char" -> "Character";
             case "int" -> "Integer";
-            case "java.lang.foreign.MemorySegment" -> "Address";
-            case "java.lang.String" -> "String";
             default -> toCamelCase(primitive, true);
         };
     }

--- a/buildSrc/src/main/java/io/github/jwharm/javagi/model/Property.java
+++ b/buildSrc/src/main/java/io/github/jwharm/javagi/model/Property.java
@@ -35,20 +35,42 @@ public class Property extends Variable {
         this.transferOwnership = transferOwnership;
         this.getter = getter;
     }
-    
+
+    /**
+     * Temporarily generate two builder methods, with deprecated and new syntax
+     * @param writer The writer to the class file
+     * @throws IOException Thrown when an exception occurs during writing
+     */
+    public void generate(SourceWriter writer) throws IOException {
+        generate(writer, true);
+        generate(writer, false);
+    }
+
     /**
      * Generate a setter method for use in a GObjectBuilder
      * @param writer The writer to the class file
      * @throws IOException Thrown when an exception occurs during writing
      */
-    public void generate(SourceWriter writer) throws IOException {
+    public void generate(SourceWriter writer, boolean deprecatedVersion) throws IOException {
         String gTypeDeclaration = getGTypeDeclaration();
         writer.write("\n");
         if (doc != null) {
-            doc.generate(writer, false);
+            writer.write("/**\n");
+            doc.generate(writer, false, false);
+            if (deprecatedVersion)
+                writer.write(" * @deprecated Use {@link #set" + Conversions.toUpperCaseJavaName(name) + "} instead\n");
+            writer.write(" */\n");
         }
+
+        String setterName = "set" + Conversions.toUpperCaseJavaName(name);
+        if (deprecatedVersion)
+            setterName = Conversions.toLowerCaseJavaName(name);
+
+        if (deprecatedVersion)
+            writer.write("@Deprecated\n");
+
         writer.write((parent instanceof Interface) ? "default " : "public ");
-        writer.write("S " + Conversions.toLowerCaseJavaName(name) + "(");
+        writer.write("S " + setterName + "(");
         writeTypeAndName(writer);
         writer.write(") {\n");
         writer.increaseIndent();

--- a/buildSrc/src/main/java/io/github/jwharm/javagi/model/ValueWrapper.java
+++ b/buildSrc/src/main/java/io/github/jwharm/javagi/model/ValueWrapper.java
@@ -19,11 +19,13 @@
 
 package io.github.jwharm.javagi.model;
 
-import io.github.jwharm.javagi.generator.Conversions;
 import io.github.jwharm.javagi.generator.SourceWriter;
 
 import java.io.IOException;
 
+/**
+ * Base class for types that wrap a primitive value: Bitfields, Enumerations, and Aliases (typedefs)
+ */
 public abstract class ValueWrapper extends RegisteredType {
     
     public ValueWrapper(GirElement parent, String name, String parentClass, String cType, String getType, String version) {
@@ -46,10 +48,6 @@ public abstract class ValueWrapper extends RegisteredType {
         if ("java.lang.foreign.MemorySegment".equals(type.qualifiedJavaType)) {
             str = paramName + ".getValue()";
         }
-        if (isPointer) {
-            return "new Pointer" + Conversions.primitiveClassName(type.qualifiedJavaType) + "(" + str + ").handle()";
-        } else {
-            return str;
-        }
+        return str;
     }
 }


### PR DESCRIPTION
Currently the builders use property names as method names:

```java
var box = Box.builder()
    .orientation(Orientation.VERTICAL)
    .halign(Align.CENTER)
    .valign(Align.CENTER)
    .build();
```

This is nice to use in Java. However, there are some disadvantages too:

1. Several other JVM languages have special syntax for JavaBean-style setters, like Kotlin *synthetic properties* and the Clojure `bean` function, that don't work with this naming pattern.
2. Although some Java API's (like `java.lang.ProcessBuilder`) use the shorter syntax, most Java developers are used to the `setXxx()` syntax.

Therefore, the builders will now use  the `setXxx()` naming pattern:

```java
var box = Box.builder()
    .setOrientation(Orientation.VERTICAL)
    .setHalign(Align.CENTER)
    .setValign(Align.CENTER)
    .build();
```

The current methods are still available, but deprecated, and will be removed in a future Java-GI release.
