### PR TITLE
Return type overrides

### DIFF
--- a/buildSrc/src/main/groovy/java-gi.library-conventions.gradle
+++ b/buildSrc/src/main/groovy/java-gi.library-conventions.gradle
@@ -31,7 +31,7 @@ dependencies {
 }
 
 group = 'io.github.jwharm.javagi'
-version = '0.8.0'
+version = '0.8.1-SNAPSHOT'
 
 java {
     if (! System.getenv('CI')) {

--- a/buildSrc/src/main/java/io/github/jwharm/javagi/generator/Patch.java
+++ b/buildSrc/src/main/java/io/github/jwharm/javagi/generator/Patch.java
@@ -70,17 +70,12 @@ public interface Patch extends Serializable {
             System.out.println("Did not remove " + type + ": Not found");
     }
 
-    default void setReturnType(Repository repo, String type, String name, String typeName, String typeCType, String defaultReturnValue, String doc) {
-        setReturnType(findVirtualMethod(repo, type, name), typeName, typeCType, defaultReturnValue, doc);
-        setReturnType(findMethod(repo, type, name), typeName, typeCType, defaultReturnValue, doc);
-    }
-
-    private void setReturnType(Method m, String typeName, String typeCType, String defaultReturnValue, String doc) {
+    default void setReturnType(Method m, String typeName, String typeCType, String defaultReturnValue, String doc) {
         if (m == null) {
             return;
         }
         ReturnValue rv = m.returnValue;
-        rv.type = new Type(rv, typeName, typeCType);
+        rv.overrideReturnType = new Type(rv, typeName, typeCType);
         rv.overrideReturnValue = defaultReturnValue;
         if (doc != null) {
             rv.doc = new Doc(rv, "1");

--- a/buildSrc/src/main/java/io/github/jwharm/javagi/model/GirElement.java
+++ b/buildSrc/src/main/java/io/github/jwharm/javagi/model/GirElement.java
@@ -74,6 +74,10 @@ public abstract class GirElement {
         previouslyCreated = this;
     }
 
+    public Type getType() {
+        return this.type;
+    }
+
     public Namespace getNamespace() {
         if (this instanceof Repository r) {
             return r.namespace;

--- a/buildSrc/src/main/java/io/github/jwharm/javagi/model/Variable.java
+++ b/buildSrc/src/main/java/io/github/jwharm/javagi/model/Variable.java
@@ -80,6 +80,7 @@ public class Variable extends GirElement {
     }
 
     private String getType(boolean writeAnnotations) {
+        Type type = getType();
 
         if (type != null && type.isActuallyAnArray())
             return getAnnotations(type, writeAnnotations) + getType(type) + "[]";
@@ -205,6 +206,8 @@ public class Variable extends GirElement {
     }
 
     private String marshalNativeToJava(String identifier, boolean upcall) {
+        Type type = getType();
+
         if (type != null && type.cType != null && type.cType.equals("gfloat**"))
             return "null /* unsupported */";
 

--- a/buildSrc/src/main/java/io/github/jwharm/javagi/patches/GioPatch.java
+++ b/buildSrc/src/main/java/io/github/jwharm/javagi/patches/GioPatch.java
@@ -16,8 +16,6 @@ public class GioPatch implements Patch {
         renameMethod(repo, "BufferedInputStream", "read_byte", "read_int");
         renameMethod(repo, "IOModule", "load", "load_module");
 
-        setReturnType(repo, "ActionGroup", "activate_action", "gboolean", "gboolean", "true", "always %TRUE");
-
         // Override of static method
         removeVirtualMethod(repo, "SocketControlMessage", "get_type");
 

--- a/buildSrc/src/main/java/io/github/jwharm/javagi/patches/GstAudioPatch.java
+++ b/buildSrc/src/main/java/io/github/jwharm/javagi/patches/GstAudioPatch.java
@@ -9,8 +9,8 @@ public class GstAudioPatch implements Patch {
 
     @Override
     public void patch(Repository repo) {
-        // Override with different return type
-        setReturnType(repo, "AudioSink", "stop", "gboolean", "gboolean", "true", "always %TRUE");
+        // Override with different return type (BaseSink.stop() returns boolean)
+        setReturnType(findVirtualMethod(repo, "AudioSink", "stop"), "gboolean", "gboolean", "1", "always %TRUE");
         // A GstFraction cannot automatically be put into a GValue
         removeProperty(repo, "AudioAggregator", "output-buffer-duration-fraction");
 

--- a/buildSrc/src/main/java/io/github/jwharm/javagi/patches/GstVideoPatch.java
+++ b/buildSrc/src/main/java/io/github/jwharm/javagi/patches/GstVideoPatch.java
@@ -7,6 +7,6 @@ public class GstVideoPatch implements Patch {
 
     @Override
     public void patch(Repository repo) {
-        setReturnType(repo, "VideoOverlay", "set_render_rectangle", "none", "void", null, null);
+        setReturnType(findVirtualMethod(repo, "VideoOverlay", "set_render_rectangle"), "gboolean", "gboolean", "1", null);
     }
 }

--- a/buildSrc/src/main/java/io/github/jwharm/javagi/patches/GtkPatch.java
+++ b/buildSrc/src/main/java/io/github/jwharm/javagi/patches/GtkPatch.java
@@ -15,8 +15,9 @@ public class GtkPatch implements Patch {
         if (repo.module.platform != Platform.WINDOWS)
             renameMethod(repo, "PrintUnixDialog", "get_settings", "get_print_settings");
         renameMethod(repo, "Widget", "activate", "activate_widget");
+        renameMethod(repo, "Widget", "activate_action", "activate_action_if_exists");
 
-        setReturnType(repo, "MediaStream", "play", "none", "void", null, null);
+        setReturnType(findMethod(repo, "MediaStream", "play"), "gboolean", "gboolean", "1", null);
 
         // These calls return floating references
         setReturnFloating(findMethod(repo, "FileFilter", "to_gvariant"));

--- a/buildSrc/src/main/java/io/github/jwharm/javagi/patches/SoupPatch.java
+++ b/buildSrc/src/main/java/io/github/jwharm/javagi/patches/SoupPatch.java
@@ -7,6 +7,6 @@ public class SoupPatch implements Patch {
 
     @Override
     public void patch(Repository repo) {
-        setReturnType(repo, "AuthDomain", "challenge", "none", "void", null, null);
+        setReturnType(findMethod(repo, "AuthDomain", "challenge"), "utf8", "char*", "null", "Always {@code null}");
     }
 }


### PR DESCRIPTION
In a few situations, we need to override the return type of a method:
- When a method in a subclass overrides a method in a superclass, with a different return type
- When an instance method and virtual method in the same class and the same name have differnt return types.

In previous Java-GI versions, the return type would be updated with a patch, but that would also impact the actual call to the native function. That can lead to segfaults. So with this PR, the return type of the Java bindings is changed, but the native function invocation still uses the type signature as declared in the GIR file.

The following return types are changed:
- `void GtkMediaStream.play()` returns void, but a virtual method with the same name returns `gboolean`. The instance method now also returns `gboolean` (always `true`).
- `void GstAudioSink.stop()` overrides `gboolean GstBaseSink.stop()`, so it now returns `gboolean` (always `true`).
- `void GstVideoOverlay.setRenderRectangle()` returns void, but a virtual method with the same name returns `gboolean`. The instance method now also returns `gboolean` (always `true`).
- `void SoupAuthDomain.challenge()` returns void, but a virtual method with the same name returns `char*`. The instance method now also returns `char*` (always `null`).
