### PR TITLE
Add support for doc-stability gir element

### DIFF
--- a/generator/src/main/java/io/github/jwharm/javagi/gir/DocStability.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/gir/DocStability.java
@@ -19,10 +19,27 @@
 
 package io.github.jwharm.javagi.gir;
 
-public sealed interface Documentation
-        extends Node
-        permits Doc, DocDeprecated, DocVersion, DocStability {
+public final class DocStability extends GirElement implements Documentation {
 
-    String text();
-    Namespace namespace();
+    private final String text;
+
+    public DocStability(String text) {
+        this.text = text;
+    }
+
+    public String text() {
+        return text;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this)
+            return true;
+        return obj != null && obj.getClass() == this.getClass();
+    }
+
+    @Override
+    public int hashCode() {
+        return 1;
+    }
 }

--- a/generator/src/main/java/io/github/jwharm/javagi/gir/GirElement.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/gir/GirElement.java
@@ -97,8 +97,8 @@ public abstract class GirElement implements Serializable, Node {
 
     public InfoElements infoElements() {
         return new InfoElements(
-                attr("doc-version"),
-                attr("doc-stability"),
+                findAny(children, DocVersion.class),
+                findAny(children, DocStability.class),
                 findAny(children, Doc.class),
                 findAny(children, DocDeprecated.class),
                 findAny(children, SourcePosition.class),

--- a/generator/src/main/java/io/github/jwharm/javagi/gir/GirParser.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/gir/GirParser.java
@@ -234,6 +234,7 @@ public final class GirParser {
             case "doc"                -> new Doc(attributes, contents.toString().trim());
             case "docsection"         -> new Docsection(attributes, children);
             case "doc-deprecated"     -> new DocDeprecated(contents.toString().trim());
+            case "doc-stability"      -> new DocStability(contents.toString().trim());
             case "doc-version"        -> new DocVersion(contents.toString().trim());
             case "enumeration"        -> new Enumeration(attributes, children, platform);
             case "field"              -> new Field(attributes, children);

--- a/generator/src/main/java/io/github/jwharm/javagi/gir/InfoElements.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/gir/InfoElements.java
@@ -23,8 +23,8 @@ import java.io.Serializable;
 import java.util.List;
 
 public record InfoElements(
-        String docVersion,
-        String docStability,
+        DocVersion docVersion,
+        DocStability docStability,
         Doc doc,
         DocDeprecated docDeprecated,
         SourcePosition sourcePosition,


### PR DESCRIPTION
Apparently the Gir `<doc-stability>` element was not supported yet. It is added with this PR.