### PR TITLE
Gradle configuration cache

### DIFF
--- a/buildSrc/src/main/java/GenerateSources.java
+++ b/buildSrc/src/main/java/GenerateSources.java
@@ -43,6 +43,9 @@ public abstract class GenerateSources extends DefaultTask {
     @Input
     public abstract Property<String> getNamespace();
 
+    @InputFiles
+    public abstract DirectoryProperty getMainJavaSourcesDirectory();
+
     @OutputDirectory
     public abstract DirectoryProperty getOutputDirectory();
 
@@ -67,8 +70,7 @@ public abstract class GenerateSources extends DefaultTask {
      */
     private Set<String> getPackages() throws IOException {
         var packages = new HashSet<String>();
-        var rootDir = getProject().getProjectDir().toPath();
-        var srcDir = rootDir.resolve(Path.of("src", "main", "java"));
+        var srcDir = getMainJavaSourcesDirectory().getAsFile().get().toPath();
         var separator = srcDir.getFileSystem().getSeparator();
 
         if (! Files.exists(srcDir))

--- a/buildSrc/src/main/kotlin/java-gi.library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-gi.library-conventions.gradle.kts
@@ -51,6 +51,7 @@ gradle.sharedServices.registerIfAbsent("gir", GirParserService::class) {
 
 // Register the task that will generate Java sources from GIR files
 val generateSources by tasks.registering(GenerateSources::class) {
+    mainJavaSourcesDirectory = layout.projectDirectory.dir("src/main/java")
     outputDirectory = layout.buildDirectory.dir("generated/sources/java-gi")
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,6 @@
 org.gradle.jvmargs=-Xmx4096M
 org.gradle.caching=true
 org.gradle.parallel=true
+org.gradle.configuration-cache=true
 
 girFilesLocation=ext/gir-files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
* Changed the `GenerateSources` task to be compatible with the Gradle configuration cache (avoid referencing `project` from the task)
* Upgraded Gradle wrapper to 8.11.1
