### PR TITLE
Value type constructors

### DIFF
--- a/buildSrc/src/main/groovy/java-gi.library-conventions.gradle
+++ b/buildSrc/src/main/groovy/java-gi.library-conventions.gradle
@@ -32,7 +32,7 @@ dependencies {
 }
 
 group = 'io.github.jwharm.javagi'
-version = '0.9.0'
+version = '0.9.1-SNAPSHOT'
 
 java {
     if (! System.getenv('CI')) {

--- a/buildSrc/src/main/java/io/github/jwharm/javagi/generators/RecordGenerator.java
+++ b/buildSrc/src/main/java/io/github/jwharm/javagi/generators/RecordGenerator.java
@@ -22,6 +22,7 @@ package io.github.jwharm.javagi.generators;
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import com.squareup.javapoet.*;
 import io.github.jwharm.javagi.configuration.ClassNames;
@@ -105,10 +106,13 @@ public class RecordGenerator extends RegisteredTypeGenerator {
         MethodSpec memoryLayout = new MemoryLayoutGenerator().generateMemoryLayout(rec);
         if (memoryLayout != null) {
             builder.addMethod(memoryLayout);
+            builder.addMethod(constructor());
             builder.addMethod(allocate());
 
-            if (outerClass == null && hasFieldSetters())
+            if (outerClass == null && hasFieldSetters()) {
+                builder.addMethod(constructorWithParameters());
                 builder.addMethod(allocateWithParameters());
+            }
 
             for (Field f : rec.fields())
                 generateField(f);
@@ -199,14 +203,68 @@ public class RecordGenerator extends RegisteredTypeGenerator {
         }
     }
 
+    private MethodSpec constructor() {
+        return MethodSpec.constructorBuilder()
+                .addJavadoc("""
+                        Allocate a new $1T.
+                        
+                        @param arena to control the memory allocation scope
+                        """, rec.typeName())
+                .addModifiers(Modifier.PUBLIC)
+                .addParameter(Arena.class, "arena")
+                .addStatement("super(arena.allocate(getMemoryLayout()))")
+                .build();
+    }
+
+    private MethodSpec constructorWithParameters() {
+        var spec = MethodSpec.constructorBuilder()
+                .addJavadoc("""
+                        Allocate a new $T with the fields set to the provided values.
+                        
+                        @param arena to control the memory allocation scope
+                        """, rec.typeName());
+
+        // Javadoc for parameters and return value
+        rec.fields().stream().filter(not(Field::isDisguised)).forEach(f ->
+                spec.addJavadoc("@param $1L $2L for the field {@code $1L}\n",
+                        toJavaIdentifier(f.name()),
+                        f.callback() == null ? "value" : "callback function")
+        );
+
+        // Set visibility, return type, and parameters
+        spec.addModifiers(Modifier.PUBLIC)
+                .addParameter(Arena.class, "arena");
+        rec.fields().stream().filter(not(Field::isDisguised)).forEach(f ->
+                spec.addParameter(
+                        new TypedValueGenerator(f).getType(),
+                        toJavaIdentifier(f.name()))
+        );
+
+        // Allocate the new instance
+        spec.addStatement("this(arena)");
+
+        // Copy the parameter values into the instance fields
+        rec.fields().stream().filter(not(Field::isDisguised)).forEach(f ->
+                spec.addStatement("$L$L($L$L)",
+                        f.callback() == null ? "write" : "override",
+                        toCamelCase(f.name(), true),
+                        f.allocatesMemory() ? "arena, " : "",
+                        toJavaIdentifier(f.name()))
+        );
+
+        return spec.build();
+    }
+
     private MethodSpec allocate() {
         return MethodSpec.methodBuilder("allocate")
                 .addJavadoc("""
                         Allocate a new $1T.
-                                                
+                        
                         @param  arena to control the memory allocation scope
                         @return a new, uninitialized {@link $1T}
+                        @deprecated Replaced by {@link $1T#$1T()}
                         """, rec.typeName())
+                .addAnnotation(Deprecated.class)
                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
                 .returns(rec.typeName())
                 .addParameter(Arena.class, "arena")
@@ -225,7 +283,7 @@ public class RecordGenerator extends RegisteredTypeGenerator {
         var spec = MethodSpec.methodBuilder("allocate")
                 .addJavadoc("""
                         Allocate a new $T with the fields set to the provided values.
-                                                        
+                        
                         @param  arena to control the memory allocation scope
                         """, rec.typeName());
 
@@ -237,6 +295,14 @@ public class RecordGenerator extends RegisteredTypeGenerator {
         );
         spec.addJavadoc("@return a new {@link $T} with the fields set to the provided values\n",
                         rec.typeName());
+
+        String paramTypes = rec.fields().stream()
+                .filter(not(Field::isDisguised))
+                .map(f -> ", " + new TypedValueGenerator(f).getType().toString())
+                .collect(Collectors.joining());
+        spec.addJavadoc("@deprecated Replaced by {@link $1T#$1T($2T$3L)}\n",
+                        rec.typeName(), Arena.class, paramTypes)
+                        .addAnnotation(Deprecated.class);
 
         // Set visibility, return type, and parameters
         spec.addModifiers(Modifier.PUBLIC, Modifier.STATIC)

--- a/buildSrc/src/main/java/io/github/jwharm/javagi/generators/RecordGenerator.java
+++ b/buildSrc/src/main/java/io/github/jwharm/javagi/generators/RecordGenerator.java
@@ -262,8 +262,8 @@ public class RecordGenerator extends RegisteredTypeGenerator {
                         
                         @param  arena to control the memory allocation scope
                         @return a new, uninitialized {@link $1T}
-                        @deprecated Replaced by {@link $1T#$1T()}
-                        """, rec.typeName())
+                        @deprecated Replaced by {@link $1T#$1T($2T)}
+                        """, rec.typeName(), Arena.class)
                 .addAnnotation(Deprecated.class)
                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
                 .returns(rec.typeName())

--- a/modules/gobject/src/main/java/io/github/jwharm/javagi/gobject/types/Properties.java
+++ b/modules/gobject/src/main/java/io/github/jwharm/javagi/gobject/types/Properties.java
@@ -72,7 +72,7 @@ public class Properties {
         GObject.ObjectClass gclass = (GObject.ObjectClass) gobject.readGClass();
         Type valueType = readPropertyValueType(gclass, propertyName);
         try (var arena = Arena.ofConfined()) {
-            var gvalue = Value.allocate(arena).init(valueType);
+            var gvalue = new Value(arena).init(valueType);
             ValueUtil.objectToValue(propertyValue, gvalue);
             gobject.setProperty(propertyName, gvalue);
             gvalue.unset();
@@ -92,7 +92,7 @@ public class Properties {
         GObject.ObjectClass gclass = (GObject.ObjectClass) gobject.readGClass();
         Type valueType = readPropertyValueType(gclass, propertyName);
         try (var arena = Arena.ofConfined()) {
-            var gvalue = Value.allocate(arena).init(valueType);
+            var gvalue = new Value(arena).init(valueType);
             gobject.getProperty(propertyName, gvalue);
             Object result = ValueUtil.valueToObject(gvalue);
             gvalue.unset();
@@ -150,7 +150,7 @@ public class Properties {
                 Type valueType = readPropertyValueType(objectClass, name);
 
                 // Create a GValue and write the object to it
-                Value gvalue = Value.allocate(arena).init(valueType);
+                Value gvalue = new Value(arena).init(valueType);
                 ValueUtil.objectToValue(object, gvalue);
                 values.add(gvalue);
             }

--- a/modules/gobject/src/main/java/io/github/jwharm/javagi/gobject/types/Signals.java
+++ b/modules/gobject/src/main/java/io/github/jwharm/javagi/gobject/types/Signals.java
@@ -257,7 +257,7 @@ public class Signals {
 
         try (var arena = Arena.ofConfined()) {
             // Query the parameter details of the signal
-            SignalQuery query = SignalQuery.allocate(arena);
+            SignalQuery query = new SignalQuery(arena);
             GObjects.signalQuery(signalId.get(), query);
 
             // Create an array of Types for the parameters
@@ -269,18 +269,18 @@ public class Signals {
             var values = new Value[nParams+1];
 
             // Allocation return value
-            var returnValue = Value.allocate(arena);
+            var returnValue = new Value(arena);
             Type returnType = query.readReturnType();
             if (! Types.NONE.equals(returnType))
                 returnValue.init(returnType);
 
             // Set instance parameter
-            values[0] = Value.allocate(arena).init(gtype);
+            values[0] = new Value(arena).init(gtype);
             values[0].setObject(gobject);
 
             // Set other parameters
             for (int i = 0; i < nParams; i++) {
-                values[i+1] = Value.allocate(arena).init(paramTypes[i]);
+                values[i+1] = new Value(arena).init(paramTypes[i]);
                 ValueUtil.objectToValue(params[i], values[i+1]);
             }
 

--- a/modules/gobject/src/main/java/io/github/jwharm/javagi/gobject/types/Types.java
+++ b/modules/gobject/src/main/java/io/github/jwharm/javagi/gobject/types/Types.java
@@ -1094,7 +1094,7 @@ public class Types {
                             continue;
                         }
 
-                        InterfaceInfo interfaceInfo = InterfaceInfo.allocate(arena);
+                        InterfaceInfo interfaceInfo = new InterfaceInfo(arena);
                         Consumer<TypeInterface> ifaceOverridesInit = Overrides.overrideInterfaceMethods(cls, iface);
                         Consumer<TypeInterface> ifaceInit = getInterfaceInit(cls, iface);
 

--- a/modules/gobject/src/test/java/io/github/jwharm/javagi/test/gobject/DerivedClassTest.java
+++ b/modules/gobject/src/test/java/io/github/jwharm/javagi/test/gobject/DerivedClassTest.java
@@ -77,8 +77,8 @@ public class DerivedClassTest {
     @Test
     public void writeAndReadProperty() {
         // With manually created GValues
-        Value input = Value.allocate(Arena.ofAuto()).init(Types.STRING);
-        Value output = Value.allocate(Arena.ofAuto()).init(Types.STRING);
+        Value input = new Value(Arena.ofAuto()).init(Types.STRING);
+        Value output = new Value(Arena.ofAuto()).init(Types.STRING);
         input.setString("test value");
 
         TestObject object = GObject.newInstance(TestObject.gtype);
@@ -98,8 +98,8 @@ public class DerivedClassTest {
     @Test
     public void writeAndReadBooleanProperty() {
         // With manually created GValues
-        Value input = Value.allocate(Arena.ofAuto()).init(Types.BOOLEAN);
-        Value output = Value.allocate(Arena.ofAuto()).init(Types.BOOLEAN);
+        Value input = new Value(Arena.ofAuto()).init(Types.BOOLEAN);
+        Value output = new Value(Arena.ofAuto()).init(Types.BOOLEAN);
         input.setBoolean(true);
         TestObject object = GObject.newInstance(TestObject.gtype);
         object.setProperty("bool-property", input);

--- a/modules/gobject/src/test/java/io/github/jwharm/javagi/test/gobject/ValueToStringTest.java
+++ b/modules/gobject/src/test/java/io/github/jwharm/javagi/test/gobject/ValueToStringTest.java
@@ -20,15 +20,15 @@ public class ValueToStringTest {
 
     @Test
     public void testValueToString() {
-        Value vInt = Value.allocate(Arena.ofAuto()).init(Types.INT);
+        Value vInt = new Value(Arena.ofAuto()).init(Types.INT);
         vInt.setInt(123);
         assertEquals("123", vInt.toString());
 
-        Value vBool = Value.allocate(Arena.ofAuto()).init(Types.BOOLEAN);
+        Value vBool = new Value(Arena.ofAuto()).init(Types.BOOLEAN);
         vBool.setBoolean(true);
         assertEquals("TRUE", vBool.toString());
 
-        Value vStr = Value.allocate(Arena.ofAuto()).init(Types.STRING);
+        Value vStr = new Value(Arena.ofAuto()).init(Types.STRING);
         vStr.setString("abc");
         assertEquals("\"abc\"", vStr.toString());
     }


### PR DESCRIPTION
Generate constructors to replace the `allocate()` factory methods on records (structs). The old methods are still available (but deprecated).

This adds a constructor for union types as well.
