### PR TITLE
Improve virtual methods

### DIFF
--- a/buildSrc/src/main/java/io/github/jwharm/javagi/GenerateSources.java
+++ b/buildSrc/src/main/java/io/github/jwharm/javagi/GenerateSources.java
@@ -61,11 +61,11 @@ public abstract class GenerateSources extends DefaultTask {
     void execute() {
         try {
             Module linux = parse(Platform.LINUX, getInputDirectory().get(), getGirFile().get(),
-                    getUrlPrefix().getOrElse(null), getPatch().getOrElse(null));
+                    getUrlPrefix().getOrNull(), getPatch().getOrNull());
             Module windows = parse(Platform.WINDOWS, getInputDirectory().get(), getGirFile().get(),
-                    getUrlPrefix().getOrElse(null), getPatch().getOrElse(null));
+                    getUrlPrefix().getOrNull(), getPatch().getOrNull());
             Module macos = parse(Platform.MACOS, getInputDirectory().get(), getGirFile().get(),
-                    getUrlPrefix().getOrElse(null), getPatch().getOrElse(null));
+                    getUrlPrefix().getOrNull(), getPatch().getOrNull());
 
             Module module = new Merge().merge(linux, windows, macos);
 
@@ -109,6 +109,9 @@ public abstract class GenerateSources extends DefaultTask {
             // Flag unsupported va_list methods so they will not be generated
             module.flagVaListFunctions();
 
+            // Link the type references to the GIR type definition across the GI repositories
+            module.link();
+
             // Apply patch
             if (patch != null) {
                 patch.patch(r);
@@ -117,9 +120,6 @@ public abstract class GenerateSources extends DefaultTask {
         } catch (IOException ignored) {
             // Gir file not found for this platform: This will generate code with UnsupportedPlatformExceptions
         }
-
-        // Link the type references to the GIR type definition across the GI repositories
-        module.link();
 
         return module;
     }

--- a/buildSrc/src/main/java/io/github/jwharm/javagi/generator/Merge.java
+++ b/buildSrc/src/main/java/io/github/jwharm/javagi/generator/Merge.java
@@ -212,10 +212,10 @@ public class Merge {
      * @param methods the list of methods to add
      */
     private <T extends Method> void mergeMethods(GirElement parent, List<T> multi, List<T> methods) {
-        Set<String> signatures = new HashSet<>(multi.stream().map(Method::getTypeSignature).toList());
+        Set<String> signatures = new HashSet<>(multi.stream().map(Method::getNameAndSignature).toList());
         Set<String> cIdentifiers = new HashSet<>(multi.stream().map(method -> method.cIdentifier).toList());
         for (T method : methods) {
-            var signature = method.getTypeSignature();
+            var signature = method.getNameAndSignature();
             var cIdentifier = method.cIdentifier;
             if (cIdentifier != null && cIdentifiers.contains(cIdentifier)) {
                 continue;
@@ -237,21 +237,21 @@ public class Merge {
      */
     private void setMethodPlatforms(List<? extends Method> methods, List<? extends GirElement> registeredTypes) {
         for (Method method : methods) {
-            String signature = method.getTypeSignature();
+            String signature = method.getNameAndSignature();
             for (var rt : registeredTypes) {
                 if (rt == null) {
                     continue;
                 }
-                if (rt.methodList.stream().map(Method::getTypeSignature).anyMatch(signature::equals)) {
+                if (rt.methodList.stream().map(Method::getNameAndSignature).anyMatch(signature::equals)) {
                     method.platforms.add(rt.module().platform);
                 }
-                if (rt.virtualMethodList.stream().map(Method::getTypeSignature).anyMatch(signature::equals)) {
+                if (rt.virtualMethodList.stream().map(Method::getNameAndSignature).anyMatch(signature::equals)) {
                     method.platforms.add(rt.module().platform);
                 }
-                if (rt.functionList.stream().map(Method::getTypeSignature).anyMatch(signature::equals)) {
+                if (rt.functionList.stream().map(Method::getNameAndSignature).anyMatch(signature::equals)) {
                     method.platforms.add(rt.module().platform);
                 }
-                if (rt.constructorList.stream().map(Method::getTypeSignature).anyMatch(signature::equals)) {
+                if (rt.constructorList.stream().map(Method::getNameAndSignature).anyMatch(signature::equals)) {
                     method.platforms.add(rt.module().platform);
                 }
             }
@@ -265,32 +265,32 @@ public class Merge {
      */
     private void overrideLongValues(List<? extends Method> methods, List<? extends GirElement> registeredTypes) {
         for (Method method : methods) {
-            String signature = method.getTypeSignature();
+            String signature = method.getNameAndSignature();
             for (var rt : registeredTypes) {
                 if (rt == null) {
                     continue;
                 }
                 // Check if this method exists on Windows
-                if (rt.methodList.stream().map(Method::getTypeSignature).anyMatch(signature::equals)) {
+                if (rt.methodList.stream().map(Method::getNameAndSignature).anyMatch(signature::equals)) {
                     if (rt.module().platform == Platform.WINDOWS) {
                         // Convert glong/gulong parameters to gint/guint
                         overrideLongValues(method);
                     }
                 }
                 // Same for virtual methods
-                if (rt.virtualMethodList.stream().map(Method::getTypeSignature).anyMatch(signature::equals)) {
+                if (rt.virtualMethodList.stream().map(Method::getNameAndSignature).anyMatch(signature::equals)) {
                     if (rt.module().platform == Platform.WINDOWS) {
                         overrideLongValues(method);
                     }
                 }
                 // Same for functions (static methods)
-                if (rt.functionList.stream().map(Method::getTypeSignature).anyMatch(signature::equals)) {
+                if (rt.functionList.stream().map(Method::getNameAndSignature).anyMatch(signature::equals)) {
                     if (rt.module().platform == Platform.WINDOWS) {
                         overrideLongValues(method);
                     }
                 }
                 // Same for constructors
-                if (rt.constructorList.stream().map(Method::getTypeSignature).anyMatch(signature::equals)) {
+                if (rt.constructorList.stream().map(Method::getNameAndSignature).anyMatch(signature::equals)) {
                     if (rt.module().platform == Platform.WINDOWS) {
                         overrideLongValues(method);
                     }

--- a/buildSrc/src/main/java/io/github/jwharm/javagi/generator/Merge.java
+++ b/buildSrc/src/main/java/io/github/jwharm/javagi/generator/Merge.java
@@ -212,10 +212,10 @@ public class Merge {
      * @param methods the list of methods to add
      */
     private <T extends Method> void mergeMethods(GirElement parent, List<T> multi, List<T> methods) {
-        Set<String> signatures = new HashSet<>(multi.stream().map(Method::getMethodSpecification).toList());
+        Set<String> signatures = new HashSet<>(multi.stream().map(Method::getTypeSignature).toList());
         Set<String> cIdentifiers = new HashSet<>(multi.stream().map(method -> method.cIdentifier).toList());
         for (T method : methods) {
-            var signature = method.getMethodSpecification();
+            var signature = method.getTypeSignature();
             var cIdentifier = method.cIdentifier;
             if (cIdentifier != null && cIdentifiers.contains(cIdentifier)) {
                 continue;
@@ -237,21 +237,21 @@ public class Merge {
      */
     private void setMethodPlatforms(List<? extends Method> methods, List<? extends GirElement> registeredTypes) {
         for (Method method : methods) {
-            String signature = method.getMethodSpecification();
+            String signature = method.getTypeSignature();
             for (var rt : registeredTypes) {
                 if (rt == null) {
                     continue;
                 }
-                if (rt.methodList.stream().map(Method::getMethodSpecification).anyMatch(signature::equals)) {
+                if (rt.methodList.stream().map(Method::getTypeSignature).anyMatch(signature::equals)) {
                     method.platforms.add(rt.module().platform);
                 }
-                if (rt.virtualMethodList.stream().map(Method::getMethodSpecification).anyMatch(signature::equals)) {
+                if (rt.virtualMethodList.stream().map(Method::getTypeSignature).anyMatch(signature::equals)) {
                     method.platforms.add(rt.module().platform);
                 }
-                if (rt.functionList.stream().map(Method::getMethodSpecification).anyMatch(signature::equals)) {
+                if (rt.functionList.stream().map(Method::getTypeSignature).anyMatch(signature::equals)) {
                     method.platforms.add(rt.module().platform);
                 }
-                if (rt.constructorList.stream().map(Method::getMethodSpecification).anyMatch(signature::equals)) {
+                if (rt.constructorList.stream().map(Method::getTypeSignature).anyMatch(signature::equals)) {
                     method.platforms.add(rt.module().platform);
                 }
             }
@@ -265,32 +265,32 @@ public class Merge {
      */
     private void overrideLongValues(List<? extends Method> methods, List<? extends GirElement> registeredTypes) {
         for (Method method : methods) {
-            String signature = method.getMethodSpecification();
+            String signature = method.getTypeSignature();
             for (var rt : registeredTypes) {
                 if (rt == null) {
                     continue;
                 }
                 // Check if this method exists on Windows
-                if (rt.methodList.stream().map(Method::getMethodSpecification).anyMatch(signature::equals)) {
+                if (rt.methodList.stream().map(Method::getTypeSignature).anyMatch(signature::equals)) {
                     if (rt.module().platform == Platform.WINDOWS) {
                         // Convert glong/gulong parameters to gint/guint
                         overrideLongValues(method);
                     }
                 }
                 // Same for virtual methods
-                if (rt.virtualMethodList.stream().map(Method::getMethodSpecification).anyMatch(signature::equals)) {
+                if (rt.virtualMethodList.stream().map(Method::getTypeSignature).anyMatch(signature::equals)) {
                     if (rt.module().platform == Platform.WINDOWS) {
                         overrideLongValues(method);
                     }
                 }
                 // Same for functions (static methods)
-                if (rt.functionList.stream().map(Method::getMethodSpecification).anyMatch(signature::equals)) {
+                if (rt.functionList.stream().map(Method::getTypeSignature).anyMatch(signature::equals)) {
                     if (rt.module().platform == Platform.WINDOWS) {
                         overrideLongValues(method);
                     }
                 }
                 // Same for constructors
-                if (rt.constructorList.stream().map(Method::getMethodSpecification).anyMatch(signature::equals)) {
+                if (rt.constructorList.stream().map(Method::getTypeSignature).anyMatch(signature::equals)) {
                     if (rt.module().platform == Platform.WINDOWS) {
                         overrideLongValues(method);
                     }

--- a/buildSrc/src/main/java/io/github/jwharm/javagi/generator/Patch.java
+++ b/buildSrc/src/main/java/io/github/jwharm/javagi/generator/Patch.java
@@ -190,6 +190,7 @@ public interface Patch extends Serializable {
         method.parameters = vm.parameters;
         method.returnValue = vm.returnValue;
         vm.parent.methodList.add(method);
+        vm.skip = true;
     }
 
     default void makeGeneric(Repository repo, String type) {
@@ -201,6 +202,7 @@ public interface Patch extends Serializable {
                     for (Parameter p : m.parameters.parameterList) {
                         if (p.type != null && "org.gnome.gobject.GObject".equals(p.type.qualifiedJavaType)) {
                             p.type.isGeneric = true;
+                            p.type.init(p.type.name);
                         }
                     }
                 }
@@ -208,6 +210,7 @@ public interface Patch extends Serializable {
                     Type returnType = m.returnValue.type;
                     if (returnType != null && "org.gnome.gobject.GObject".equals(returnType.qualifiedJavaType)) {
                         returnType.isGeneric = true;
+                        returnType.init(returnType.name);
                     }
                 }
             }

--- a/buildSrc/src/main/java/io/github/jwharm/javagi/model/CallableType.java
+++ b/buildSrc/src/main/java/io/github/jwharm/javagi/model/CallableType.java
@@ -26,6 +26,8 @@ import java.io.IOException;
 
 public interface CallableType {
 
+    GirElement getParent();
+
     Parameters getParameters();
     void setParameters(Parameters ps);
 

--- a/buildSrc/src/main/java/io/github/jwharm/javagi/model/Callback.java
+++ b/buildSrc/src/main/java/io/github/jwharm/javagi/model/Callback.java
@@ -53,6 +53,11 @@ public class Callback extends RegisteredType implements CallableType, Closure {
     }
 
     @Override
+    public GirElement getParent() {
+        return parent;
+    }
+
+    @Override
     public Parameters getParameters() {
         return parameters;
     }

--- a/buildSrc/src/main/java/io/github/jwharm/javagi/model/Class.java
+++ b/buildSrc/src/main/java/io/github/jwharm/javagi/model/Class.java
@@ -141,7 +141,7 @@ public class Class extends RegisteredType {
         writer.write(" * again. To chain up, call {@code asParent().methodName()}. This will call the native function\n");
         writer.write(" * pointer of this virtual method in the typeclass of the parent type.\n");
         writer.write(" */\n");
-        writer.write("public " + qualifiedName + " asParent() {\n");
+        writer.write("protected " + qualifiedName + " asParent() {\n");
         writer.increaseIndent();
         if ("1".equals(abstract_)) {
             writer.write(qualifiedName + " _parent = new " + qualifiedName + "." + javaName + "Impl(handle());\n");

--- a/buildSrc/src/main/java/io/github/jwharm/javagi/model/Closure.java
+++ b/buildSrc/src/main/java/io/github/jwharm/javagi/model/Closure.java
@@ -44,14 +44,18 @@ public interface Closure extends CallableType {
             writer.write(" */\n");
         }
         writer.write("@FunctionalInterface\n");
-        writer.write("public interface " + javaName + " {\n");
+        if (! (getParent() instanceof Interface)) {
+            writer.write("public ");
+        }
+        writer.write("interface " + javaName + " {\n");
         writer.write("\n");
         writer.increaseIndent();
 
         // Generate javadoc for run(...)
         Doc doc = getDoc();
-        if (doc != null)
+        if (doc != null) {
             doc.generate(writer, false);
+        }
 
         // Deprecation
         if ("1".equals(((GirElement) this).deprecated)) {

--- a/buildSrc/src/main/java/io/github/jwharm/javagi/model/Constructor.java
+++ b/buildSrc/src/main/java/io/github/jwharm/javagi/model/Constructor.java
@@ -28,6 +28,8 @@ public class Constructor extends Method {
 
     public Constructor(GirElement parent, String name, String cIdentifier, String deprecated, String throws_) {
         super(parent, name, cIdentifier, deprecated, throws_, null, null, null);
+        // constructor helper method has private visibility
+        visibility = "private";
     }
 
     public void generate(SourceWriter writer) throws IOException {

--- a/buildSrc/src/main/java/io/github/jwharm/javagi/model/Constructor.java
+++ b/buildSrc/src/main/java/io/github/jwharm/javagi/model/Constructor.java
@@ -33,6 +33,10 @@ public class Constructor extends Method {
     }
 
     public void generate(SourceWriter writer) throws IOException {
+        if (skip) {
+            return;
+        }
+
         String privateMethodName = "construct" + Conversions.toCamelCase(name, true);
         writer.write("\n");
 
@@ -85,6 +89,10 @@ public class Constructor extends Method {
     }
 
     public void generateNamed(SourceWriter writer) throws IOException {
+        if (skip) {
+            return;
+        }
+
         String privateMethodName = "construct" + Conversions.toCamelCase(name, true);
         RegisteredType constructed = (RegisteredType) parent;
 

--- a/buildSrc/src/main/java/io/github/jwharm/javagi/model/Function.java
+++ b/buildSrc/src/main/java/io/github/jwharm/javagi/model/Function.java
@@ -23,6 +23,6 @@ public class Function extends Method {
 
     public Function(GirElement parent, String name, String cIdentifier, String deprecated, String throws_, String movedTo) {
         super(parent, name, cIdentifier, deprecated, throws_, null, null, movedTo);
-        visibility = "public";
+        visibility = parent instanceof Interface ? "" : "public";
     }
 }

--- a/buildSrc/src/main/java/io/github/jwharm/javagi/model/Function.java
+++ b/buildSrc/src/main/java/io/github/jwharm/javagi/model/Function.java
@@ -23,5 +23,6 @@ public class Function extends Method {
 
     public Function(GirElement parent, String name, String cIdentifier, String deprecated, String throws_, String movedTo) {
         super(parent, name, cIdentifier, deprecated, throws_, null, null, movedTo);
+        visibility = "public";
     }
 }

--- a/buildSrc/src/main/java/io/github/jwharm/javagi/model/FunctionMacro.java
+++ b/buildSrc/src/main/java/io/github/jwharm/javagi/model/FunctionMacro.java
@@ -39,6 +39,11 @@ public class FunctionMacro extends GirElement implements CallableType {
     }
 
     @Override
+    public GirElement getParent() {
+        return parent;
+    }
+
+    @Override
     public Parameters getParameters() {
         return parameters;
     }

--- a/buildSrc/src/main/java/io/github/jwharm/javagi/model/Method.java
+++ b/buildSrc/src/main/java/io/github/jwharm/javagi/model/Method.java
@@ -78,7 +78,9 @@ public class Method extends GirElement implements CallableType {
         
         try {
             // Visibility
-            writer.write(visibility + " ");
+            if (! visibility.isEmpty()) {
+                writer.write(visibility + " ");
+            }
 
             // Static methods (functions and constructor helpers)
             if (this instanceof Function || this instanceof Constructor) {
@@ -306,6 +308,11 @@ public class Method extends GirElement implements CallableType {
             return false;
         var lastParam = parameters.parameterList.get(parameters.parameterList.size() - 1);
         return lastParam.type != null && "VaList".equals(lastParam.type.simpleJavaType);
+    }
+
+    @Override
+    public GirElement getParent() {
+        return parent;
     }
     
     @Override

--- a/buildSrc/src/main/java/io/github/jwharm/javagi/model/Module.java
+++ b/buildSrc/src/main/java/io/github/jwharm/javagi/model/Module.java
@@ -167,8 +167,7 @@ public class Module {
             for (RegisteredType rt : repository.namespace.registeredTypeMap.values()) {
                 for (Method method : rt.methodList) {
                     for (VirtualMethod vm : rt.virtualMethodList) {
-                        if (method.name.equals(vm.name)
-                                && method.getTypeSignature().equals(vm.getTypeSignature())) {
+                        if (method.getNameAndSignature().equals(vm.getNameAndSignature())) {
                             method.linkedVirtualMethod = vm;
                             vm.linkedMethod = method;
                             break;

--- a/buildSrc/src/main/java/io/github/jwharm/javagi/model/RegisteredType.java
+++ b/buildSrc/src/main/java/io/github/jwharm/javagi/model/RegisteredType.java
@@ -293,27 +293,20 @@ public abstract class RegisteredType extends GirElement {
     }
 
     protected void generateMethodsAndSignals(SourceWriter writer) throws IOException {
-        HashSet<String> generatedMethods = new HashSet<>();
-        
-        // First, generate all virtual methods
-        for (VirtualMethod vm : virtualMethodList) {
-            if (vm.hasVaListParameter()) { // va_list parameters are not supported
-                continue;
-            }
-            vm.generate(writer);
-            generatedMethods.add(vm.name + " " + vm.getMethodSpecification());
-        }
-
-        // Next, generate the non-virtual instance methods
+        // Generate instance methods
         for (Method m : methodList) {
-            if (m.hasVaListParameter()) {
-                continue;
-            }
-            if (generatedMethods.contains(m.name + " " + m.getMethodSpecification())) {
+            if (m.hasVaListParameter()) { // va_list parameters are not supported
                 continue;
             }
             m.generate(writer);
-            generatedMethods.add(m.name + " " + m.getMethodSpecification());
+        }
+
+        // Generate virtual methods
+        for (VirtualMethod vm : virtualMethodList) {
+            if (vm.hasVaListParameter()) {
+                continue;
+            }
+            vm.generate(writer);
         }
 
         // Generate all functions as static methods

--- a/buildSrc/src/main/java/io/github/jwharm/javagi/model/Signal.java
+++ b/buildSrc/src/main/java/io/github/jwharm/javagi/model/Signal.java
@@ -43,6 +43,10 @@ public class Signal extends Method implements Closure {
     }
 
     public void generate(SourceWriter writer) throws IOException {
+        if (skip) {
+            return;
+        }
+
         writer.write("\n");
         generateFunctionalInterface(writer, signalName);
         writer.write("\n");

--- a/buildSrc/src/main/java/io/github/jwharm/javagi/model/VirtualMethod.java
+++ b/buildSrc/src/main/java/io/github/jwharm/javagi/model/VirtualMethod.java
@@ -30,11 +30,11 @@ public class VirtualMethod extends Method {
 
     public VirtualMethod(GirElement parent, String name, String deprecated, String throws_) {
         super(parent, name, null, deprecated, throws_, null, null, null);
-        visibility = "protected";
+        visibility = parent instanceof Interface ? "default" : "protected";
     }
     
     public void generate(SourceWriter writer) throws IOException {
-        if (parent instanceof Interface || linkedMethod != null) {
+        if (skip) {
             return;
         }
 

--- a/buildSrc/src/main/java/io/github/jwharm/javagi/patches/GioPatch.java
+++ b/buildSrc/src/main/java/io/github/jwharm/javagi/patches/GioPatch.java
@@ -1,7 +1,12 @@
 package io.github.jwharm.javagi.patches;
 
 import io.github.jwharm.javagi.generator.Patch;
+import io.github.jwharm.javagi.model.Method;
+import io.github.jwharm.javagi.model.RegisteredType;
 import io.github.jwharm.javagi.model.Repository;
+import io.github.jwharm.javagi.model.VirtualMethod;
+
+import java.util.List;
 
 public class GioPatch implements Patch {
 
@@ -21,6 +26,14 @@ public class GioPatch implements Patch {
         // However, Java does not allow a (non-static) method to be implemented/overridden by a static method.
         // The current solution is to remove the method from the interface. It is still available in the implementing classes.
         removeMethod(repo, "AsyncInitable", "new_finish");
+
+        // Add virtual methods as instance methods
+        for (String type : List.of("FileInputStream", "FileOutputStream", "FileIOStream")) {
+            addInstanceMethod(repo, type, "tell");
+            addInstanceMethod(repo, type, "seek");
+            addInstanceMethod(repo, type, "can_truncate");
+            addInstanceMethod(repo, type, "can_seek");
+        }
 
         // Let these classes implement the AutoCloseable interface, so they can be used in try-with-resources blocks.
         makeAutoCloseable(repo, "IOStream");

--- a/buildSrc/src/main/java/io/github/jwharm/javagi/patches/GstBasePatch.java
+++ b/buildSrc/src/main/java/io/github/jwharm/javagi/patches/GstBasePatch.java
@@ -1,0 +1,14 @@
+package io.github.jwharm.javagi.patches;
+
+import io.github.jwharm.javagi.generator.Patch;
+import io.github.jwharm.javagi.model.Repository;
+
+public class GstBasePatch implements Patch {
+
+    @Override
+    public void patch(Repository repo) {
+        // Add virtual methods as instance methods
+        addInstanceMethod(repo, "BaseSink", "query");
+        addInstanceMethod(repo, "BaseSrc", "query");
+    }
+}

--- a/buildSrc/src/main/java/io/github/jwharm/javagi/patches/GstBasePatch.java
+++ b/buildSrc/src/main/java/io/github/jwharm/javagi/patches/GstBasePatch.java
@@ -10,5 +10,12 @@ public class GstBasePatch implements Patch {
         // Add virtual methods as instance methods
         addInstanceMethod(repo, "BaseSink", "query");
         addInstanceMethod(repo, "BaseSrc", "query");
+
+        // Change virtual method parameter name to the instance method parameter name
+        findVirtualMethod(repo, "Aggregator", "peek_next_sample")
+                .parameters
+                .parameterList
+                .get(1)
+                .name = "pad";
     }
 }

--- a/buildSrc/src/main/java/io/github/jwharm/javagi/patches/GstVideoPatch.java
+++ b/buildSrc/src/main/java/io/github/jwharm/javagi/patches/GstVideoPatch.java
@@ -1,0 +1,12 @@
+package io.github.jwharm.javagi.patches;
+
+import io.github.jwharm.javagi.generator.Patch;
+import io.github.jwharm.javagi.model.Repository;
+
+public class GstVideoPatch implements Patch {
+
+    @Override
+    public void patch(Repository repo) {
+        setReturnType(repo, "VideoOverlay", "set_render_rectangle", "none", "void", null, null);
+    }
+}

--- a/buildSrc/src/main/java/io/github/jwharm/javagi/patches/GtkPatch.java
+++ b/buildSrc/src/main/java/io/github/jwharm/javagi/patches/GtkPatch.java
@@ -24,10 +24,11 @@ public class GtkPatch implements Patch {
         setReturnFloating(findMethod(repo, "PaperSize", "to_gvariant"));
         setReturnFloating(findMethod(repo, "PrintSettings", "to_gvariant"));
 
+        findVirtualMethod(repo, "BuilderScope", "get_type_from_name").skip = false;
+        findVirtualMethod(repo, "BuilderScope", "get_type_from_function").skip = false;
+        findVirtualMethod(repo, "BuilderScope", "create_closure").skip = false;
+
         // Add virtual methods as instance methods
-        addInstanceMethod(repo, "BuilderScope", "get_type_from_name");
-        addInstanceMethod(repo, "BuilderScope", "get_type_from_function");
-        addInstanceMethod(repo, "BuilderScope", "create_closure");
         addInstanceMethod(repo, "Window", "activate_default");
         addInstanceMethod(repo, "Dialog", "close");
         addInstanceMethod(repo, "Popover", "activate_default");

--- a/buildSrc/src/main/java/io/github/jwharm/javagi/patches/GtkPatch.java
+++ b/buildSrc/src/main/java/io/github/jwharm/javagi/patches/GtkPatch.java
@@ -21,5 +21,13 @@ public class GtkPatch implements Patch {
         setReturnFloating(findMethod(repo, "PageSetup", "to_gvariant"));
         setReturnFloating(findMethod(repo, "PaperSize", "to_gvariant"));
         setReturnFloating(findMethod(repo, "PrintSettings", "to_gvariant"));
+
+        // Add virtual methods as instance methods
+        addInstanceMethod(repo, "BuilderScope", "get_type_from_name");
+        addInstanceMethod(repo, "BuilderScope", "get_type_from_function");
+        addInstanceMethod(repo, "BuilderScope", "create_closure");
+        addInstanceMethod(repo, "Window", "activate_default");
+        addInstanceMethod(repo, "Dialog", "close");
+        addInstanceMethod(repo, "Popover", "activate_default");
     }
 }

--- a/buildSrc/src/main/java/io/github/jwharm/javagi/patches/GtkPatch.java
+++ b/buildSrc/src/main/java/io/github/jwharm/javagi/patches/GtkPatch.java
@@ -16,6 +16,8 @@ public class GtkPatch implements Patch {
             renameMethod(repo, "PrintUnixDialog", "get_settings", "get_print_settings");
         renameMethod(repo, "Widget", "activate", "activate_widget");
 
+        setReturnType(repo, "MediaStream", "play", "none", "void", null, null);
+
         // These calls return floating references
         setReturnFloating(findMethod(repo, "FileFilter", "to_gvariant"));
         setReturnFloating(findMethod(repo, "PageSetup", "to_gvariant"));

--- a/buildSrc/src/main/java/io/github/jwharm/javagi/patches/PangoPatch.java
+++ b/buildSrc/src/main/java/io/github/jwharm/javagi/patches/PangoPatch.java
@@ -9,6 +9,8 @@ public class PangoPatch implements Patch {
     public void patch(Repository repo) {
         // Return type defined as "Language" but should be "Language*"
         removeMethod(repo, "Font", "get_languages");
-    }
 
+        // Deprecated method, causes java-gi compile warnings
+        removeMethod(repo, "Coverage", "ref");
+    }
 }

--- a/buildSrc/src/main/java/io/github/jwharm/javagi/patches/SoupPatch.java
+++ b/buildSrc/src/main/java/io/github/jwharm/javagi/patches/SoupPatch.java
@@ -1,0 +1,12 @@
+package io.github.jwharm.javagi.patches;
+
+import io.github.jwharm.javagi.generator.Patch;
+import io.github.jwharm.javagi.model.Repository;
+
+public class SoupPatch implements Patch {
+
+    @Override
+    public void patch(Repository repo) {
+        setReturnType(repo, "AuthDomain", "challenge", "none", "void", null, null);
+    }
+}

--- a/modules/gdk/build.gradle
+++ b/modules/gdk/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     api project(':gio')
     api project(':pango')
     api project(':pangocairo')
-    api 'io.github.jwharm.cairobindings:cairo:1.18.0'
+    api 'io.github.jwharm.cairobindings:cairo:1.18.1'
 }
 
 tasks.named('generateSources') {

--- a/modules/gstbase/build.gradle
+++ b/modules/gstbase/build.gradle
@@ -1,3 +1,5 @@
+import io.github.jwharm.javagi.patches.GstBasePatch;
+
 plugins {
     id 'java-gi.library-conventions'
 }
@@ -11,4 +13,5 @@ dependencies {
 
 tasks.named('generateSources') {
     girFile = 'GstBase-1.0.gir'
+    patch = new GstBasePatch()
 }

--- a/modules/gstvideo/build.gradle
+++ b/modules/gstvideo/build.gradle
@@ -1,3 +1,5 @@
+import io.github.jwharm.javagi.patches.GstVideoPatch;
+
 plugins {
     id 'java-gi.library-conventions'
 }
@@ -9,4 +11,5 @@ dependencies {
 
 tasks.named('generateSources') {
     girFile = 'GstVideo-1.0.gir'
+    patch = new GstVideoPatch()
 }

--- a/modules/gtk/src/main/java/io/github/jwharm/javagi/gtk/util/BuilderJavaScope.java
+++ b/modules/gtk/src/main/java/io/github/jwharm/javagi/gtk/util/BuilderJavaScope.java
@@ -73,8 +73,8 @@ public final class BuilderJavaScope extends GObject implements BuilderScope {
     /**
      * Instantiates a new {@link BuilderScope}
      */
-    public BuilderJavaScope() {
-        super(gtype, null);
+    public static BuilderJavaScope newInstance() {
+        return GObject.newInstance(gtype);
     }
 
     /**

--- a/modules/gtk/src/main/java/io/github/jwharm/javagi/gtk/util/BuilderJavaScope.java
+++ b/modules/gtk/src/main/java/io/github/jwharm/javagi/gtk/util/BuilderJavaScope.java
@@ -46,7 +46,7 @@ import static io.github.jwharm.javagi.Constants.LOG_DOMAIN;
  * the Java instance method {@code okButtonClicked()} will be called on
  * the widget that is being built with the {@link GtkBuilder}.
  */
-public final class BuilderJavaScope extends GObject implements BuilderScope {
+public final class BuilderJavaScope extends BuilderCScope implements BuilderScope {
 
     private static final Type gtype = Types.register(BuilderJavaScope.class);
 
@@ -97,7 +97,7 @@ public final class BuilderJavaScope extends GObject implements BuilderScope {
         if (currentObject == null) {
             GLib.log(LOG_DOMAIN, LogLevelFlags.LEVEL_CRITICAL,
                     "Cannot create closure for handler %s: Current object not set\n", functionName);
-            return new BuilderCScope().createClosure(builder, functionName, flags, object);
+            return asParent().createClosure(builder, functionName, flags, object);
         }
 
         try {
@@ -132,7 +132,7 @@ public final class BuilderJavaScope extends GObject implements BuilderScope {
             GLib.log(LOG_DOMAIN, LogLevelFlags.LEVEL_CRITICAL,
                     "Cannot find method %s in class %s\n",
                     functionName, currentObject.getClass().getName());
-            return new BuilderCScope().createClosure(builder, functionName, flags, object);
+            return asParent().createClosure(builder, functionName, flags, object);
         }
     }
 
@@ -165,7 +165,7 @@ public final class BuilderJavaScope extends GObject implements BuilderScope {
      */
     @Override
     public Type getTypeFromFunction(GtkBuilder builder, String functionName) {
-        return new BuilderCScope().getTypeFromFunction(builder, functionName);
+        return asParent().getTypeFromFunction(builder, functionName);
     }
 
     /**
@@ -176,6 +176,6 @@ public final class BuilderJavaScope extends GObject implements BuilderScope {
      */
     @Override
     public Type getTypeFromName(GtkBuilder builder, String typeName) {
-        return new BuilderCScope().getTypeFromName(builder, typeName);
+        return asParent().getTypeFromName(builder, typeName);
     }
 }

--- a/modules/harfbuzz/build.gradle
+++ b/modules/harfbuzz/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 dependencies {
     api project(':gobject')
-    api 'io.github.jwharm.cairobindings:cairo:1.18.0'
+    api 'io.github.jwharm.cairobindings:cairo:1.18.1'
 }
 
 tasks.named('generateSources') {

--- a/modules/pango/build.gradle
+++ b/modules/pango/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     api project(':gobject')
     api project(':gio')
     api project(':harfbuzz')
-    api 'io.github.jwharm.cairobindings:cairo:1.18.0'
+    api 'io.github.jwharm.cairobindings:cairo:1.18.1'
 }
 
 tasks.named('generateSources') {

--- a/modules/pangocairo/build.gradle
+++ b/modules/pangocairo/build.gradle
@@ -5,7 +5,7 @@ plugins {
 dependencies {
     api project(':gobject')
     api project(':pango')
-    api 'io.github.jwharm.cairobindings:cairo:1.18.0'
+    api 'io.github.jwharm.cairobindings:cairo:1.18.1'
 }
 
 tasks.named('generateSources') {

--- a/modules/soup/build.gradle
+++ b/modules/soup/build.gradle
@@ -1,3 +1,5 @@
+import io.github.jwharm.javagi.patches.SoupPatch;
+
 plugins {
     id 'java-gi.library-conventions'
 }
@@ -9,4 +11,5 @@ dependencies {
 tasks.named('generateSources') {
     girFile = 'Soup-3.0.gir'
     urlPrefix = 'https://libsoup.org/libsoup-3.0/'
+    patch = new SoupPatch()
 }


### PR DESCRIPTION
Until now, Java-GI generated `public` Java methods for GObject virtual methods. The Java method would lookup the function pointer in the typeclass and invoke it. When also a regular method existed, it would be hidden from the Java API in favor of the virtual method.

This is not correct, because GObject virtual methods are not supposed to be treated as the API. The regular methods should be the `public` methods in the Java classes, and the virtual methods should only be available for "chaining up" from an overridden method in a derived class. In other words, virtual methods are supposed to have `protected` visibility in the Java API.

When generating a Java class, the Java-GI bindings generator look for matching pairs of regular methods and virtual methods, with the same name and type signature:
- When only a regular method is found, the Java API will contain a method with `public` visibility. The method invokes the regular C method. 
- When only a virtual method is found, the Java API will contain a method with `protected` visibility. When called, the function pointer of the parent typeclass is invoked.
- When a matching pair (a regular method and a virtual method with the same name and type signature) is found, the Java API will contain one method with `public` visibility. Under normal circumstances, the method invokes the regular C method. When chaining up (with `asParent()`), the function pointer of the parent typeclass is invoked. The `asParent()` method itself has `protected` visibility so this is only exposed to derived types.

Virtual methods in an interface are not exposed in the Java bindings, because Java interfaces cannot contain `protected` methods.

As a result, a virtual method will never be exposed directly as part of the API. It is, however, available for chaining up, from a method override in a derived class.
