### PR TITLE
Fixed bugs in the MemoryCleaner class

### DIFF
--- a/modules/glib/src/test/java/io/github/jwharm/javagi/interop/ArrayTest.java
+++ b/modules/glib/src/test/java/io/github/jwharm/javagi/interop/ArrayTest.java
@@ -1,6 +1,5 @@
-package io.github.jwharm.javagi.test.glib;
+package io.github.jwharm.javagi.interop;
 
-import io.github.jwharm.javagi.interop.Interop;
 import org.gnome.glib.GLib;
 import org.gnome.glib.HashTable;
 import org.junit.jupiter.api.Test;

--- a/modules/glib/src/test/java/io/github/jwharm/javagi/interop/ArrayTest.java
+++ b/modules/glib/src/test/java/io/github/jwharm/javagi/interop/ArrayTest.java
@@ -16,7 +16,7 @@ public class ArrayTest {
     @Test
     void testArray() {
         try (var arena = Arena.ofConfined()) {
-            HashTable table = HashTable.new_(GLib::strHash, GLib::strEqual);
+            var table = HashTable.new_(GLib::strHash, GLib::strEqual);
             for (int i = 0; i < 3; i++)
                 table.insert(
                         Interop.allocateNativeString("key" + i, arena),

--- a/modules/glib/src/test/java/io/github/jwharm/javagi/interop/FlagsTest.java
+++ b/modules/glib/src/test/java/io/github/jwharm/javagi/interop/FlagsTest.java
@@ -1,6 +1,5 @@
-package io.github.jwharm.javagi.test.glib;
+package io.github.jwharm.javagi.interop;
 
-import io.github.jwharm.javagi.interop.Interop;
 import org.gnome.glib.AsciiType;
 import org.junit.jupiter.api.Test;
 

--- a/modules/glib/src/test/java/io/github/jwharm/javagi/interop/HashTableTest.java
+++ b/modules/glib/src/test/java/io/github/jwharm/javagi/interop/HashTableTest.java
@@ -1,4 +1,4 @@
-package io.github.jwharm.javagi.test.glib;
+package io.github.jwharm.javagi.interop;
 
 import io.github.jwharm.javagi.base.GErrorException;
 import org.gnome.glib.HashTable;

--- a/modules/glib/src/test/java/io/github/jwharm/javagi/interop/MarshalTest.java
+++ b/modules/glib/src/test/java/io/github/jwharm/javagi/interop/MarshalTest.java
@@ -1,7 +1,6 @@
-package io.github.jwharm.javagi.test.glib;
+package io.github.jwharm.javagi.interop;
 
 import io.github.jwharm.javagi.base.Proxy;
-import io.github.jwharm.javagi.interop.Interop;
 import org.gnome.glib.GString;
 import org.gnome.glib.OptionFlags;
 import org.gnome.glib.Variant;

--- a/modules/glib/src/test/java/io/github/jwharm/javagi/interop/VarargsTest.java
+++ b/modules/glib/src/test/java/io/github/jwharm/javagi/interop/VarargsTest.java
@@ -1,4 +1,4 @@
-package io.github.jwharm.javagi.test.glib;
+package io.github.jwharm.javagi.interop;
 
 import org.gnome.glib.GLib;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
Removed the `reference` counter field because there can always be only one single instance that has ownership.

Clarified the javadoc comments and improved some formatting.

Moved the call to `g_free()` down, below the calls to `g_boxed_free()` and the specialized free-function, to make it more clear that it is a fallback case.