### PR TITLE
Generate better Harfbuzz type names

### DIFF
--- a/buildSrc/src/main/java/io/github/jwharm/javagi/generator/Builder.java
+++ b/buildSrc/src/main/java/io/github/jwharm/javagi/generator/Builder.java
@@ -50,10 +50,10 @@ public class Builder {
         // Write the inner Build class definition
         writer.write("\n");
         writer.write("/**\n");
-        writer.write(" * A {@link " + c.javaName + ".Builder} object constructs a {@code " + c.javaName + "} \n");
+        writer.write(" * A {@link Builder} object constructs a {@code " + c.javaName + "} \n");
         writer.write(" * using the <em>builder pattern</em> to set property values. \n");
         writer.write(" * Use the various {@code set...()} methods to set properties, \n");
-        writer.write(" * and finish construction with {@link " + c.javaName + ".Builder#build()}. \n");
+        writer.write(" * and finish construction with {@link Builder#build()}. \n");
         writer.write(" */\n");
         writer.write("public static Builder<? extends Builder> builder() {\n");
         writer.write("    return new Builder<>();\n");

--- a/buildSrc/src/main/java/io/github/jwharm/javagi/generator/Conversions.java
+++ b/buildSrc/src/main/java/io/github/jwharm/javagi/generator/Conversions.java
@@ -143,7 +143,7 @@ public class Conversions {
     }
 
     /**
-     * For types that conflict with common Java classes, prefix with Gi
+     * For types that conflict with common Java classes, prefix with C namespace
      */
     public static String replaceKnownType(String name, Namespace ns) {
         final String[] types = {"String", "Object", "Error", "Builder"};

--- a/buildSrc/src/main/java/io/github/jwharm/javagi/generator/Conversions.java
+++ b/buildSrc/src/main/java/io/github/jwharm/javagi/generator/Conversions.java
@@ -105,8 +105,16 @@ public class Conversions {
         if (typeName == null) {
             return null;
         }
-        char[] chars = typeName.toCharArray();
+
+        char[] chars;
         StringBuilder builder = new StringBuilder();
+
+        // Strip "_t" from "type_name_t"-style names (HarfBuzz has this)
+        if (typeName.endsWith("_t")) {
+            chars = typeName.substring(0, typeName.length() - 2).toCharArray();
+        } else {
+            chars = typeName.toCharArray();
+        }
 
         boolean upper = startUpperCase;
         for (char c : chars) {

--- a/buildSrc/src/main/java/io/github/jwharm/javagi/generator/Javadoc.java
+++ b/buildSrc/src/main/java/io/github/jwharm/javagi/generator/Javadoc.java
@@ -230,10 +230,12 @@ public class Javadoc {
                         return checkLink(part1, part2) + part1 + formatMethod(part2) + "}";
                     }
                 } else {
+                    Namespace ns = getNamespace(part1);
+                    String className = (ns == null) ? part2 : Conversions.replaceKnownType(part2, ns);
                     if ("new".equals(part3)) {
-                        return checkLink(part1, part2) + formatNS(part1) + part2 + "#" + part2 + "}";
+                        return checkLink(part1, part2) + formatNS(part1) + className + "#" + className + "}";
                     } else {
-                        return checkLink(part1, part2, part3) + formatNS(part1) + part2 + formatMethod(part3) + "}";
+                        return checkLink(part1, part2, part3) + formatNS(part1) + className + formatMethod(part3) + "}";
                     }
                 }
             case "method":
@@ -251,7 +253,9 @@ public class Javadoc {
                     if (part2 == null) {
                         return checkLink(part1) + doc.getNamespace().name + formatMethod(part1) + "}";
                     } else {
-                        return checkLink(part1, part2) + formatNS(part1) + part1 + formatMethod(part2) + "}";
+                        Namespace ns = getNamespace(part1);
+                        String className = (ns == null) ? part1 : ns.globalClassName;
+                        return checkLink(part1, part2) + formatNS(part1) + className + formatMethod(part2) + "}";
                     }
                 } else {
                     return checkLink(part1, part2, part3) + formatNS(part1) + part2 + formatMethod(part3) + "}";
@@ -405,7 +409,9 @@ public class Javadoc {
             return null;
         }
         String name = formatNS(girElement.getNamespace().name);
-        String type = girElement.parent.name;
+        String type = girElement.parent instanceof RegisteredType rt ? rt.javaName
+                : girElement.parent instanceof Namespace ns ? ns.globalClassName
+                : girElement.parent.name;
         if (type != null) {
             name += type;
         }


### PR DESCRIPTION
HarfBuzz types are postfixed with `_t` in C, like `hb_font_t`. This leads to Java types like `FontT`. The trailing `T` is unnecessary and doesn't look very nice. With this change, the HarfBuzz types in Java will loose the trailing `T` so `hb_font_t` will generate a Java `Font` class. The change is not specific for HarfBuzz, but will apply to all type names ending with `_t`.
