### PR TITLE
Register interfaces and enums

### DIFF
--- a/generator/settings.gradle.kts
+++ b/generator/settings.gradle.kts
@@ -1,7 +1,7 @@
 rootProject.name = "generator"
 
 plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.9.0"
 }
 
 dependencyResolutionManagement {

--- a/generator/src/main/java/io/github/jwharm/javagi/JavaGI.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/JavaGI.java
@@ -36,10 +36,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
@@ -134,8 +131,12 @@ public class JavaGI implements Callable<Integer> {
     private static int handleException(Exception ex,
                                        CommandLine cmd,
                                        CommandLine.ParseResult parseResult) {
+        String message = Objects.requireNonNullElse(
+                ex.getMessage(),
+                ex.getClass().getSimpleName());
+
         // bold red error message
-        cmd.getErr().println(cmd.getColorScheme().errorText(ex.getMessage()));
+        cmd.getErr().println(cmd.getColorScheme().errorText(message));
 
         return cmd.getExitCodeExceptionMapper() != null
                 ? cmd.getExitCodeExceptionMapper().getExitCode(ex)

--- a/generator/src/main/java/io/github/jwharm/javagi/JavaGI.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/JavaGI.java
@@ -353,7 +353,7 @@ public class JavaGI implements Callable<Integer> {
         }
         else if (ModuleInfo.INCLUDED_MODULES.containsKey(name)) {
             String version = System.getProperty("app.version");
-            return "    api(\"io.github.jwharm.javagi:" + name + ":" + version + "\")";
+            return "    api(\"io.github.jwharm.javagi:" + name + ":0.11.0\")";
         } else {
             return "    api(project(\":" + name + "\"))";
         }

--- a/generator/src/main/java/io/github/jwharm/javagi/configuration/ClassNames.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/configuration/ClassNames.java
@@ -68,18 +68,19 @@ public final class ClassNames {
     public static final ClassName TYPES = get(PKG_GOBJECT_TYPES, "Types");
 
     // Some frequently used class names
-    public final static ClassName GERROR = get("org.gnome.glib", "GError");
-    public final static ClassName GLIB = get("org.gnome.glib", "GLib");
-    public final static ClassName GTYPE = get("org.gnome.glib", "Type");
-    public final static ClassName LOG_LEVEL_FLAGS = get("org.gnome.glib", "LogLevelFlags");
+    public final static ClassName G_BYTE_ARRAY = get("org.gnome.glib", "ByteArray");
+    public final static ClassName G_ERROR = get("org.gnome.glib", "GError");
+    public final static ClassName G_LIB = get("org.gnome.glib", "GLib");
+    public final static ClassName G_LOG_LEVEL_FLAGS = get("org.gnome.glib", "LogLevelFlags");
+    public final static ClassName G_TYPE = get("org.gnome.glib", "Type");
 
-    public final static ClassName GOBJECT = get("org.gnome.gobject", "GObject");
-    public final static ClassName GOBJECTS = get("org.gnome.gobject", "GObjects");
-    public final static ClassName GVALUE = get("org.gnome.gobject", "Value");
-    public final static ClassName TYPE_CLASS = get("org.gnome.gobject", "TypeClass");
-    public final static ClassName TYPE_INTERFACE = get("org.gnome.gobject", "TypeInterface");
-    public final static ClassName TYPE_INSTANCE = get("org.gnome.gobject", "TypeInstance");
+    public final static ClassName G_OBJECT = get("org.gnome.gobject", "GObject");
+    public final static ClassName G_OBJECTS = get("org.gnome.gobject", "GObjects");
+    public final static ClassName G_VALUE = get("org.gnome.gobject", "Value");
+    public final static ClassName G_TYPE_CLASS = get("org.gnome.gobject", "TypeClass");
+    public final static ClassName G_TYPE_INTERFACE = get("org.gnome.gobject", "TypeInterface");
+    public final static ClassName G_TYPE_INSTANCE = get("org.gnome.gobject", "TypeInstance");
 
     // The type variable used for <T extends GObject>
-    public final static TypeVariableName GENERIC_T = TypeVariableName.get("T", GOBJECT);
+    public final static TypeVariableName GENERIC_T = TypeVariableName.get("T", G_OBJECT);
 }

--- a/generator/src/main/java/io/github/jwharm/javagi/configuration/Patches.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/configuration/Patches.java
@@ -38,6 +38,7 @@ public class Patches {
             new GstAudioPatch(),
             new GstVideoPatch(),
             new GstBasePatch(),
+            new GdkPatch(),
             new GtkPatch(),
             new HarfBuzzPatch(),
             new PangoPatch(),

--- a/generator/src/main/java/io/github/jwharm/javagi/generators/AliasGenerator.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/generators/AliasGenerator.java
@@ -182,7 +182,7 @@ public class AliasGenerator extends RegisteredTypeGenerator {
                     layout);
 
         return spec.endControlFlow()
-                .addStatement("if (free) $T.free(address)", ClassNames.GLIB)
+                .addStatement("if (free) $T.free(address)", ClassNames.G_LIB)
                 .addStatement("return array")
                 .build();
     }

--- a/generator/src/main/java/io/github/jwharm/javagi/generators/AliasGenerator.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/generators/AliasGenerator.java
@@ -30,7 +30,6 @@ import javax.lang.model.element.Modifier;
 
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
-import java.util.List;
 
 import static io.github.jwharm.javagi.util.Conversions.getValueLayoutPlain;
 import static io.github.jwharm.javagi.util.Conversions.toJavaSimpleType;
@@ -43,7 +42,7 @@ public class AliasGenerator extends RegisteredTypeGenerator {
     public AliasGenerator(Alias alias) {
         super(alias);
         this.alias = alias;
-        this.target = alias.type().get();
+        this.target = alias.lookup();
     }
 
     public TypeSpec generate() {
@@ -51,10 +50,10 @@ public class AliasGenerator extends RegisteredTypeGenerator {
         builder.addAnnotation(GeneratedAnnotationBuilder.generate());
 
         // Alias for an alias for a primitive type
-        if (target instanceof Alias other && other.type().isPrimitive())
+        if (target instanceof Alias other && other.isValueWrapper())
             builder.superclass(other.typeName())
-                    .addMethod(valueConstructor(other.type().typeName()))
-                    .addMethod(arrayConstructor(other.type()));
+                    .addMethod(valueConstructor(other.anyType().typeName()))
+                    .addMethod(arrayConstructor(other.anyType()));
 
         // Alias for an alias
         else if (target instanceof Alias other)
@@ -70,13 +69,11 @@ public class AliasGenerator extends RegisteredTypeGenerator {
             builder = TypeSpec.interfaceBuilder(alias.typeName())
                     .addSuperinterface(target.typeName());
 
-        else if (alias.type().isPrimitive()
-                || List.of("java.lang.String", "java.lang.foreign.MemorySegment")
-                            .contains(alias.type().javaType()))
+        else if (alias.isValueWrapper())
             builder.superclass(ParameterizedTypeName.get(
-                            ClassNames.ALIAS, alias.type().typeName().box()))
-                    .addMethod(valueConstructor(alias.type().typeName()))
-                    .addMethod(arrayConstructor(alias.type()));
+                            ClassNames.ALIAS, alias.anyType().typeName().box()))
+                    .addMethod(valueConstructor(alias.anyType().typeName()))
+                    .addMethod(arrayConstructor(alias.anyType()));
 
         if (target instanceof Class || target instanceof Interface
                 || target instanceof Record || target instanceof Boxed
@@ -133,8 +130,11 @@ public class AliasGenerator extends RegisteredTypeGenerator {
                 .build();
     }
 
-    private MethodSpec arrayConstructor(Type primitiveType) {
-        String layout = getValueLayoutPlain(primitiveType, false);
+    private MethodSpec arrayConstructor(AnyType anyType) {
+        String layout = switch (anyType) {
+            case Array _ -> "ADDRESS";
+            case Type type -> getValueLayoutPlain(type, false);
+        };
 
         var spec = MethodSpec.methodBuilder("fromNativeArray")
                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
@@ -145,7 +145,7 @@ public class AliasGenerator extends RegisteredTypeGenerator {
                 .addStatement("$T array = new $T[(int) length]",
                         ArrayTypeName.of(alias.typeName()), alias.typeName());
 
-        if (primitiveType.isLong()) {
+        if (anyType instanceof Type t && t.isLong()) {
             spec.addStatement("long byteSize = $1T.longAsInt() ? $2T.JAVA_INT.byteSize() : $2T.JAVA_LONG.byteSize()",
                     ClassNames.INTEROP, ValueLayout.class);
         } else {
@@ -157,12 +157,29 @@ public class AliasGenerator extends RegisteredTypeGenerator {
                         MemorySegment.class)
                 .beginControlFlow("for (int i = 0; i < length; i++)");
 
-        if ("java.lang.String".equals(primitiveType.javaType()))
+        // String[]
+        if (anyType instanceof Array a
+                && a.anyType() instanceof Type t
+                && t.typeName().equals(TypeName.get(String.class)))
+            spec.addStatement("array[i] = new $T($T.getStringArrayFrom(segment.get($T.$L, i * byteSize), free))",
+                    alias.typeName(),
+                    ClassNames.INTEROP,
+                    ValueLayout.class,
+                    layout);
+        // String
+        else if (anyType instanceof Type t
+                && t.typeName().equals(TypeName.get(String.class)))
             spec.addStatement("array[i] = new $T($T.getStringFrom(segment.get($T.$L, i * byteSize), free))",
-                    alias.typeName(), ClassNames.INTEROP, ValueLayout.class, layout);
+                    alias.typeName(),
+                    ClassNames.INTEROP,
+                    ValueLayout.class,
+                    layout);
+        // Primitive value
         else
             spec.addStatement("array[i] = new $T(segment.get($T.$L, i * byteSize))",
-                    alias.typeName(), ValueLayout.class, layout);
+                    alias.typeName(),
+                    ValueLayout.class,
+                    layout);
 
         return spec.endControlFlow()
                 .addStatement("if (free) $T.free(address)", ClassNames.GLIB)

--- a/generator/src/main/java/io/github/jwharm/javagi/generators/BuilderGenerator.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/generators/BuilderGenerator.java
@@ -83,7 +83,7 @@ public class BuilderGenerator {
                 .addTypeVariable(BUILDER_B)
                 .superclass(ParameterizedTypeName.get(parentTypeName, B))
                 .addSuperinterfaces(cls.implements_().stream()
-                        .map(TypeReference::get)
+                        .map(TypeReference::lookup)
                         .map(Interface.class::cast)
                         .filter(Interface::hasProperties)
                         .map(inf -> inf.typeName().nestedClass("Builder"))

--- a/generator/src/main/java/io/github/jwharm/javagi/generators/BuilderGenerator.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/generators/BuilderGenerator.java
@@ -155,7 +155,7 @@ public class BuilderGenerator {
         PartialStatement valueSetter = generator.getValueSetter(gtype, generator.getName())
                 .add(";\n");
         return builder.addStatement("$T _arena = getArena()", Arena.class)
-                .addStatement("$1T _value = new $1T(_arena)", ClassNames.GVALUE)
+                .addStatement("$1T _value = new $1T(_arena)", ClassNames.G_VALUE)
                 .addNamedCode("_value.init(" + gtype.format() + ");\n", gtype.arguments())
                 .addNamedCode(valueSetter.format(), valueSetter.arguments())
                 .addStatement("addBuilderProperty($S, _value)", prp.name())
@@ -257,7 +257,7 @@ public class BuilderGenerator {
                         
                         @return a new instance of {@code $1L} with the properties
                                 that were set in the Builder object.
-                        """, rt.typeName().simpleName(), ClassNames.GOBJECT);
+                        """, rt.typeName().simpleName(), ClassNames.G_OBJECT);
         if (rt instanceof Multiplatform mp && mp.doPlatformCheck())
             builder.addException(ClassNames.UNSUPPORTED_PLATFORM_EXCEPTION)
                     .addJavadoc("@throws $T when run on an unsupported platform",
@@ -272,12 +272,12 @@ public class BuilderGenerator {
 
         return builder.addStatement("var _instance = ($1T) $2T.withProperties($1T.getType(), getNames(), getValues())",
                         rt.typeName(),
-                        ClassNames.GOBJECT)
+                        ClassNames.G_OBJECT)
                 .addStatement("connectSignals(_instance.handle())")
                 .addStatement("return _instance")
                 .nextControlFlow("finally")
                 .addStatement("for ($T _value : getValues()) _value.unset()",
-                        ClassNames.GVALUE)
+                        ClassNames.G_VALUE)
                 .addStatement("getArena().close()")
                 .endControlFlow()
                 .build();

--- a/generator/src/main/java/io/github/jwharm/javagi/generators/CallableGenerator.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/generators/CallableGenerator.java
@@ -150,7 +150,7 @@ public class CallableGenerator {
         // Marshal instance parameter
         InstanceParameter iParam = parameters.instanceParameter();
         if (iParam != null) {
-            if (iParam.type().get() instanceof FlaggedType)
+            if (iParam.type().lookup() instanceof FlaggedType)
                 stmt.add("getValue()"); // method in Enumeration class
             else
                 stmt.add("handle()");   // method in regular TypeInstance class
@@ -204,8 +204,8 @@ public class CallableGenerator {
             // Preprocessing statement
             else if (p.isOutParameter()
                     || (p.anyType() instanceof Type type
-                        && type.get() instanceof Alias a
-                        && a.type().isPrimitive()
+                        && type.lookup() instanceof Alias a
+                        && a.isValueWrapper()
                         && type.isPointer())) {
                 stmt.add("_" + name + "Pointer");
             }

--- a/generator/src/main/java/io/github/jwharm/javagi/generators/CallableGenerator.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/generators/CallableGenerator.java
@@ -124,7 +124,7 @@ public class CallableGenerator {
                     builder.varargs(true);
                 }
 
-                if (generic && type.equals(ClassNames.GOBJECT))
+                if (generic && type.equals(ClassNames.G_OBJECT))
                     type = ClassNames.GENERIC_T;
 
                 var spec = ParameterSpec.builder(type, generator.getName());
@@ -273,7 +273,7 @@ public class CallableGenerator {
 
         // Return type
         var returnValue = callable.returnValue();
-        if (generic && returnValue.anyType().typeName().equals(ClassNames.GOBJECT))
+        if (generic && returnValue.anyType().typeName().equals(ClassNames.G_OBJECT))
             builder.returns(ClassNames.GENERIC_T);
         else if ((!ctor) || namedCtor)
             builder.returns(new TypedValueGenerator(returnValue).getType());

--- a/generator/src/main/java/io/github/jwharm/javagi/generators/ClassGenerator.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/generators/ClassGenerator.java
@@ -61,7 +61,7 @@ public class ClassGenerator extends RegisteredTypeGenerator {
                                                     ClassNames.GENERIC_T)
                     : parentClass.typeName());
         else
-            builder.superclass(ClassNames.TYPE_INSTANCE);
+            builder.superclass(ClassNames.G_TYPE_INSTANCE);
 
         // Add "implements" clause for all implemented interfaces.
         // For generic interfaces, add "<GObject>" generic type.
@@ -194,7 +194,7 @@ public class ClassGenerator extends RegisteredTypeGenerator {
                     @return always {@link $T#PARAM}
                     """, cls.cType(), ClassNames.TYPES)
                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-                .returns(ClassNames.GTYPE)
+                .returns(ClassNames.G_TYPE)
                 .addStatement("return $T.PARAM", ClassNames.TYPES)
                 .build();
     }
@@ -208,12 +208,12 @@ public class ClassGenerator extends RegisteredTypeGenerator {
                     @return the newly created GObject instance
                     """)
                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-                .addTypeVariable(TypeVariableName.get("T", ClassNames.GOBJECT))
+                .addTypeVariable(TypeVariableName.get("T", ClassNames.G_OBJECT))
                 .returns(TypeVariableName.get("T"))
-                .addParameter(ClassNames.GTYPE, "objectType")
+                .addParameter(ClassNames.G_TYPE, "objectType")
                 .addStatement("var _result = constructNew(objectType, null)")
                 .addStatement("T _object = (T) $T.getForType(_result, $T::new, true)",
-                        ClassNames.INSTANCE_CACHE, ClassNames.GOBJECT)
+                        ClassNames.INSTANCE_CACHE, ClassNames.G_OBJECT)
                 .addStatement("return _object")
                 .build();
     }
@@ -231,9 +231,9 @@ public class ClassGenerator extends RegisteredTypeGenerator {
                     @throws IllegalArgumentException invalid property name
                     """)
                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-                .addTypeVariable(TypeVariableName.get("T", ClassNames.GOBJECT))
+                .addTypeVariable(TypeVariableName.get("T", ClassNames.G_OBJECT))
                 .returns(TypeVariableName.get("T"))
-                .addParameter(ClassNames.GTYPE, "objectType")
+                .addParameter(ClassNames.G_TYPE, "objectType")
                 .addParameter(Object[].class, "propertyNamesAndValues")
                 .varargs(true)
                 .addStatement("return $T.newGObjectWithProperties(objectType, propertyNamesAndValues)",
@@ -323,7 +323,7 @@ public class ClassGenerator extends RegisteredTypeGenerator {
                 .addTypeVariable(T)
                 .returns(ParameterizedTypeName.get(ClassNames.BINDING_BUILDER, S, T))
                 .addParameter(String.class, "sourceProperty")
-                .addParameter(ClassNames.GOBJECT, "target")
+                .addParameter(ClassNames.G_OBJECT, "target")
                 .addParameter(String.class, "targetProperty")
                 .addStatement("return new $T<S, T>(this, sourceProperty, target, targetProperty)",
                         ClassNames.BINDING_BUILDER)
@@ -371,7 +371,7 @@ public class ClassGenerator extends RegisteredTypeGenerator {
                 .addStatement("$1T closure = new $1T(callback)",
                         ClassNames.JAVA_CLOSURE)
                 .addStatement("int handlerId = $T.signalConnectClosure(this, detailedSignal, closure, after)",
-                        ClassNames.GOBJECTS)
+                        ClassNames.G_OBJECTS)
                 .addStatement("return new $T(handle(), handlerId, closure)",
                         ClassNames.SIGNAL_CONNECTION)
                 .build();

--- a/generator/src/main/java/io/github/jwharm/javagi/generators/ClassGenerator.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/generators/ClassGenerator.java
@@ -66,7 +66,7 @@ public class ClassGenerator extends RegisteredTypeGenerator {
         // Add "implements" clause for all implemented interfaces.
         // For generic interfaces, add "<GObject>" generic type.
         for (var impl : cls.implements_())
-            if (impl.get() instanceof Interface iface)
+            if (impl.lookup() instanceof Interface iface)
                 builder.addSuperinterface(iface.generic()
                         ? ParameterizedTypeName.get(iface.typeName(),
                                                     ClassNames.GENERIC_T)

--- a/generator/src/main/java/io/github/jwharm/javagi/generators/ClosureGenerator.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/generators/ClosureGenerator.java
@@ -274,8 +274,8 @@ public class ClosureGenerator {
 
             if (p.anyType() instanceof Type t
                     && t.isPointer()
-                    && t.get() instanceof Alias a
-                    && a.type().isPrimitive()) {
+                    && t.lookup() instanceof Alias a
+                    && a.isValueWrapper()) {
                 stmt.add("_" + toJavaIdentifier(p.name()) + "Alias");
                 continue;
             }
@@ -302,10 +302,10 @@ public class ClosureGenerator {
 
     private void returnNull(MethodSpec.Builder upcall) {
         if (returnValue.anyType() instanceof Type type) {
-            var target = type.get();
+            var target = type.lookup();
             if ((type.isPrimitive()
                         || target instanceof FlaggedType
-                        || (target instanceof Alias a && a.type().isPrimitive()))
+                        || (target instanceof Alias a && a.isValueWrapper()))
                     && (!type.isPointer())) {
                 upcall.addStatement("return 0");
                 return;

--- a/generator/src/main/java/io/github/jwharm/javagi/generators/ClosureGenerator.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/generators/ClosureGenerator.java
@@ -196,7 +196,7 @@ public class ClosureGenerator {
         if (returnValue.anyType() instanceof Type t && t.checkIsGObject()
                 && returnValue.transferOwnership() != TransferOwnership.NONE)
             upcall.addStatement("if (_result instanceof $T _gobject) _gobject.ref()",
-                    ClassNames.GOBJECT);
+                    ClassNames.G_OBJECT);
 
         // Marshal return value
         if (!returnsVoid) {
@@ -218,7 +218,7 @@ public class ClosureGenerator {
                         ClassNames.GERROR_EXCEPTION);
             }
             upcall.addStatement("$1T _gerror = new $1T(_ge.getDomain(), _ge.getCode(), _ge.getMessage())",
-                    ClassNames.GERROR);
+                    ClassNames.G_ERROR);
             upcall.addStatement("_gerrorPointer.set($T.ADDRESS, 0, _gerror.handle())",
                     ValueLayout.class);
             if (!returnsVoid)
@@ -236,9 +236,9 @@ public class ClosureGenerator {
             upcall.nextControlFlow("catch ($T ite)",
                     InvocationTargetException.class);
             upcall.addStatement("$T.log($T.LOG_DOMAIN, $T.LEVEL_WARNING, ite.getCause().toString() + $S + $L)",
-                    ClassNames.GLIB,
+                    ClassNames.G_LIB,
                     ClassNames.CONSTANTS,
-                    ClassNames.LOG_LEVEL_FLAGS,
+                    ClassNames.G_LOG_LEVEL_FLAGS,
                     " in ",
                     methodName);
             if (!returnsVoid)

--- a/generator/src/main/java/io/github/jwharm/javagi/generators/ConstructorGenerator.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/generators/ConstructorGenerator.java
@@ -175,7 +175,7 @@ public class ConstructorGenerator {
                                     .format(),
                             stmt.arguments())
                     .beginControlFlow("if (_object instanceof $T _gobject)",
-                            ClassNames.GOBJECT)
+                            ClassNames.G_OBJECT)
                     .addStatement("$T.debug($S, _gobject.handle().address())",
                             ClassNames.GLIB_LOGGER,
                             "Ref " + returnType + " %ld")

--- a/generator/src/main/java/io/github/jwharm/javagi/generators/InterfaceGenerator.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/generators/InterfaceGenerator.java
@@ -54,7 +54,7 @@ public class InterfaceGenerator extends RegisteredTypeGenerator {
         // Add "extends" clause for all prerequisite interfaces.
         // For generic interfaces, add "<GObject>" generic type.
         for (var prereq : inf.prerequisites())
-            if (prereq.get() instanceof Interface iface)
+            if (prereq.lookup() instanceof Interface iface)
                 builder.addSuperinterface(iface.generic()
                         ? ParameterizedTypeName.get(iface.typeName(),
                                                 ClassNames.GENERIC_T)

--- a/generator/src/main/java/io/github/jwharm/javagi/generators/MemoryLayoutGenerator.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/generators/MemoryLayoutGenerator.java
@@ -39,9 +39,9 @@ public class MemoryLayoutGenerator {
     // Opaque structs have unknown memory layout.
     public boolean canGenerate(FieldContainer rt) {
         boolean isOpaque = switch (rt) {
-            case Class c -> c.hasOpaqueStructFields() || c.isOpaque();
-            case Record r -> r.hasOpaqueStructFields() || r.isOpaque();
-            case Union u -> u.hasOpaqueStructFields() || u.isOpaque();
+            case Class c -> c.hasOpaqueStructFields() || c.opaque();
+            case Record r -> r.hasOpaqueStructFields() || r.opaque();
+            case Union u -> u.hasOpaqueStructFields() || u.opaque();
             default -> false;
         };
         return !isOpaque;
@@ -184,11 +184,11 @@ public class MemoryLayoutGenerator {
     }
 
     private PartialStatement layoutForType(Type type, boolean longAsInt) {
-        RegisteredType target = type.get();
+        RegisteredType target = type.lookup();
 
         // Recursive lookup for aliases
-        if (target instanceof Alias alias)
-            return layoutForType(alias.type(), longAsInt);
+        if (target instanceof Alias alias && alias.anyType() instanceof Type t)
+            return layoutForType(t, longAsInt);
 
         // Proxy objects with a known memory layout
         if (!type.isPointer()

--- a/generator/src/main/java/io/github/jwharm/javagi/generators/MethodGenerator.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/generators/MethodGenerator.java
@@ -240,7 +240,7 @@ public class MethodGenerator {
     private void generateOwnershipTransfer() {
         // Prepare a statement that marshals the return value to Java
         RegisteredType target = returnValue.anyType() instanceof Type type
-                ? type.get() : null;
+                ? type.lookup() : null;
         var generator = new TypedValueGenerator(returnValue);
         PartialStatement stmt = PartialStatement.of("");
         if (generic && returnValue.anyType().typeName().equals(ClassNames.GOBJECT))

--- a/generator/src/main/java/io/github/jwharm/javagi/generators/MethodGenerator.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/generators/MethodGenerator.java
@@ -54,9 +54,7 @@ public class MethodGenerator {
 
     public static String getName(Callable func) {
         String name = toJavaIdentifier(func.name());
-        return func.parent() instanceof Interface
-                ? replaceJavaObjectMethodNames(name)
-                : name;
+        return replaceJavaObjectMethodNames(name, func.parent() instanceof Interface);
     }
 
     public static boolean isGeneric(Callable func) {

--- a/generator/src/main/java/io/github/jwharm/javagi/generators/MethodGenerator.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/generators/MethodGenerator.java
@@ -295,7 +295,7 @@ public class MethodGenerator {
             // No ownership transfer: Copy/ref the struct
             else {
                 // First check for NULL
-                if (returnValue.nullable()) {
+                if (generator.checkNull()) {
                     builder.beginControlFlow("if (_result == null || _result.equals($T.NULL))",
                                     MemorySegment.class)
                             .addStatement("return null")

--- a/generator/src/main/java/io/github/jwharm/javagi/generators/MethodGenerator.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/generators/MethodGenerator.java
@@ -134,7 +134,7 @@ public class MethodGenerator {
             builder.addModifiers(Modifier.DEFAULT);
 
         // Return type
-        if (generic && returnValue.anyType().typeName().equals(ClassNames.GOBJECT))
+        if (generic && returnValue.anyType().typeName().equals(ClassNames.G_OBJECT))
             builder.returns(ClassNames.GENERIC_T);
         else if (func instanceof Constructor)
             builder.returns(MemorySegment.class);
@@ -186,7 +186,7 @@ public class MethodGenerator {
         if (vm != null && vm != func) {
             if (func.parent() instanceof Interface)
                 builder.beginControlFlow("if ((($T) this).callParent())",
-                        ClassNames.TYPE_INSTANCE);
+                        ClassNames.G_TYPE_INSTANCE);
             else
                 builder.beginControlFlow("if (callParent())");
             functionPointerInvocation();
@@ -243,7 +243,7 @@ public class MethodGenerator {
                 ? type.lookup() : null;
         var generator = new TypedValueGenerator(returnValue);
         PartialStatement stmt = PartialStatement.of("");
-        if (generic && returnValue.anyType().typeName().equals(ClassNames.GOBJECT))
+        if (generic && returnValue.anyType().typeName().equals(ClassNames.G_OBJECT))
             stmt.add("($generic:T) ", "generic", ClassNames.GENERIC_T);
         stmt.add(generator.marshalNativeToJava("_result", false));
 
@@ -256,7 +256,7 @@ public class MethodGenerator {
             builder.addNamedCode(PartialStatement.of("var _object = ")
                     .add(stmt).format() + ";\n", stmt.arguments())
                     .beginControlFlow("if (_object instanceof $T _gobject)",
-                            ClassNames.GOBJECT)
+                            ClassNames.G_OBJECT)
                     .addStatement("$T.debug($S, _gobject.handle().address())",
                             ClassNames.GLIB_LOGGER,
                             "Ref " + generator.getType() + " %ld")
@@ -333,7 +333,7 @@ public class MethodGenerator {
                 else if (hasMemoryLayout && copyFunc == null) {
                     builder.addStatement("$T _copy = $T.malloc($T.getMemoryLayout().byteSize())",
                             MemorySegment.class,
-                            ClassNames.GLIB,
+                            ClassNames.G_LIB,
                             returnValue.anyType().typeName());
                     stmt = PartialStatement.of("var _instance = ")
                             .add(generator.marshalNativeToJava("_copy", false))

--- a/generator/src/main/java/io/github/jwharm/javagi/generators/NamespaceGenerator.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/generators/NamespaceGenerator.java
@@ -135,7 +135,7 @@ public class NamespaceGenerator extends RegisteredTypeGenerator {
             spec.addCode(register(i.constructorName(), i.typeName()));
 
         for (Alias a : ns.aliases()) {
-            RegisteredType target = a.type().get();
+            RegisteredType target = a.lookup();
             if (target instanceof Class c)
                 spec.addCode(register(c.constructorName(), a.typeName()));
             if (target instanceof Interface i)

--- a/generator/src/main/java/io/github/jwharm/javagi/generators/PreprocessingGenerator.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/generators/PreprocessingGenerator.java
@@ -186,7 +186,7 @@ public class PreprocessingGenerator extends TypedValueGenerator {
                 && !p.isOutParameter()
                 && (type.cType() == null || !type.cType().endsWith("**"))) {
             builder.beginControlFlow("if ($L instanceof $T _gobject)",
-                            getName(), ClassNames.GOBJECT)
+                            getName(), ClassNames.G_OBJECT)
                     .addStatement("$T.debug($S, _gobject.handle().address())",
                             ClassNames.GLIB_LOGGER,
                             "Ref " + type.typeName() + " %ld")

--- a/generator/src/main/java/io/github/jwharm/javagi/generators/RecordGenerator.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/generators/RecordGenerator.java
@@ -80,7 +80,7 @@ public class RecordGenerator extends RegisteredTypeGenerator {
                  * disguised.
                  */
                 Type type = (Type) rec.fields().getFirst().anyType();
-                Record parentRec = (Record) type.get();
+                Record parentRec = (Record) type.lookup();
                 RegisteredType parentClass = parentRec.isGTypeStructFor();
                 if (parentClass != null) {
                     String nestedClassName = toJavaSimpleType(parentRec.name(), parentRec.namespace());
@@ -154,7 +154,7 @@ public class RecordGenerator extends RegisteredTypeGenerator {
         if (cb == null) {
             if (f.anyType() instanceof Type t
                     && (!t.isPointer())
-                    && t.get() instanceof Record)
+                    && t.lookup() instanceof Record)
                 // Copy contents from nested struct
                 builder.addMethod(generator.generateReadCopyMethod());
             else
@@ -191,7 +191,7 @@ public class RecordGenerator extends RegisteredTypeGenerator {
 
         if (f.anyType() instanceof Type t
                 && (!t.isPointer())
-                && t.get() instanceof Record)
+                && t.lookup() instanceof Record)
             // Generate write-method to copy contents to nested struct
             builder.addMethod(generator.generateWriteCopyMethod());
         else if (cb == null || outerClass == null)

--- a/generator/src/main/java/io/github/jwharm/javagi/generators/RecordGenerator.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/generators/RecordGenerator.java
@@ -73,7 +73,7 @@ public class RecordGenerator extends RegisteredTypeGenerator {
             builder.addModifiers(Modifier.STATIC);
             if (rec.fields().isEmpty()) {
                 builder.superclass(outerClass instanceof Interface
-                        ? ClassNames.TYPE_INTERFACE : ClassNames.TYPE_CLASS);
+                        ? ClassNames.G_TYPE_INTERFACE : ClassNames.G_TYPE_CLASS);
             } else {
                 /*
                  * parent_class is always the first field, unless the struct is
@@ -306,9 +306,9 @@ public class RecordGenerator extends RegisteredTypeGenerator {
                     @return the GType
                     """)
                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-                .returns(ClassNames.GTYPE)
+                .returns(ClassNames.G_TYPE)
                 // Types.VARIANT is declared in GObject. Hard-coded value as workaround
-                .addStatement("return new $T(21L << 2)", ClassNames.GTYPE)
+                .addStatement("return new $T(21L << 2)", ClassNames.G_TYPE)
                 .build();
     }
 
@@ -356,12 +356,12 @@ public class RecordGenerator extends RegisteredTypeGenerator {
                         described may change between different GLib versions.
                         
                         @return the newly allocated String.
-                        """, ClassNames.GOBJECTS, ClassNames.GVALUE)
+                        """, ClassNames.G_OBJECTS, ClassNames.G_VALUE)
                 .addModifiers(Modifier.PUBLIC)
                 .addAnnotation(Override.class)
                 .returns(String.class)
                 .addStatement("return $T.strdupValueContents(this)",
-                        ClassNames.GOBJECTS)
+                        ClassNames.G_OBJECTS)
                 .build();
     }
 }

--- a/generator/src/main/java/io/github/jwharm/javagi/generators/RegisteredTypeGenerator.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/generators/RegisteredTypeGenerator.java
@@ -65,7 +65,7 @@ public class RegisteredTypeGenerator {
                     @return the GType
                     """, name())
                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-                .returns(ClassNames.GTYPE)
+                .returns(ClassNames.G_TYPE)
                 .addStatement("return $T.getType($S)",
                         ClassNames.INTEROP,
                         rt.getTypeFunc())
@@ -146,7 +146,7 @@ public class RegisteredTypeGenerator {
                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC);
 
         TypeName base = rt.generic()
-                ? ParameterizedTypeName.get(rt.typeName(), ClassNames.GOBJECT)
+                ? ParameterizedTypeName.get(rt.typeName(), ClassNames.G_OBJECT)
                 : rt.typeName();
 
         if (rt instanceof Interface i) {
@@ -180,7 +180,7 @@ public class RegisteredTypeGenerator {
     private TypeName getInterfaceSuperclass(Interface i) {
         Class c = i.prerequisiteBaseClass();
         return c.generic()
-                ? ParameterizedTypeName.get(c.typeName(), ClassNames.GOBJECT)
+                ? ParameterizedTypeName.get(c.typeName(), ClassNames.G_OBJECT)
                 : c.typeName();
     }
 

--- a/generator/src/main/java/io/github/jwharm/javagi/generators/RegisteredTypeGenerator.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/generators/RegisteredTypeGenerator.java
@@ -33,7 +33,6 @@ import java.lang.foreign.MemorySegment;
 import java.util.List;
 
 import static io.github.jwharm.javagi.util.CollectionUtils.filter;
-import static io.github.jwharm.javagi.util.Conversions.toJavaIdentifier;
 import static java.util.function.Predicate.not;
 
 public class RegisteredTypeGenerator {
@@ -132,9 +131,8 @@ public class RegisteredTypeGenerator {
                     """, name())
                 .addParameter(MemorySegment.class, "address");
 
-        if (rt instanceof Record rec && rec.isOpaque()
-                || rt instanceof Boxed
-                || rt instanceof Union union && union.isOpaque())
+        if (rt instanceof FieldContainer fc
+                && (fc.opaque() || fc.hasOpaqueStructFields()))
             builder.addStatement("super(address)");
         else
             builder.addStatement("super($T.reinterpret(address, getMemoryLayout().byteSize()))",

--- a/generator/src/main/java/io/github/jwharm/javagi/generators/TypedValueGenerator.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/generators/TypedValueGenerator.java
@@ -426,7 +426,7 @@ class TypedValueGenerator {
             case Type t when t.isPrimitive() ->
                     null;
             case Type t when t.isMemorySegment() ->
-                    PartialStatement.of("$glib:T::free", "glib", ClassNames.GLIB);
+                    PartialStatement.of("$glib:T::free", "glib", ClassNames.G_LIB);
             case Type t when t.lookup() != null ->
                     t.lookup().destructorName();
             default ->
@@ -592,7 +592,7 @@ class TypedValueGenerator {
         if (type.isMemorySegment())
             return PartialStatement.of("$types:T.POINTER", "types", ClassNames.TYPES);
 
-        if (type.typeName().equals(ClassNames.GOBJECT))
+        if (type.typeName().equals(ClassNames.G_OBJECT))
             return PartialStatement.of("$types:T.OBJECT", "types", ClassNames.TYPES);
 
         RegisteredType rt = target instanceof Alias a ? a.lookup() : target;
@@ -610,9 +610,9 @@ class TypedValueGenerator {
             }
         }
 
-        if (type.typeName().equals(ClassNames.GTYPE))
+        if (type.typeName().equals(ClassNames.G_TYPE))
             return PartialStatement.of("$gobjects:T.gtypeGetType()",
-                    "gobjects", ClassNames.GOBJECTS);
+                    "gobjects", ClassNames.G_OBJECTS);
 
         return PartialStatement.of("$types:T.POINTER", "types", ClassNames.TYPES);
     }
@@ -676,7 +676,7 @@ class TypedValueGenerator {
                         .add(")");
             case "setObject" ->
                     PartialStatement.of("_value" + "." + setValue + "(($gobject:T) " + payloadIdentifier + ")",
-                            "gobject", ClassNames.GOBJECT);
+                            "gobject", ClassNames.G_OBJECT);
             default ->
                     PartialStatement.of("_value" + "." + setValue + "(" + payloadIdentifier + ")");
         };

--- a/generator/src/main/java/io/github/jwharm/javagi/generators/TypedValueGenerator.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/generators/TypedValueGenerator.java
@@ -49,7 +49,7 @@ class TypedValueGenerator {
         this.v = v;
         this.array = v.anyType() instanceof Array a ? a : null;
         this.type = v.anyType() instanceof Type t ? t : null;
-        this.target = type != null ? type.get() : null;
+        this.target = type != null ? type.lookup() : null;
     }
 
     /**
@@ -57,7 +57,8 @@ class TypedValueGenerator {
      * @return true if this parameter is not a primitive value
      */
     boolean checkNull() {
-        if (v instanceof InstanceParameter) return false;
+        if (v instanceof InstanceParameter)
+            return false;
 
         if (v instanceof Parameter p &&
                 (p.notNull()
@@ -71,7 +72,9 @@ class TypedValueGenerator {
         return ! (type != null
                     && !type.isPointer()
                     && (type.isPrimitive()
-                        || (target instanceof Alias a && a.type().isPrimitive())
+                        || (target instanceof Alias a
+                                && a.anyType() instanceof Type t
+                                && t.isPrimitive())
                         || target instanceof FlaggedType));
     }
 
@@ -121,9 +124,7 @@ class TypedValueGenerator {
     }
 
     String getName() {
-        return "...".equals(v.name())
-                ? "varargs"
-                : toJavaIdentifier(v.name());
+        return "...".equals(v.name()) ? "varargs" : toJavaIdentifier(v.name());
     }
 
     PartialStatement marshalJavaToNative(String identifier) {
@@ -164,8 +165,7 @@ class TypedValueGenerator {
         if (type.isMemorySegment())
             return PartialStatement.of(identifier);
 
-        if (type.isPointer()
-                && (type.isPrimitive() || target instanceof FlaggedType))
+        if (type.isPointer() && (type.isPrimitive() || target instanceof FlaggedType))
             return PartialStatement.of(identifier);
 
         if (type.isBoolean())
@@ -174,18 +174,21 @@ class TypedValueGenerator {
         return marshalJavaToNative(target, identifier);
     }
 
-    private PartialStatement marshalJavaToNative(RegisteredType target,
-                                                 String identifier) {
+    private PartialStatement marshalJavaToNative(RegisteredType target, String identifier) {
         return switch (target) {
             case null -> PartialStatement.of(identifier);
-            case Alias alias -> {
-                RegisteredType typedef = alias.type().get();
+            case Alias alias when alias.anyType() instanceof Array ->
+                    PartialStatement.of(
+                            "$interop.allocateNativeArray(" + identifier + ", true, _arena)",
+                            "interop", ClassNames.INTEROP);
+            case Alias alias when alias.anyType() instanceof Type t -> {
+                RegisteredType typedef = t.lookup();
                 if (typedef != null)
                     yield marshalJavaToNative(typedef, identifier);
-                String stmt = switch(toJavaBaseType(alias.type().name())) {
+                String stmt = switch(toJavaBaseType(t.name())) {
                     case null -> null;
                     case "String", "MemorySegment" -> identifier + ".getValue()";
-                    default -> identifier + ".getValue()." + alias.type().typeName() + "Value()";
+                    default -> identifier + ".getValue()." + t.typeName() + "Value()";
                 };
                 yield PartialStatement.of(stmt);
             }
@@ -210,30 +213,28 @@ class TypedValueGenerator {
         };
     }
 
-    private PartialStatement marshalJavaArrayToNative(Array array,
-                                                      String identifier) {
-
+    private PartialStatement marshalJavaArrayToNative(Array array, String identifier) {
         // When ownership is transferred, we must not free the allocated
         // memory -> use global scope
         String allocator = (v instanceof Parameter p && p.transferOwnership() != NONE)
                 ? "$arena:T.global()" : "_arena";
 
         Type type = (Type) array.anyType();
-        RegisteredType target = type.get();
+        RegisteredType target = type.lookup();
 
         boolean isFlaggedType = target instanceof FlaggedType;
-        boolean isPrimitiveAlias = target instanceof Alias a
-                                            && a.type().isPrimitive();
+        boolean isPrimitiveAlias = target instanceof Alias a && a.isValueWrapper();
 
         String targetTypeTag = isFlaggedType ? "flaggedType" : type.toTypeTag();
 
         String primitiveClassName = isPrimitiveAlias
-                ? primitiveClassName(((Alias) target).type().javaType())
+                ? primitiveClassName(((Alias) target).anyType().typeName().toString())
                 : "";
 
         if (isFlaggedType || isPrimitiveAlias) {
             return PartialStatement.of(
-                    "$interop:T.allocateNativeArray($" + targetTypeTag + ":T.get" + primitiveClassName + "Values(" + identifier + "), "
+                    "$interop:T.allocateNativeArray($" + targetTypeTag + ":T.get"
+                            + primitiveClassName + "Values(" + identifier + "), "
                             + array.zeroTerminated() + ", " + allocator + ")",
                     "arena", Arena.class,
                     "interop", ClassNames.INTEROP,
@@ -242,58 +243,52 @@ class TypedValueGenerator {
 
         if (target instanceof Record && (!type.isPointer()))
             return PartialStatement.of(
-                    "$interop:T.allocateNativeArray(" + identifier + ", $" + targetTypeTag + ":T.getMemoryLayout(), "
+                    "$interop:T.allocateNativeArray(" + identifier
+                            + ", $" + targetTypeTag + ":T.getMemoryLayout(), "
                             + array.zeroTerminated() + ", " + allocator + ")",
                     "arena", Arena.class,
                     targetTypeTag, target.typeName(),
                     "interop", ClassNames.INTEROP);
 
         return PartialStatement.of(
-                "$interop:T.allocateNativeArray(" + identifier + ", " + array.zeroTerminated() + ", " + allocator + ")",
+                "$interop:T.allocateNativeArray(" + identifier
+                        + ", " + array.zeroTerminated() + ", " + allocator + ")",
                 "arena", Arena.class,
                 "interop", ClassNames.INTEROP);
     }
 
     PartialStatement marshalNativeToJava(String identifier, boolean upcall) {
-        if (type != null
-                && type.cType() != null
-                && type.cType().equals("gfloat**"))
-            return PartialStatement.of("null /* unsupported */");
-
         if (type != null) {
+            if ("gfloat**".equals(type.cType()))
+                return PartialStatement.of("null /* unsupported */");
+
             if (type.isActuallyAnArray())
                 return marshalNativeToJavaArray(type, null, identifier);
 
-            if (type.isPointer()
-                    && (type.isPrimitive() || target instanceof FlaggedType))
+            if (type.isPointer() && (type.isPrimitive() || target instanceof FlaggedType))
                 return PartialStatement.of(identifier);
 
             return marshalNativeToJava(type, identifier, upcall);
         }
 
+        // String[][]
         if (array != null && array.anyType() instanceof Array inner
-                && inner.anyType() instanceof Type t
-                && t.isString())
+                && inner.anyType() instanceof Type t && t.isString())
             return PartialStatement.of(
                     "$interop:T.getStrvArrayFrom(" + identifier + ", " + doFree() + ")",
                     "interop", ClassNames.INTEROP);
 
-        if (array != null && array.anyType() instanceof Type arrayType)
-            return marshalNativeToJavaArray(
-                    arrayType,
-                    array.sizeExpression(upcall),
-                    identifier
-            );
+        // Array
+        if (array != null && array.anyType() instanceof Type t)
+             return marshalNativeToJavaArray(t, array.sizeExpression(upcall), identifier);
 
+        // Nested array
         return PartialStatement.of("null /* unsupported */");
     }
 
-    PartialStatement marshalNativeToJava(Type type,
-                                         String identifier,
-                                         boolean upcall) {
+    PartialStatement marshalNativeToJava(Type type, String identifier, boolean upcall) {
         String free = doFree();
         String targetTypeTag = target == null ? null : type.toTypeTag();
-
         boolean isTypeClass = target instanceof Record
                                     && "TypeClass".equals(target.name());
 
@@ -331,11 +326,11 @@ class TypedValueGenerator {
 
             // Find out how ownership is transferred
             var transferOwnership = switch(parent) {
-                case Parameter p -> p.transferOwnership();
-                case InstanceParameter ip -> ip.transferOwnership();
-                case ReturnValue rv -> rv.transferOwnership();
-                case Property p -> p.transferOwnership();
-                default -> throw new IllegalStateException();
+                case Parameter p         -> p.transferOwnership();
+                case InstanceParameter i -> i.transferOwnership();
+                case ReturnValue r       -> r.transferOwnership();
+                case Property p          -> p.transferOwnership();
+                default                  -> throw new IllegalStateException();
             };
 
             var stmt = PartialStatement.of("new $" + targetTypeTag + ":T(" + identifier + ", ",
@@ -344,9 +339,8 @@ class TypedValueGenerator {
 
             if (elementDestructor != null)
                 stmt.add(", ").add(elementDestructor);
-            stmt.add(", " + (transferOwnership == FULL))
-                .add(")");
-            return stmt;
+
+            return stmt.add(", " + (transferOwnership == FULL)).add(")");
         }
 
         // Generate constructor call for HashTable with generic types for keys and values
@@ -363,20 +357,17 @@ class TypedValueGenerator {
 
         }
 
-        if ((target instanceof Record && (!isTypeClass))
+        if ((target instanceof Record && !isTypeClass)
                 || target instanceof Union
                 || target instanceof Boxed
-                || (target instanceof Alias a
-                        && a.type().get() instanceof Record))
+                || (target instanceof Alias a && a.lookup() instanceof Record))
             return PartialStatement.of(
-                    "$memorySegment:T.NULL.equals(" + identifier + ") ? null : new $" + targetTypeTag + ":T(" + identifier + ")",
+                    "$memorySegment:T.NULL.equals(" + identifier
+                            + ") ? null : new $" + targetTypeTag + ":T(" + identifier + ")",
                     "memorySegment", MemorySegment.class,
                     targetTypeTag, target.typeName());
 
-        if (target instanceof Alias a &&
-                (a.type().isPrimitive()
-                    || a.type().isString()
-                    || a.type().isMemorySegment()))
+        if (target instanceof Alias a && a.isValueWrapper())
             return PartialStatement.of(
                     "new $" + targetTypeTag + ":T(" + identifier + ")",
                     targetTypeTag, target.typeName());
@@ -387,25 +378,21 @@ class TypedValueGenerator {
         boolean hasGType = target instanceof Class
                 || target instanceof Interface
                 || (target instanceof Alias a
-                    && (a.type().get() instanceof Class ||
-                        a.type().get() instanceof Interface));
+                    && (a.lookup() instanceof Class || a.lookup() instanceof Interface));
 
-        String cacheFunction =
-                hasGType ? "getForType" :
-                isTypeClass ? "getForTypeClass" :
-                "get";
-
+        String cacheFunction = hasGType ? "getForType" : isTypeClass ? "getForTypeClass" : "get";
         String cache = upcall ? "false" : "true";
 
         if (target instanceof Class
                 || target instanceof Interface
-                || target instanceof Alias a && a.type().isProxy()
+                || (target instanceof Alias a && a.isProxy())
                 || isTypeClass)
-            return PartialStatement.of("($" + targetTypeTag + ":T) $instanceCache:T." + cacheFunction + "(" + identifier + ", ")
-                            .add(target.constructorName())
-                            .add(", " + cache + ")",
-                                    targetTypeTag, target.typeName(),
-                                    "instanceCache", ClassNames.INSTANCE_CACHE);
+            return PartialStatement.of(
+                        "($" + targetTypeTag + ":T) $instanceCache:T." + cacheFunction + "(" + identifier + ", ")
+                    .add(target.constructorName())
+                    .add(", " + cache + ")",
+                            targetTypeTag, target.typeName(),
+                            "instanceCache", ClassNames.INSTANCE_CACHE);
 
         if (type.isBoolean())
             return PartialStatement.of(identifier + " != 0");
@@ -415,43 +402,47 @@ class TypedValueGenerator {
 
     private static PartialStatement getElementConstructor(Type type, int child) {
         return switch (type.anyTypes().get(child)) {
-            case Type t when t.isString()        -> PartialStatement.of("$interop:T::getStringFrom", "interop", ClassNames.INTEROP);
-            case Type t when t.isPrimitive()     -> PartialStatement.of("$interop:T::get" + primitiveClassName(t.javaType()) + "From", "interop", ClassNames.INTEROP);
-            case Type t when t.isMemorySegment() -> PartialStatement.of("(_p -> _p)");
-            case Array _                         -> PartialStatement.of("(_p -> _p)");
-            case Type t when t.get() != null     -> t.get().constructorName();
-            default                              -> throw new UnsupportedOperationException("Unsupported element type: " + type);
+            case Type t when t.isString() ->
+                    PartialStatement.of("$interop:T::getStringFrom", "interop", ClassNames.INTEROP);
+            case Type t when t.isPrimitive() ->
+                    PartialStatement.of("$interop:T::get" + primitiveClassName(t.javaType()) + "From", "interop", ClassNames.INTEROP);
+            case Type t when t.isMemorySegment() ->
+                    PartialStatement.of("(_p -> _p)");
+            case Array _ ->
+                    PartialStatement.of("(_p -> _p)");
+            case Type t when t.lookup() != null ->
+                    t.lookup().constructorName();
+            default ->
+                    throw new UnsupportedOperationException("Unsupported element type: " + type);
         };
     }
 
     private static PartialStatement getElementDestructor(Type type, int child) {
         return switch (type.anyTypes().get(child)) {
-            case Array _                         -> PartialStatement.of("(_ -> {}) /* unsupported */");
-            case Type t when t.isString()        -> null;
-            case Type t when t.isPrimitive()     -> null;
-            case Type t when t.isMemorySegment() -> PartialStatement.of("$glib:T::free", "glib", ClassNames.GLIB);
-            case Type t when t.get() != null     -> t.get().destructorName();
-            default                              -> throw new UnsupportedOperationException("Unsupported element type: " + type);
+            case Array _ ->
+                    PartialStatement.of("(_ -> {}) /* unsupported */");
+            case Type t when t.isString() ->
+                    null;
+            case Type t when t.isPrimitive() ->
+                    null;
+            case Type t when t.isMemorySegment() ->
+                    PartialStatement.of("$glib:T::free", "glib", ClassNames.GLIB);
+            case Type t when t.lookup() != null ->
+                    t.lookup().destructorName();
+            default ->
+                    throw new UnsupportedOperationException("Unsupported element type: " + type);
         };
     }
 
-    private PartialStatement marshalNativeToJavaArray(Type type,
-                                                      String size,
-                                                      String identifier) {
+    private PartialStatement marshalNativeToJavaArray(Type type, String size, String identifier) {
         String free = doFree();
-        RegisteredType target = type.get();
+        RegisteredType target = type.lookup();
         String targetTypeTag = target != null ? type.toTypeTag() : null;
-
-        String primitive = type.isPrimitive()
-                ? primitiveClassName(type.javaType())
-                : null;
+        String primitive = type.isPrimitive() ? primitiveClassName(type.javaType()) : null;
 
         // GArray stores the length in the len field
-        if (size == null
-                && array != null
-                && array.name() != null
-                && List.of("GLib.Array", "GLib.PtrArray", "GLib.ByteArray")
-                       .contains(array.name())) {
+        if (size == null && array != null && array.name() != null
+                && List.of("GLib.Array", "GLib.PtrArray", "GLib.ByteArray").contains(array.name())) {
             size = "new $arrayType:T(" + identifier + ").readLen()";
             identifier = "$interop:T.dereference(" + identifier + ")";
         }
@@ -470,11 +461,12 @@ class TypedValueGenerator {
 
             if (target instanceof FlaggedType)
                 return PartialStatement.of(
-                        "$interop:T.getArrayFromIntPointer(" + identifier + ", (int) $" + targetTypeTag + ":T.class, $" + targetTypeTag + ":T::of)",
+                        "$interop:T.getArrayFromIntPointer(" + identifier
+                                + ", (int) $" + targetTypeTag + ":T.class, $" + targetTypeTag + ":T::of)",
                         "interop", ClassNames.INTEROP,
                         targetTypeTag, target.typeName());
 
-            if (target instanceof Alias a && a.type().isPrimitive())
+            if (target instanceof Alias a && a.isValueWrapper())
                 return PartialStatement.of(
                         "$" + targetTypeTag + ":T.fromNativeArray(" + identifier + ", " + free + ")",
                         targetTypeTag, target.typeName());
@@ -487,17 +479,21 @@ class TypedValueGenerator {
             if (target instanceof Record && (! type.isPointer()) &&
                     (! (array != null && "GLib.PtrArray".equals(array.name()))))
                 return PartialStatement.of(
-                        "$interop:T.getStructArrayFrom(" + identifier + ", $" + targetTypeTag + ":T.class, ").add(target.constructorName()).add(", $" + targetTypeTag + ":T.getMemoryLayout())",
-                        "interop", ClassNames.INTEROP,
-                        targetTypeTag, target.typeName());
+                                "$interop:T.getStructArrayFrom(" + identifier + ", $" + targetTypeTag + ":T.class, ")
+                        .add(target.constructorName())
+                        .add(", $" + targetTypeTag + ":T.getMemoryLayout())",
+                                "interop", ClassNames.INTEROP,
+                                targetTypeTag, target.typeName());
 
             if (target == null)
                 throw new IllegalStateException("Target is null for type " + type);
 
             return PartialStatement.of(
-                    "$interop:T.getProxyArrayFrom(" + identifier + ", $" + targetTypeTag + ":T.class, ").add(target.constructorName()).add(")",
-                    "interop", ClassNames.INTEROP,
-                    targetTypeTag, target.typeName());
+                            "$interop:T.getProxyArrayFrom(" + identifier + ", $" + targetTypeTag + ":T.class, ")
+                    .add(target.constructorName())
+                    .add(")",
+                            "interop", ClassNames.INTEROP,
+                            targetTypeTag, target.typeName());
         }
 
         // Array with known size
@@ -515,12 +511,13 @@ class TypedValueGenerator {
 
         if (target instanceof FlaggedType)
             return PartialStatement.of(
-                    "$interop:T.getArrayFromIntPointer(" + identifier + ", (int) " + size + ", $" + targetTypeTag + ":T.class, $" + targetTypeTag + ":T::of)",
+                    "$interop:T.getArrayFromIntPointer(" + identifier
+                            + ", (int) " + size + ", $" + targetTypeTag + ":T.class, $" + targetTypeTag + ":T::of)",
                     "interop", ClassNames.INTEROP,
                     "arrayType", array == null ? null : toJavaQualifiedType(array.name(), array.namespace()),
                     targetTypeTag, target.typeName());
 
-        if (target instanceof Alias a && a.type().isPrimitive())
+        if (target instanceof Alias a && a.isValueWrapper())
             return PartialStatement.of(
                     "$targetType:T.fromNativeArray(" + identifier + ", " + size + ", " + free + ")",
                     "interop", ClassNames.INTEROP,
@@ -536,34 +533,41 @@ class TypedValueGenerator {
         if (target instanceof Record && (! type.isPointer()) &&
                 (! (array != null && "GLib.PtrArray".equals(array.name()))))
             return PartialStatement.of(
-                    "$interop:T.getStructArrayFrom(" + identifier + ", (int) " + size + ", $" + targetTypeTag + ":T.class, ").add(target.constructorName()).add(", $" + targetTypeTag + ":T.getMemoryLayout())",
-                    "interop", ClassNames.INTEROP,
-                    "arrayType", array == null ? null : toJavaQualifiedType(array.name(), array.namespace()),
-                    targetTypeTag, target.typeName());
+                            "$interop:T.getStructArrayFrom(" + identifier + ", (int) " + size + ", $" + targetTypeTag + ":T.class, ")
+                    .add(target.constructorName())
+                    .add(", $" + targetTypeTag + ":T.getMemoryLayout())",
+                            "interop", ClassNames.INTEROP,
+                            "arrayType", array == null ? null : toJavaQualifiedType(array.name(), array.namespace()),
+                            targetTypeTag, target.typeName());
 
         if (target == null)
             throw new IllegalStateException("Target is null for type " + type);
 
         return PartialStatement.of(
-                "$interop:T.getProxyArrayFrom(" + identifier + ", (int) " + size + ", $" + targetTypeTag + ":T.class, ").add(target.constructorName()).add(")",
-                "interop", ClassNames.INTEROP,
-                "arrayType", array == null ? null : toJavaQualifiedType(array.name(), array.namespace()),
-                targetTypeTag, target.typeName());
+                        "$interop:T.getProxyArrayFrom(" + identifier + ", (int) " + size + ", $" + targetTypeTag + ":T.class, ")
+                .add(target.constructorName())
+                .add(")",
+                        "interop", ClassNames.INTEROP,
+                        "arrayType", array == null ? null : toJavaQualifiedType(array.name(), array.namespace()),
+                        targetTypeTag, target.typeName());
     }
 
     PartialStatement getGTypeDeclaration() {
         if (array != null) {
             if (array.anyType() instanceof Type arrayType
                     && "utf8".equals(arrayType.name()))
-                return PartialStatement.of("$types:T.STRV", "types", ClassNames.TYPES);
+                return PartialStatement.of("$types:T.STRV",
+                        "types", ClassNames.TYPES);
 
             // Other array types are not supported yet, but could be added here
-            return PartialStatement.of("$types:T.BOXED", "types", ClassNames.TYPES);
+            return PartialStatement.of("$types:T.POINTER /* unsupported */",
+                    "types", ClassNames.TYPES);
         }
-        if (type == null)
-            return PartialStatement.of("$types:T.BOXED", "types", ClassNames.TYPES);
 
-        if (type.isPrimitive()) {
+        if (type == null)
+            throw new IllegalStateException("Expected type or array");
+
+        if (type.isPrimitive())
             return PartialStatement.of("$types:T." + switch(type.cType()) {
                 case "gboolean" -> "BOOLEAN";
                 case "gchar", "gint8" -> "CHAR";
@@ -574,15 +578,14 @@ class TypedValueGenerator {
                 case "gulong" -> "ULONG";
                 case "gint64" -> "INT64";
                 case "guint64" -> "UINT64";
-                case "gpointer", "gconstpointer", "gssize", "gsize", "goffset",
-                     "gintptr", "guintptr" -> "POINTER";
+                case "gpointer", "gconstpointer", "gssize", "gsize", "goffset", "gintptr", "guintptr" -> "POINTER";
                 case "gdouble" -> "DOUBLE";
                 case "gfloat" -> "FLOAT";
                 case "none" -> "NONE";
                 case "utf8", "filename" -> "STRING";
                 default -> throw new IllegalStateException("Unexpected type: " + type.cType());
             }, "types", ClassNames.TYPES);
-        }
+
         if (type.isString())
             return PartialStatement.of("$types:T.STRING", "types", ClassNames.TYPES);
 
@@ -592,9 +595,7 @@ class TypedValueGenerator {
         if (type.typeName().equals(ClassNames.GOBJECT))
             return PartialStatement.of("$types:T.OBJECT", "types", ClassNames.TYPES);
 
-        RegisteredType rt = (target instanceof Alias a && (!a.type().isPrimitive()))
-                ? a.type().get()
-                : target;
+        RegisteredType rt = target instanceof Alias a ? a.lookup() : target;
 
         if (rt != null) {
             if (rt instanceof Class cls && cls.isInstanceOf("GObject", "ParamSpec"))
@@ -616,13 +617,10 @@ class TypedValueGenerator {
         return PartialStatement.of("$types:T.POINTER", "types", ClassNames.TYPES);
     }
 
-    PartialStatement getValueSetter(PartialStatement gTypeDeclaration,
-                                    String payloadIdentifier) {
+    PartialStatement getValueSetter(PartialStatement gTypeDeclaration, String payloadIdentifier) {
         // First, check for fundamental classes with their own GValue setters
         if (type != null) {
-            RegisteredType rt = target instanceof Alias a
-                    ? a.type().get()
-                    : target;
+            RegisteredType rt = target instanceof Alias a ? a.lookup() : target;
 
             if (rt instanceof Class cls && cls.setValueFunc() != null) {
                 var setter = cls.namespace().functions().stream()
@@ -633,7 +631,8 @@ class TypedValueGenerator {
                     Function function = setter.get();
                     String setValueFunc = toJavaIdentifier(function.name());
                     String globalClassTag = uncapitalize(rt.namespace().globalClassName());
-                    return PartialStatement.of("$" + globalClassTag + ":T." + setValueFunc + "(_value, " + payloadIdentifier + ")",
+                    return PartialStatement.of(
+                            "$" + globalClassTag + ":T." + setValueFunc + "(_value, " + payloadIdentifier + ")",
                             globalClassTag,
                             toJavaQualifiedType(rt.namespace().globalClassName(), rt.namespace()));
                 }
@@ -686,35 +685,25 @@ class TypedValueGenerator {
     FieldSpec generateConstantDeclaration() {
         final String value = ((Constant) v).value();
         try {
-            var builder = FieldSpec.builder(
-                    getType(true),
-                    toJavaConstant(v.name()),
-                    Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL
-            );
+            var builder = FieldSpec.builder(getType(true), toJavaConstant(v.name()),
+                    Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL);
 
             if (v.infoElements().doc() != null)
-                builder.addJavadoc(
-                        new DocGenerator(v.infoElements().doc()).generate());
+                builder.addJavadoc(new DocGenerator(v.infoElements().doc()).generate());
 
-            if (target instanceof Alias a && a.type().isPrimitive())
-                builder.initializer("new $T($L)",
-                        a.typeName(),
-                        literal(a.type().typeName(), value));
+            if (target instanceof Alias a && a.isValueWrapper())
+                builder.initializer("new $T($L)", a.typeName(), literal(a.anyType().typeName(), value));
             else if (target instanceof FlaggedType)
-                builder.initializer(
-                        marshalNativeToJava(literal(TypeName.INT, value), false)
-                                .toCodeBlock());
+                builder.initializer(marshalNativeToJava(literal(TypeName.INT, value), false).toCodeBlock());
             else
-                builder.initializer(
-                        literal(type.typeName(), value).replace("$", "$$"));
+                builder.initializer(literal(type.typeName(), value).replace("$", "$$"));
 
             return builder.build();
 
         } catch (NumberFormatException nfe) {
             // Do not write anything
             System.out.printf("Skipping <constant name=\"%s\" value=\"%s\">: Value not allowed%n",
-                    v.name(),
-                    value);
+                    v.name(), value);
             return null;
         }
     }

--- a/generator/src/main/java/io/github/jwharm/javagi/gir/Array.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/gir/Array.java
@@ -83,7 +83,7 @@ public final class Array extends GirElement implements AnyType {
             if (lp.anyType() instanceof Type type) {
                 if (type.isPointer() || lp.isOutParameter())
                     return name + ".get().intValue()";
-                if (type.get() instanceof Alias a && a.type().isPrimitive())
+                if (type.lookup() instanceof Alias a && a.isValueWrapper())
                     return name + ".getValue()";
             }
             return name;

--- a/generator/src/main/java/io/github/jwharm/javagi/gir/Array.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/gir/Array.java
@@ -70,9 +70,10 @@ public final class Array extends GirElement implements AnyType {
     }
 
     public boolean unknownSize() {
-        return fixedSize() <= 0 && !zeroTerminated() && length() == null;
+        return !"1".equals(attr("fixed-size"))
+                && !"1".equals(attr("zero-terminated"))
+                && attr("length") == null;
     }
-
     public String sizeExpression(boolean upcall) {
         if (attr("fixed-size") != null) return attr("fixed-size");
         TypedValue length = length();

--- a/generator/src/main/java/io/github/jwharm/javagi/gir/Boxed.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/gir/Boxed.java
@@ -63,7 +63,7 @@ public final class Boxed extends Multiplatform implements StandardLayoutType, Fi
         var tag = typeTag();
         return PartialStatement.of("(_b -> $gobjects:T.boxedFree($" + tag + ":T.getType(), _b == null ? $memorySegment:T.NULL : _b.handle()))",
                 tag, typeName(),
-                "gobjects", ClassNames.GOBJECTS,
+                "gobjects", ClassNames.G_OBJECTS,
                 "memorySegment", MemorySegment.class);
     }
 

--- a/generator/src/main/java/io/github/jwharm/javagi/gir/Boxed.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/gir/Boxed.java
@@ -23,13 +23,14 @@ import io.github.jwharm.javagi.configuration.ClassNames;
 import io.github.jwharm.javagi.util.PartialStatement;
 
 import static io.github.jwharm.javagi.util.CollectionUtils.*;
+import static java.util.Collections.emptyList;
 
 import java.lang.foreign.MemorySegment;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-public final class Boxed extends Multiplatform implements StandardLayoutType {
+public final class Boxed extends Multiplatform implements StandardLayoutType, FieldContainer {
 
     public Boxed(Map<String, String> attributes,
                  List<Node> children,
@@ -64,6 +65,16 @@ public final class Boxed extends Multiplatform implements StandardLayoutType {
                 tag, typeName(),
                 "gobjects", ClassNames.GOBJECTS,
                 "memorySegment", MemorySegment.class);
+    }
+
+    @Override
+    public List<Field> fields() {
+        return emptyList();
+    }
+
+    @Override
+    public boolean opaque() {
+        return true;
     }
 
     @Override

--- a/generator/src/main/java/io/github/jwharm/javagi/gir/Class.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/gir/Class.java
@@ -78,7 +78,7 @@ public final class Class extends Multiplatform
             return true;
 
         for (var impl : implements_())
-            if (impl.get().generic())
+            if (impl.lookup().generic())
                 return true;
 
         return false;
@@ -88,12 +88,8 @@ public final class Class extends Multiplatform
         return attrBool("java-gi-auto-closeable", false);
     }
 
-    public boolean isOpaque() {
-        return fields().isEmpty() && unions().isEmpty();
-    }
-
     public Class parentClass() {
-        return (Class) TypeReference.get(namespace(), attr("parent"));
+        return (Class) TypeReference.lookup(namespace(), attr("parent"));
     }
 
     public boolean isInstanceOf(String ns, String name) {
@@ -107,7 +103,11 @@ public final class Class extends Multiplatform
 
     public Record typeStruct() {
         String typeStruct = attr("glib:type-struct");
-        return (Record) TypeReference.get(namespace(), typeStruct);
+        return (Record) TypeReference.lookup(namespace(), typeStruct);
+    }
+
+    public boolean opaque() {
+        return fields().isEmpty() && records().isEmpty() && unions().isEmpty();
     }
 
     public Method refFunc() {

--- a/generator/src/main/java/io/github/jwharm/javagi/gir/FieldContainer.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/gir/FieldContainer.java
@@ -23,9 +23,13 @@ import java.util.List;
 
 public sealed interface FieldContainer
         extends RegisteredType
-        permits Class, Interface, Record, Union {
+        permits Class, Interface, Boxed, Record, Union {
 
     List<Field> fields();
+
+    default boolean opaque() {
+        return false;
+    }
 
     default Field getAtIndex(int index) {
         return index == -1 ? null : fields().get(index);
@@ -42,8 +46,8 @@ public sealed interface FieldContainer
         for (Field field : fields())
             if (field.anyType() instanceof Type type
                     && !type.isPointer()
-                    && type.get() instanceof Class cls
-                    && (cls.isOpaque() || cls.hasOpaqueStructFields()))
+                    && type.lookup() instanceof FieldContainer fc
+                    && (fc.opaque() || fc.hasOpaqueStructFields()))
                 return true;
         return false;
     }

--- a/generator/src/main/java/io/github/jwharm/javagi/gir/Interface.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/gir/Interface.java
@@ -19,9 +19,6 @@
 
 package io.github.jwharm.javagi.gir;
 
-import com.squareup.javapoet.ParameterizedTypeName;
-import com.squareup.javapoet.TypeName;
-import io.github.jwharm.javagi.configuration.ClassNames;
 import io.github.jwharm.javagi.util.PartialStatement;
 
 import com.squareup.javapoet.ClassName;
@@ -82,7 +79,7 @@ public final class Interface extends Multiplatform
             return true;
 
         for (var prereq : prerequisites())
-            if (prereq.get() instanceof Interface i && i.generic())
+            if (prereq.lookup() instanceof Interface i && i.generic())
                 return true;
 
         return false;
@@ -100,14 +97,14 @@ public final class Interface extends Multiplatform
      */
     public Class prerequisiteBaseClass() {
         for (var prerequisite : prerequisites())
-            if (prerequisite.get() instanceof Class c)
+            if (prerequisite.lookup() instanceof Class c)
                 return c;
-        return (Class) TypeReference.get(namespace(), "GObject.Object");
+        return (Class) TypeReference.lookup(namespace(), "GObject.Object");
     }
 
     public Record typeStruct() {
         String typeStruct = attr("glib:type-struct");
-        return (Record) TypeReference.get(namespace(), typeStruct);
+        return (Record) TypeReference.lookup(namespace(), typeStruct);
     }
 
     public boolean hasProperties() {

--- a/generator/src/main/java/io/github/jwharm/javagi/gir/Parameter.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/gir/Parameter.java
@@ -47,8 +47,8 @@ public final class Parameter extends GirElement implements TypedValue {
                             || (type.cType()) != null
                                 && type.cType().endsWith("gsize")))
                         && (!type.isProxy())
-                        && (!(type.get() instanceof Alias a
-                                && a.type().isPrimitive())));
+                        && (!(type.lookup() instanceof Alias a
+                                && a.isValueWrapper())));
     }
 
     public boolean isUserDataParameter() {
@@ -62,7 +62,7 @@ public final class Parameter extends GirElement implements TypedValue {
                 && List.of("gpointer", "gconstpointer").contains(t.cType())) {
             return parent().parameters().stream().anyMatch(p ->
                     p.anyType() instanceof Type type
-                            && type.get() instanceof Callback
+                            && type.lookup() instanceof Callback
                             && p.closure() == this);
         }
         return false;
@@ -71,7 +71,7 @@ public final class Parameter extends GirElement implements TypedValue {
     public boolean isUserDataParameterForDestroyNotify() {
         return parent().parameters().stream().anyMatch(p ->
                 p.anyType() instanceof Type type
-                        && type.get() instanceof Callback
+                        && type.lookup() instanceof Callback
                         && p.scope() == Scope.NOTIFIED
                         && p.closure() == this
                         && p.destroy() != null);
@@ -111,13 +111,13 @@ public final class Parameter extends GirElement implements TypedValue {
             return true;
 
         Type type = (Type) anyType();
-        RegisteredType target = type.get();
+        RegisteredType target = type.lookup();
 
         if (target instanceof Callback)
             return true;
 
         return type.isPointer()
-                && target instanceof Alias a && a.type().isPrimitive();
+                && target instanceof Alias a && a.isValueWrapper();
     }
 
     public boolean isLastParameter() {

--- a/generator/src/main/java/io/github/jwharm/javagi/gir/Record.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/gir/Record.java
@@ -105,16 +105,15 @@ public final class Record extends Multiplatform
         return attrBool("java-gi-generic", false);
     }
 
-    public boolean isOpaque() {
-        return fields().isEmpty() && unions().isEmpty();
-    }
-
     public boolean disguised() {
         return attrBool("disguised", false);
     }
 
     public boolean opaque() {
-        return attrBool("opaque", false);
+        if (attributes().containsKey("opaque"))
+            return attrBool("opaque", false);
+        else
+            return fields().isEmpty() && unions().isEmpty();
     }
 
     public boolean pointer() {
@@ -126,8 +125,7 @@ public final class Record extends Multiplatform
     }
 
     public RegisteredType isGTypeStructFor() {
-        Namespace ns = namespace();
-        return TypeReference.get(ns, attr("glib:is-gtype-struct-for"));
+        return TypeReference.lookup(namespace(), attr("glib:is-gtype-struct-for"));
     }
 
     @Override

--- a/generator/src/main/java/io/github/jwharm/javagi/gir/Record.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/gir/Record.java
@@ -58,7 +58,7 @@ public final class Record extends Multiplatform
         if ("g_boxed_free".equals(freeFunc.callableAttrs().cIdentifier()))
             return PartialStatement.of("(_b -> $gobjects:T.boxedFree($" + tag + ":T.getType(), _b == null ? $memorySegment:T.NULL : _b.handle()))",
                     tag, typeName(),
-                    "gobjects", ClassNames.GOBJECTS,
+                    "gobjects", ClassNames.G_OBJECTS,
                     "memorySegment", MemorySegment.class);
 
         return PartialStatement.of("$" + tag + ":T::$freeFunc:L",

--- a/generator/src/main/java/io/github/jwharm/javagi/gir/RegisteredType.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/gir/RegisteredType.java
@@ -60,7 +60,7 @@ public sealed interface RegisteredType
     }
 
     default PartialStatement destructorName() {
-        return PartialStatement.of("$glib:T::free", "glib", ClassNames.GLIB);
+        return PartialStatement.of("$glib:T::free", "glib", ClassNames.G_LIB);
     }
 
     /** Return true if this class is GObject or is derived from GObject */

--- a/generator/src/main/java/io/github/jwharm/javagi/gir/RegisteredType.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/gir/RegisteredType.java
@@ -69,7 +69,7 @@ public sealed interface RegisteredType
             case Class c -> c.isInstanceOf("GObject", "Object");
             case Interface _ -> true; // Requires a runtime instanceof check
             case Alias a -> {
-                var target = a.type().get();
+                var target = a.lookup();
                 yield target != null && target.checkIsGObject();
             }
             default -> false;

--- a/generator/src/main/java/io/github/jwharm/javagi/gir/ReturnValue.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/gir/ReturnValue.java
@@ -42,7 +42,7 @@ public final class ReturnValue extends GirElement implements TypedValue {
         return switch(anyType()) {
             case Array _ -> true;
             case Type type -> List.of(Scope.CALL, Scope.ASYNC).contains(scope())
-                    && type.get() instanceof Callback;
+                    && type.lookup() instanceof Callback;
         };
     }
 

--- a/generator/src/main/java/io/github/jwharm/javagi/gir/Type.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/gir/Type.java
@@ -77,7 +77,7 @@ public final class Type extends GirElement implements AnyType, TypeReference {
     }
 
     private TypeName genericTypeName() {
-        var target = get();
+        var target = lookup();
         var rawType = toJavaQualifiedType(target.name(), target.namespace());
         var elements = new TypeName[anyTypes().size()];
         int i = 0;
@@ -133,25 +133,25 @@ public final class Type extends GirElement implements AnyType, TypeReference {
         if (cType() != null && cType().endsWith("**"))
             return false;
 
-        return switch(get()) {
-            case Alias a -> a.type().isProxy();
+        return switch(lookup()) {
+            case Alias a -> a.isProxy();
             case Class _, Interface _, Record _, Union _ -> true;
             case null, default -> false;
         };
     }
 
     public boolean checkIsGObject() {
-        RegisteredType target = get();
+        RegisteredType target = lookup();
         return target != null && target.checkIsGObject();
     }
 
     public boolean checkIsGList() {
-        RegisteredType target = get();
+        RegisteredType target = lookup();
         return target != null && target.checkIsGList();
     }
 
     public boolean checkIsGHashTable() {
-        RegisteredType target = get();
+        RegisteredType target = lookup();
         return target != null && target.checkIsGHashTable();
     }
 
@@ -183,7 +183,7 @@ public final class Type extends GirElement implements AnyType, TypeReference {
         if ("String".equals(javaBaseType))
             return "string";
 
-        RegisteredType target = get();
+        RegisteredType target = lookup();
         return target == null ? null : target.typeTag();
     }
 

--- a/generator/src/main/java/io/github/jwharm/javagi/gir/TypedValue.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/gir/TypedValue.java
@@ -49,9 +49,9 @@ public sealed interface TypedValue
 
     default boolean isBitfield() {
         if (anyType() instanceof Type type && (!type.isPrimitive())) {
-            RegisteredType target = type.get();
+            RegisteredType target = type.lookup();
             if (target instanceof Alias alias)
-                target = alias.type().get();
+                target = alias.lookup();
             return target instanceof Bitfield;
         }
         return false;

--- a/generator/src/main/java/io/github/jwharm/javagi/gir/Union.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/gir/Union.java
@@ -50,7 +50,7 @@ public final class Union
         return this;
     }
 
-    public boolean isOpaque() {
+    public boolean opaque() {
         return fields().isEmpty() && records().isEmpty();
     }
 

--- a/generator/src/main/java/io/github/jwharm/javagi/patches/BasePatch.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/patches/BasePatch.java
@@ -110,6 +110,13 @@ public class BasePatch implements Patch {
             return m.withAttribute("shadows", null);
         }
 
+        /*
+         * Remove aliases for void. They are unusable for language bindings.
+         */
+        if (element instanceof Alias a
+                && a.anyType() instanceof Type t && t.isVoid())
+            return element.withAttribute("java-gi-skip", "1");
+
         return element;
     }
 

--- a/generator/src/main/java/io/github/jwharm/javagi/patches/BasePatch.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/patches/BasePatch.java
@@ -25,7 +25,7 @@ public class BasePatch implements Patch {
         if (element instanceof Record rec
                 && (! "GPrivate".equals(rec.cType()))
                 && rec.name() != null
-                && rec.name().endsWith("Private"))
+                && (rec.name().endsWith("Private") || rec.name().startsWith("_")))
             return element.withAttribute("java-gi-skip", "1");
 
         /*

--- a/generator/src/main/java/io/github/jwharm/javagi/patches/GLibPatch.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/patches/GLibPatch.java
@@ -27,6 +27,7 @@ import io.github.jwharm.javagi.util.Platform;
 import java.util.List;
 import java.util.Map;
 
+import static io.github.jwharm.javagi.util.CollectionUtils.listOfNonNull;
 import static java.util.Collections.emptyList;
 
 public class GLibPatch implements Patch {
@@ -123,7 +124,7 @@ public class GLibPatch implements Patch {
          */
         if (element instanceof Alias a && "Strv".equals(a.name())) {
             return new Alias(a.attributes(),
-                    List.of(a.infoElements().doc(),
+                    listOfNonNull(a.infoElements().doc(),
                             a.infoElements().sourcePosition(),
                             new Array(Map.of("zero-terminated", "1"),
                                         List.of(new Type(Map.of("name", "utf8"),

--- a/generator/src/main/java/io/github/jwharm/javagi/patches/GLibPatch.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/patches/GLibPatch.java
@@ -132,13 +132,13 @@ public class GLibPatch implements Patch {
         }
 
         /*
-         * GLib.HashTable, GLib.List and GLib.SList are not generated from the
-         * gir data. Java-GI provides custom HashTable, List and SList classes
-         * that implement java.util.Map or java.util.List, to make them easier
-         * to use from Java.
+         * GLib.ByteArray, GLib.HashTable, GLib.List and GLib.SList are not
+         * generated from the gir data. Java-GI provides custom ByteArray,
+         * HashTable, List and SList classes.
          */
         if (element instanceof Record r
-                && List.of("HashTable", "List", "SList").contains(r.name()))
+                && List.of("ByteArray", "HashTable", "List", "SList")
+                        .contains(r.name()))
             return r.withAttribute("java-gi-skip", "1");
 
         return element;

--- a/generator/src/main/java/io/github/jwharm/javagi/patches/GLibPatch.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/patches/GLibPatch.java
@@ -24,9 +24,10 @@ import io.github.jwharm.javagi.gir.Record;
 import io.github.jwharm.javagi.util.Patch;
 import io.github.jwharm.javagi.util.Platform;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+
+import static java.util.Collections.emptyList;
 
 public class GLibPatch implements Patch {
 
@@ -43,9 +44,8 @@ public class GLibPatch implements Patch {
              */
             var gtype = new Alias(
                     Map.of("name", "Type", "c:type", "GType"),
-                    List.of(new Type(Map.of("name", "gsize",
-                                            "c:type", "gsize"),
-                            Collections.emptyList())),
+                    List.of(new Type(Map.of("name", "gsize", "c:type", "gsize"),
+                                     emptyList())),
                     ns.platforms());
             ns = add(ns, gtype);
 
@@ -108,12 +108,27 @@ public class GLibPatch implements Patch {
             Parameter replacement = current.withChildren(
                     current.infoElements().doc(),
                     new Type(Map.of("name", "gpointer", "c:type", "gpointer"),
-                            Collections.emptyList()));
+                             emptyList()));
             return f.withChildren(
                     f.infoElements().doc(),
                     f.infoElements().sourcePosition(),
                     f.returnValue(),
                     f.parameters().withChildren(replacement));
+        }
+
+        /*
+         * GLib.Strv is an alias for a String[], but it is defined as a type
+         * with name="utf8" (though the c-type is "gchar**"). We change it to an
+         * array.
+         */
+        if (element instanceof Alias a && "Strv".equals(a.name())) {
+            return new Alias(a.attributes(),
+                    List.of(a.infoElements().doc(),
+                            a.infoElements().sourcePosition(),
+                            new Array(Map.of("zero-terminated", "1"),
+                                        List.of(new Type(Map.of("name", "utf8"),
+                                                         emptyList())))),
+                    a.platforms());
         }
 
         /*

--- a/generator/src/main/java/io/github/jwharm/javagi/patches/GdkPatch.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/patches/GdkPatch.java
@@ -1,0 +1,64 @@
+/* Java-GI - Java language bindings for GObject-Introspection-based libraries
+ * Copyright (C) 2022-2024 Jan-Willem Harmannij
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.github.jwharm.javagi.patches;
+
+import io.github.jwharm.javagi.gir.*;
+import io.github.jwharm.javagi.util.Patch;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Collections.emptyMap;
+
+public class GdkPatch implements Patch {
+    @Override
+    public GirElement patch(GirElement element, String namespace) {
+
+        if (!"Gdk".equals(namespace))
+            return element;
+
+        /*
+         * The GdkModifierType documentation states:
+         *   Note that GDK may add internal values to events which include
+         *   values outside of this enumeration. Your code should preserve and
+         *   ignore them.
+         *
+         * We preserve and ignore the internal flags in our Java EnumSet by
+         * adding placeholder "INTERNAL_n" flags for the missing ones.
+         */
+        if (element instanceof Bitfield bf
+                && "ModifierType".equals(bf.name())) {
+            var children = new ArrayList<>(bf.children());
+            Doc doc = new Doc(emptyMap(),
+                    "Internal flag. Your code should preserve and ignore this flag.");
+            for (int bit = 0; bit < 31; bit++) {
+                var value = Integer.toString(1 << bit);
+                if (bf.members().stream().noneMatch(m -> m.value().equals(value)))
+                    children.add(bit + 2, new Member(
+                            Map.of("name", "INTERNAL_" + bit, "value", value),
+                            List.of(doc)));
+            }
+            return element.withChildren(children);
+        }
+
+        return element;
+    }
+}

--- a/generator/src/main/java/io/github/jwharm/javagi/patches/GdkPatch.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/patches/GdkPatch.java
@@ -21,6 +21,7 @@ package io.github.jwharm.javagi.patches;
 
 import io.github.jwharm.javagi.gir.*;
 import io.github.jwharm.javagi.util.Patch;
+import io.github.jwharm.javagi.util.Platform;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -45,6 +46,7 @@ public class GdkPatch implements Patch {
          * adding placeholder "INTERNAL_n" flags for the missing ones.
          */
         if (element instanceof Bitfield bf
+                && bf.platforms() == Platform.ALL
                 && "ModifierType".equals(bf.name())) {
             var children = new ArrayList<>(bf.children());
             Doc doc = new Doc(emptyMap(),

--- a/generator/src/main/java/io/github/jwharm/javagi/patches/HarfBuzzPatch.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/patches/HarfBuzzPatch.java
@@ -73,7 +73,15 @@ public class HarfBuzzPatch implements Patch {
             /*
              * This constant has type "language_t" which cannot be instantiated.
              */
-            return remove(ns, Constant.class, "name", "LANGUAGE_INVALID");
+            ns = remove(ns, Constant.class, "name", "LANGUAGE_INVALID");
+
+            /*
+             * This function returns an array of "ot_name_entry_t" entries. The
+             * size of "ot_name_entry_t" is unknown because one of its fields
+             * has a disguised type ("language_t"), therefore the array contents
+             * cannot be read. Remove the function.
+             */
+            return remove(ns, Function.class, "name", "ot_name_list_names");
         }
 
         /*

--- a/generator/src/main/java/io/github/jwharm/javagi/util/Conversions.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/util/Conversions.java
@@ -25,6 +25,7 @@ import io.github.jwharm.javagi.configuration.ModuleInfo;
 import io.github.jwharm.javagi.gir.*;
 
 import java.lang.foreign.MemorySegment;
+import java.lang.reflect.Modifier;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -162,12 +163,19 @@ public class Conversions {
 
     /**
      * Overriding java.lang.Object methods is not allowed in default methods
-     * (in interfaces), so we append an underscore to those method names.
+     * (in interfaces), and overriding its final methods is not allowed in any
+     * case, so we append an underscore to those method names.
+     *
+     * @param  name the name of the method to check
+     * @param  all  whether to check against all Object methods (instead of
+     *              only the final methods).
+     * @return the method name, possibly renamed
      */
-    public static String replaceJavaObjectMethodNames(String name) {
+    public static String replaceJavaObjectMethodNames(String name, boolean all) {
         for (java.lang.reflect.Method m : Object.class.getMethods())
             if (m.getName().equals(name))
-                return name + "_";
+                if (all || Modifier.isFinal(m.getModifiers()))
+                    return name + "_";
 
         return name;
     }

--- a/generator/src/main/java/io/github/jwharm/javagi/util/Javadoc.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/util/Javadoc.java
@@ -328,7 +328,7 @@ public class Javadoc {
     // Replace #text with {@link text}
     private String convertTyperef(String ref) {
         String type = ref.substring(1);
-        RegisteredType rt = TypeReference.get(doc.namespace(), type);
+        RegisteredType rt = TypeReference.lookup(doc.namespace(), type);
         if (rt == null) {
             return "{@code " + ref.substring(1) + "}";
         } else {
@@ -539,7 +539,7 @@ public class Javadoc {
      * "{@link" tag, otherwise, generate a "{@code" tag.
      */
     private String checkLink(String ns, String type, String identifier) {
-        RegisteredType rt = TypeReference.get(getNamespace(ns), type);
+        RegisteredType rt = TypeReference.lookup(getNamespace(ns), type);
 
         if (rt == null)
             return "{@code ";

--- a/modules/gio/src/test/java/io/github/jwharm/javagi/test/gio/StrvArrayTest.java
+++ b/modules/gio/src/test/java/io/github/jwharm/javagi/test/gio/StrvArrayTest.java
@@ -18,16 +18,19 @@ public class StrvArrayTest {
         // DesktopAppInfo is only available on Linux
         assumeTrue("linux".equals(Platform.getRuntimePlatform()));
 
-        String[][] array = DesktopAppInfo.search("gnome");
+        // Unless there are absolutely no applications installed, searching
+        // for "e" should return a few usable results
+        String[][] array = DesktopAppInfo.search("e");
         assertNotNull(array);
-        String result = "";
         for (String[] inner : array) {
             assertNotNull(inner);
             for (String str : inner) {
-                if (str.contains("org.gnome"))
-                    result = str;
+                // Check for NULL
+                assertNotNull(str);
+
+                // Check for valid strings
+                assertTrue(str.endsWith(".desktop"));
             }
         }
-        assertNotEquals("", result);
     }
 }

--- a/modules/glib/src/main/java/io/github/jwharm/javagi/interop/Interop.java
+++ b/modules/glib/src/main/java/io/github/jwharm/javagi/interop/Interop.java
@@ -1281,12 +1281,13 @@ public class Interop {
 
     /**
      * Allocate and initialize an (optionally {@code NULL}-terminated) array of
-     * structs (from Proxy instances). The actual memory segments (not the
+     * structs (from Proxy instances). The actual struct contents (not the
      * pointers) are copied into the array.
      *
      * @param  array          array of Proxy instances
-     * @param  layout         the memory layout of the object type
-     * @param  zeroTerminated whether to add a {@code NULL} to the array
+     * @param  layout         the memory layout of the struct
+     * @param  zeroTerminated whether to terminate the array by a struct with
+     *                        all members being {@code NULL}
      * @param  arena          the allocator for memory allocation
      * @return the memory segment of the native array
      */
@@ -1312,7 +1313,8 @@ public class Interop {
         }
 
         if (zeroTerminated)
-            segment.set(ValueLayout.ADDRESS, length * size, NULL);
+            // The array is zero-terminated by a struct with all members being 0
+            segment.asSlice(length * size, size).fill((byte) 0);
 
         return segment;
     }

--- a/modules/glib/src/main/java/io/github/jwharm/javagi/interop/Interop.java
+++ b/modules/glib/src/main/java/io/github/jwharm/javagi/interop/Interop.java
@@ -1346,7 +1346,7 @@ public class Interop {
 
         if (zeroTerminated)
             // The array is zero-terminated by a struct with all members being 0
-            segment.asSlice(length * size, size).fill((byte) 0);
+            segment.asSlice(array.length * size, size).fill((byte) 0);
 
         return segment;
     }

--- a/modules/glib/src/main/java/io/github/jwharm/javagi/interop/Interop.java
+++ b/modules/glib/src/main/java/io/github/jwharm/javagi/interop/Interop.java
@@ -1108,6 +1108,36 @@ public class Interop {
     }
 
     /**
+     * Allocate and initialize an (optionally {@code NULL}-terminated) array of
+     * arrays of strings (a Strv-array).
+     *
+     * @param  strvs          the array of String arrays
+     * @param  zeroTerminated whether to add a {@code NULL} to the array. The
+     *                        embedded arrays are always
+     *                        {@code NULL}-terminated.
+     * @param  arena          the segment allocator for memory allocation
+     * @return the memory segment of the native array
+     */
+    public static MemorySegment allocateNativeArray(String[][] strvs,
+                                                    boolean zeroTerminated,
+                                                    Arena arena) {
+
+        int length = zeroTerminated ? strvs.length + 1 : strvs.length;
+        var memorySegment = arena.allocate(ValueLayout.ADDRESS, length);
+
+        for (int i = 0; i < strvs.length; i++) {
+            var s = strvs[i] == null ? NULL
+                    : allocateNativeArray(strvs[i], true, arena);
+            memorySegment.setAtIndex(ValueLayout.ADDRESS, i, s);
+        }
+
+        if (zeroTerminated)
+            memorySegment.setAtIndex(ValueLayout.ADDRESS, strvs.length, NULL);
+
+        return memorySegment;
+    }
+
+    /**
      * Convert a boolean[] array into an int[] array, and calls
      * {@link #allocateNativeArray(int[], boolean, Arena)}.
      * Each boolean value "true" is converted 1, boolean value "false" to 0.

--- a/modules/glib/src/main/java/org/gnome/glib/ByteArray.java
+++ b/modules/glib/src/main/java/org/gnome/glib/ByteArray.java
@@ -1,0 +1,149 @@
+/* Java-GI - Java language bindings for GObject-Introspection-based libraries
+ * Copyright (C) 2022-2024 Jan-Willem Harmannij
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+package org.gnome.glib;
+
+import io.github.jwharm.javagi.base.ProxyInstance;
+import io.github.jwharm.javagi.interop.Interop;
+import io.github.jwharm.javagi.interop.MemoryCleaner;
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.VarHandle;
+
+import static org.gnome.glib.GLib.malloc;
+
+/**
+ * This class is used for internal purposes by Java-GI. Java-GI
+ * automatically marshals {@code GByteArray} instances from and to java
+ * {@code byte[]} primitives.
+ */
+public class ByteArray extends ProxyInstance {
+    static {
+        GLib.javagi$ensureInitialized();
+    }
+
+    /**
+     * Create a ByteArray proxy instance for the provided memory address.
+     *
+     * @param address the memory address of the native object
+     */
+    public ByteArray(MemorySegment address) {
+        super(Interop.reinterpret(address, getMemoryLayout().byteSize()));
+    }
+
+    /**
+     * Get the GType of the ByteArray class
+     *
+     * @return the GType
+     */
+    public static Type getType() {
+        return Interop.getType("g_byte_array_get_type");
+    }
+
+    /**
+     * The memory layout of the native struct.
+     * @return the memory layout
+     */
+    public static MemoryLayout getMemoryLayout() {
+        return MemoryLayout.structLayout(
+                ValueLayout.ADDRESS.withName("data"),
+                MemoryLayout.paddingLayout(3),
+                ValueLayout.JAVA_INT.withName("len")
+        ).withName("GByteArray");
+    }
+
+    /**
+     * Read the value of the field {@code len}.
+     *
+     * @return The value of the field {@code len}
+     */
+    public int readLen() {
+        return (int) MethodHandles.vh_len.get(handle(), 0);
+    }
+
+    /**
+     * Creates a new {@code GByteArray} with a reference count of 1.
+     */
+    public ByteArray() {
+        this(constructNew());
+        MemoryCleaner.takeOwnership(this);
+        MemoryCleaner.setFreeFunc(this, "g_byte_array_unref");
+    }
+
+    private static MemorySegment constructNew() {
+        MemorySegment _result;
+        try {
+            _result = (MemorySegment) MethodHandles.g_byte_array_new.invokeExact();
+        } catch (Throwable _err) {
+            throw new AssertionError(_err);
+        }
+        return _result;
+    }
+
+    /**
+     * Creates a byte array containing the {@code data}.
+     *
+     * @param data byte data for the array
+     * @return a new {@code GByteArray}
+     */
+    public static ByteArray take(byte[] data) {
+        var instance = takeUnowned(data);
+        if (instance != null) {
+            MemoryCleaner.takeOwnership(instance);
+            MemoryCleaner.setFreeFunc(instance, "g_byte_array_unref");
+        }
+        return instance;
+    }
+
+    /**
+     * Creates a byte array containing the {@code data}. The allocated native
+     * memory is not freed automatically by Java-GI.
+     *
+     * @param data byte data for the array
+     * @return a new {@code GByteArray}
+     */
+    public static ByteArray takeUnowned(byte[] data) {
+        if (data == null)
+            return new ByteArray();
+
+        MemorySegment result;
+        try {
+            MemorySegment segment = malloc(data.length);
+            segment.asByteBuffer().put(data, 0, data.length);
+            result = (MemorySegment) MethodHandles.g_byte_array_new_take.invokeExact(segment, data.length);
+        } catch (Throwable _err) {
+            throw new AssertionError(_err);
+        }
+        return MemorySegment.NULL.equals(result) ? null : new ByteArray(result);
+    }
+
+    private static final class MethodHandles {
+        static final VarHandle vh_len = getMemoryLayout().varHandle(
+                MemoryLayout.PathElement.groupElement("len"));
+
+        static final MethodHandle g_byte_array_new = Interop.downcallHandle("g_byte_array_new",
+                FunctionDescriptor.of(ValueLayout.ADDRESS), false);
+
+        static final MethodHandle g_byte_array_new_take = Interop.downcallHandle(
+                "g_byte_array_new_take", FunctionDescriptor.of(ValueLayout.ADDRESS,
+                        ValueLayout.ADDRESS, ValueLayout.JAVA_LONG), false);
+    }
+}

--- a/modules/glib/src/test/java/io/github/jwharm/javagi/interop/ArrayTest.java
+++ b/modules/glib/src/test/java/io/github/jwharm/javagi/interop/ArrayTest.java
@@ -1,6 +1,5 @@
-package io.github.jwharm.javagi.test.glib;
+package io.github.jwharm.javagi.interop;
 
-import io.github.jwharm.javagi.interop.Interop;
 import org.gnome.glib.GLib;
 import org.gnome.glib.HashTable;
 import org.junit.jupiter.api.Test;

--- a/modules/glib/src/test/java/io/github/jwharm/javagi/interop/ArrayTest.java
+++ b/modules/glib/src/test/java/io/github/jwharm/javagi/interop/ArrayTest.java
@@ -16,7 +16,7 @@ public class ArrayTest {
     @Test
     void testArray() {
         try (var arena = Arena.ofConfined()) {
-            HashTable table = HashTable.new_(GLib::strHash, GLib::strEqual);
+            var table = HashTable.new_(GLib::strHash, GLib::strEqual);
             for (int i = 0; i < 3; i++)
                 table.insert(
                         Interop.allocateNativeString("key" + i, arena),

--- a/modules/glib/src/test/java/io/github/jwharm/javagi/interop/FlagsTest.java
+++ b/modules/glib/src/test/java/io/github/jwharm/javagi/interop/FlagsTest.java
@@ -1,6 +1,5 @@
-package io.github.jwharm.javagi.test.glib;
+package io.github.jwharm.javagi.interop;
 
-import io.github.jwharm.javagi.interop.Interop;
 import org.gnome.glib.AsciiType;
 import org.junit.jupiter.api.Test;
 

--- a/modules/glib/src/test/java/io/github/jwharm/javagi/interop/HashTableTest.java
+++ b/modules/glib/src/test/java/io/github/jwharm/javagi/interop/HashTableTest.java
@@ -1,4 +1,4 @@
-package io.github.jwharm.javagi.test.glib;
+package io.github.jwharm.javagi.interop;
 
 import io.github.jwharm.javagi.base.GErrorException;
 import org.gnome.glib.HashTable;

--- a/modules/glib/src/test/java/io/github/jwharm/javagi/interop/MarshalTest.java
+++ b/modules/glib/src/test/java/io/github/jwharm/javagi/interop/MarshalTest.java
@@ -1,7 +1,6 @@
-package io.github.jwharm.javagi.test.glib;
+package io.github.jwharm.javagi.interop;
 
 import io.github.jwharm.javagi.base.Proxy;
-import io.github.jwharm.javagi.interop.Interop;
 import org.gnome.glib.GString;
 import org.gnome.glib.OptionFlags;
 import org.gnome.glib.Variant;

--- a/modules/glib/src/test/java/io/github/jwharm/javagi/interop/VarargsTest.java
+++ b/modules/glib/src/test/java/io/github/jwharm/javagi/interop/VarargsTest.java
@@ -1,4 +1,4 @@
-package io.github.jwharm.javagi.test.glib;
+package io.github.jwharm.javagi.interop;
 
 import org.gnome.glib.GLib;
 import org.junit.jupiter.api.Test;

--- a/modules/gobject/src/main/java/io/github/jwharm/javagi/gobject/InstanceCache.java
+++ b/modules/gobject/src/main/java/io/github/jwharm/javagi/gobject/InstanceCache.java
@@ -130,7 +130,7 @@ public class InstanceCache {
      * @param  address get the Proxy object for this address from the cache
      * @return the instance (if found), or null (if not found)
      */
-    private static Proxy get(MemorySegment address) {
+    private static Proxy lookup(MemorySegment address) {
         
         // Null check on the memory address
         if (address == null || address.equals(MemorySegment.NULL))
@@ -158,11 +158,11 @@ public class InstanceCache {
                                    boolean cache) {
         
         // Get instance from the cache
-        Proxy instance = get(address);
+        Proxy instance = lookup(address);
         if (instance != null)
             return instance;
 
-        // Get constructor from the type registry
+        // Read gclass->gtype and get constructor from the type registry
         Function<MemorySegment, ? extends Proxy> ctor =
                 TypeCache.getConstructor(address, fallback);
         if (ctor == null)
@@ -219,8 +219,7 @@ public class InstanceCache {
             return fallback.apply(address);
 
         // Get the Java proxy TypeClass definition
-        TypeInstance typeInstance = (TypeInstance) newInstance;
-        Class<? extends TypeInstance> instanceClass = typeInstance.getClass();
+        Class<? extends Proxy> instanceClass = newInstance.getClass();
         Class<? extends TypeClass> typeClass = Types.getTypeClass(instanceClass);
         if (typeClass == null)
             return fallback.apply(address);
@@ -254,7 +253,7 @@ public class InstanceCache {
                             boolean cache) {
 
         // Get instance from the cache
-        Proxy instance = get(address);
+        Proxy instance = lookup(address);
         if (instance != null)
             return instance;
 

--- a/modules/gobject/src/main/java/io/github/jwharm/javagi/gobject/annotations/Flags.java
+++ b/modules/gobject/src/main/java/io/github/jwharm/javagi/gobject/annotations/Flags.java
@@ -1,0 +1,37 @@
+/* Java-GI - Java language bindings for GObject-Introspection-based libraries
+ * Copyright (C) 2022-2024 Jan-Willem Harmannij
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.github.jwharm.javagi.gobject.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import io.github.jwharm.javagi.gobject.types.Types;
+
+/**
+ * The {@code @Flags} annotation is used by {@link Types#register} to register
+ * a Java enum as a GObject Flags type. Flags types are like enumerations, but
+ * allow bitwise comparison of their values.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface Flags {
+}

--- a/modules/gobject/src/main/java/io/github/jwharm/javagi/gobject/annotations/RegisteredType.java
+++ b/modules/gobject/src/main/java/io/github/jwharm/javagi/gobject/annotations/RegisteredType.java
@@ -28,4 +28,5 @@ import java.lang.annotation.Target;
 @Target(ElementType.TYPE)
 public @interface RegisteredType {
     String name() default "";
+    Class<?>[] prerequisites() default {};
 }

--- a/modules/gobject/src/main/java/io/github/jwharm/javagi/gobject/types/Overrides.java
+++ b/modules/gobject/src/main/java/io/github/jwharm/javagi/gobject/types/Overrides.java
@@ -25,9 +25,7 @@ import io.github.jwharm.javagi.interop.InteropException;
 import org.gnome.glib.GLib;
 import org.gnome.glib.LogLevelFlags;
 import org.gnome.glib.Type;
-import org.gnome.gobject.GObject;
-import org.gnome.gobject.GObjects;
-import org.gnome.gobject.TypeInterface;
+import org.gnome.gobject.*;
 
 import java.lang.foreign.*;
 import java.lang.invoke.MethodHandle;
@@ -92,14 +90,10 @@ public class Overrides {
      * method overrides in the class virtual function table.
      *
      * @param  cls  the class that possibly declares method overrides
-     * @param  <T>  the class must extend {@link GObject}
-     * @param  <TC> the returned lambda expects a {@link GObject.ObjectClass}
-     *              parameter
      * @return a lambda to run during class initialization that will register
      *         the virtual functions
      */
-    public static <T extends GObject, TC extends GObject.ObjectClass>
-    Consumer<TC> overrideClassMethods(Class<T> cls) {
+    public static Consumer<TypeClass> overrideClassMethods(Class<?> cls) {
 
         Class<?> typeStruct = Types.getTypeClass(cls);
         if (typeStruct == null)
@@ -192,13 +186,13 @@ public class Overrides {
      *
      * @param  cls   the class that possibly declares method overrides
      * @param  iface the interface from which methods are implemented
-     * @param  <T>   the class must extend {@link GObject}
+     * @param  <T>   the class must extend {@link TypeInstance}
      * @param  <TI>  the returned lambda expects a {@link TypeInterface}
      *               parameter
      * @return a lambda to run during interface initialization that will
      *         register the virtual functions
      */
-    static <T extends GObject, TI extends TypeInterface>
+    static <T extends TypeInstance, TI extends TypeInterface>
     Consumer<TI> overrideInterfaceMethods(Class<T> cls, Class<?> iface) {
 
         // Lookup the memory address constructor for the TypeInterface

--- a/modules/gobject/src/main/java/io/github/jwharm/javagi/gobject/types/Properties.java
+++ b/modules/gobject/src/main/java/io/github/jwharm/javagi/gobject/types/Properties.java
@@ -50,13 +50,13 @@ import static io.github.jwharm.javagi.Constants.LOG_DOMAIN;
 public class Properties {
 
     /**
-     * Read the GType of the GParamSpec of a GObject property.
+     * Read the value type from the GParamSpec of a GObject property.
      *
      * @param  objectClass  the GObject typeclass that has a property installed
      *                      with the provided name
      * @param  propertyName the name of the property
-     * @return the GType of the GParamSpec of the GObject property, or null if
-     *         not found
+     * @return the value type of the GParamSpec of the GObject property, or null
+     *         if not found
      */
     public static Type readPropertyValueType(GObject.ObjectClass objectClass,
                                              String propertyName) {

--- a/modules/gobject/src/main/java/io/github/jwharm/javagi/gobject/types/Signals.java
+++ b/modules/gobject/src/main/java/io/github/jwharm/javagi/gobject/types/Signals.java
@@ -1,5 +1,5 @@
 /* Java-GI - Java language bindings for GObject-Introspection-based libraries
- * Copyright (C) 2022-2023 Jan-Willem Harmannij
+ * Copyright (C) 2022-2024 Jan-Willem Harmannij
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *

--- a/modules/gobject/src/main/java/io/github/jwharm/javagi/gobject/types/Signals.java
+++ b/modules/gobject/src/main/java/io/github/jwharm/javagi/gobject/types/Signals.java
@@ -166,13 +166,9 @@ public class Signals {
      * {@code g_signal_newv}) in the class initializer.
      *
      * @param cls  the class that possibly contains @Signal annotations
-     * @param <T>  the class must extend {@link org.gnome.gobject.GObject}
-     * @param <TC> the returned lambda expects a {@link GObject.ObjectClass}
-     *             parameter
      * @return a class initializer that registers the signals
      */
-    public static <T extends GObject, TC extends GObject.ObjectClass>
-    Consumer<TC> installSignals(Class<T> cls) {
+    public static Consumer<TypeClass> installSignals(Class<?> cls) {
 
         List<SignalDeclaration> signalDeclarations = new ArrayList<>();
         

--- a/modules/gobject/src/main/java/io/github/jwharm/javagi/gobject/types/TypeCache.java
+++ b/modules/gobject/src/main/java/io/github/jwharm/javagi/gobject/types/TypeCache.java
@@ -56,8 +56,9 @@ public class TypeCache {
      * @return         the constructor, or {@code null} if address is
      *                 {@code null} or a null-pointer
      */
-    public static Function<MemorySegment, ? extends Proxy> getConstructor(MemorySegment address,
-                                                                          Function<MemorySegment, ? extends Proxy> fallback) {
+    public static Function<MemorySegment, ? extends Proxy>
+    getConstructor(MemorySegment address,
+                   Function<MemorySegment, ? extends Proxy> fallback) {
         // Null check on the memory address
         if (address == null || address.equals(MemorySegment.NULL)) return null;
 

--- a/modules/gobject/src/main/java/io/github/jwharm/javagi/gobject/types/Types.java
+++ b/modules/gobject/src/main/java/io/github/jwharm/javagi/gobject/types/Types.java
@@ -1,5 +1,5 @@
 /* Java-GI - Java language bindings for GObject-Introspection-based libraries
- * Copyright (C) 2022-2023 Jan-Willem Harmannij
+ * Copyright (C) 2022-2024 Jan-Willem Harmannij
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *
@@ -1165,7 +1165,7 @@ public class Types {
      * @return whether this is a class that extends GObject or an interface
      *         that has GObject as a prerequisite
      */
-    private static boolean isGObjectBased(Class<?> cls) {
+    public static boolean isGObjectBased(Class<?> cls) {
         // Class that extends GObject
         if (GObject.class.isAssignableFrom(cls))
             return true;
@@ -1237,19 +1237,13 @@ public class Types {
             var overridesInit = Overrides.overrideClassMethods(cls);
 
             // GObject class initializers for properties and signals
-            Consumer<GObject.ObjectClass> propertiesInit;
+            Consumer<TypeClass> propertiesInit;
             Consumer<TypeClass> signalsInit;
             if (isGObjectBased(cls)) {
                 signalsInit = Signals.installSignals(cls);
+                propertiesInit = Properties.installProperties(cls);
             } else {
                 signalsInit = null;
-            }
-
-            if (GObject.class.isAssignableFrom(cls)) {
-                @SuppressWarnings("unchecked") // checked by isAssignableFrom()
-                var gobject = (Class<GObject>) cls;
-                propertiesInit = Properties.installProperties(gobject);
-            } else {
                 propertiesInit = null;
             }
 

--- a/modules/gobject/src/test/java/io/github/jwharm/javagi/test/gobject/CustomEnumTest.java
+++ b/modules/gobject/src/test/java/io/github/jwharm/javagi/test/gobject/CustomEnumTest.java
@@ -1,0 +1,70 @@
+package io.github.jwharm.javagi.test.gobject;
+
+import io.github.jwharm.javagi.gobject.annotations.Flags;
+import io.github.jwharm.javagi.gobject.types.Types;
+import org.gnome.glib.Type;
+import org.gnome.gobject.GObjects;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Test custom registered enum and flags types
+ */
+public class CustomEnumTest {
+
+    @Test
+    public void testCustomEnum() {
+        var foo = MyEnum.FOO;
+        var bar = MyEnum.BAR;
+        var baz = MyEnum.BAZ;
+
+        assertNotNull(foo);
+        assertNotNull(bar);
+        assertNotNull(baz);
+
+        assertEquals(foo.toString(), GObjects.enumToString(MyEnum.getType(), 0));
+        assertEquals(bar.toString(), GObjects.enumToString(MyEnum.getType(), 1));
+        assertEquals(baz.toString(), GObjects.enumToString(MyEnum.getType(), 2));
+    }
+
+    @Test
+    public void testCustomFlags() {
+        var foo = MyFlags.FOO;
+        var bar = MyFlags.BAR;
+        var baz = MyFlags.BAZ;
+
+        assertNotNull(foo);
+        assertNotNull(bar);
+        assertNotNull(baz);
+
+        assertEquals("FOO | BAR | BAZ",
+                     GObjects.flagsToString(MyFlags.getType(), 1|2|4));
+    }
+
+    public enum MyEnum {
+        FOO,
+        BAR,
+        BAZ;
+
+        private static final Type gtype = Types.register(MyEnum.class);
+
+        public static Type getType() {
+            return gtype;
+        }
+    }
+
+    @Flags
+    public enum MyFlags {
+        FOO,
+        BAR,
+        BAZ;
+
+        private static final Type gtype = Types.register(MyFlags.class);
+
+        public static Type getType() {
+            return gtype;
+        }
+    }
+}

--- a/modules/gobject/src/test/java/io/github/jwharm/javagi/test/gobject/CustomInterfaceTest.java
+++ b/modules/gobject/src/test/java/io/github/jwharm/javagi/test/gobject/CustomInterfaceTest.java
@@ -1,0 +1,124 @@
+/* Java-GI - Java language bindings for GObject-Introspection-based libraries
+ * Copyright (C) 2022-2023 Jan-Willem Harmannij
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.github.jwharm.javagi.test.gobject;
+
+import io.github.jwharm.javagi.base.Proxy;
+import io.github.jwharm.javagi.gobject.annotations.Property;
+import io.github.jwharm.javagi.gobject.annotations.RegisteredType;
+import io.github.jwharm.javagi.gobject.annotations.Signal;
+import io.github.jwharm.javagi.gobject.types.Types;
+import org.gnome.glib.Type;
+import org.gnome.gobject.GObject;
+import org.gnome.gobject.GObjects;
+import org.junit.jupiter.api.Test;
+
+import java.lang.foreign.MemorySegment;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.IntConsumer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test registering new GTypes for a Java class
+ */
+public class CustomInterfaceTest {
+
+    /**
+     * Check if the name of the  GType is correctly set
+     */
+    @Test
+    public void testCustomInterface() {
+        assertTrue(Types.IS_INTERFACE(TestInterface.gtype));
+        assertTrue(GObjects.typeIsA(TestObject.gtype, TestInterface.gtype));
+
+        var instance = GObject.newInstance(TestObject.gtype);
+        assertTrue(GObjects.typeCheckInstanceIsA(instance, TestInterface.gtype));
+    }
+
+    @Test
+    public void testComplexInterface() {
+        var instance = GObject.newInstance(TestObjectWithComplexInterface.gtype);
+        assertTrue(GObjects.typeCheckInstanceIsA(instance, TestInterfaceWithPropertiesAndSignals.gtype));
+
+        var result = new AtomicInteger(0);
+        instance.connect("number-changed", (TestInterfaceWithPropertiesAndSignals.NumberChanged) result::set);
+        instance.setProperty("number", 2);
+        assertEquals(2, result.get());
+    }
+
+    @RegisteredType(name="JavaGiTestInterface")
+    public interface TestInterface extends Proxy {
+        Type gtype = Types.register(TestInterface.class);
+
+        static Type getType() {
+            return gtype;
+        }
+    }
+
+    @RegisteredType(name="JavaGiTestObjectWithInterface")
+    public static class TestObject extends GObject implements TestInterface {
+        public static Type gtype = Types.register(TestObject.class);
+        public TestObject(MemorySegment address) {
+            super(address);
+        }
+    }
+
+    @RegisteredType(name="JavaGiTestInterfaceWithPropertiesAndSignals",
+                    prerequisites = {GObject.class})
+    public interface TestInterfaceWithPropertiesAndSignals extends Proxy {
+        Type gtype = Types.register(TestInterfaceWithPropertiesAndSignals.class);
+
+        @Property
+        int getNumber();
+
+        @Property
+        void setNumber(int number);
+
+        @Signal
+        interface NumberChanged extends IntConsumer {}
+
+        static Type getType() {
+            return gtype;
+        }
+    }
+
+    @RegisteredType(name="JavaGiTestObjectWithComplexInterface")
+    public static class TestObjectWithComplexInterface extends GObject
+            implements TestInterfaceWithPropertiesAndSignals {
+        public static Type gtype = Types.register(TestObjectWithComplexInterface.class);
+        public TestObjectWithComplexInterface(MemorySegment address) {
+            super(address);
+        }
+
+        private int number = 0;
+
+        @Override
+        public int getNumber() {
+            return number;
+        }
+
+        @Override
+        public void setNumber(int number) {
+            this.number = number;
+            emit("number-changed", number);
+        }
+    }
+}

--- a/modules/gobject/src/test/java/io/github/jwharm/javagi/test/gobject/CustomInterfaceTest.java
+++ b/modules/gobject/src/test/java/io/github/jwharm/javagi/test/gobject/CustomInterfaceTest.java
@@ -110,15 +110,19 @@ public class CustomInterfaceTest {
 
         private int number = 0;
 
-        @Override
+        @Override @Property
         public int getNumber() {
             return number;
         }
 
-        @Override
+        @Override @Property
         public void setNumber(int number) {
             this.number = number;
             emit("number-changed", number);
+        }
+
+        public static Type getType() {
+            return gtype;
         }
     }
 }

--- a/modules/gobject/src/test/java/io/github/jwharm/javagi/test/gobject/DerivedClassTest.java
+++ b/modules/gobject/src/test/java/io/github/jwharm/javagi/test/gobject/DerivedClassTest.java
@@ -46,7 +46,7 @@ public class DerivedClassTest {
      */
     @Test
     public void gtypeNameIsCorrect() {
-        assertEquals(GObjects.typeName(TestObject.gtype), "JavaGiTestObject");
+        assertEquals("JavaGiTestObject", GObjects.typeName(TestObject.gtype));
     }
 
     private static boolean classInitHasRun = false;

--- a/modules/gtk/src/main/java/io/github/jwharm/javagi/gtk/types/Types.java
+++ b/modules/gtk/src/main/java/io/github/jwharm/javagi/gtk/types/Types.java
@@ -21,9 +21,12 @@ package io.github.jwharm.javagi.gtk.types;
 
 import io.github.jwharm.javagi.gtk.annotations.GtkTemplate;
 
+import org.gnome.gio.Proxy;
 import org.gnome.glib.Type;
 import org.gnome.gobject.GObject;
+import org.gnome.gobject.TypeClass;
 import org.gnome.gobject.TypeFlags;
+import org.gnome.gobject.TypeInstance;
 import org.gnome.gtk.Widget;
 
 import java.lang.foreign.*;
@@ -42,20 +45,6 @@ import java.util.function.Function;
  */
 @Deprecated
 public class Types {
-
-    /**
-     * Get the {@code name} parameter of the {@code GtkTemplate} annotation, or
-     * if it is not defined, fallback to
-     * {@link io.github.jwharm.javagi.gobject.types.Types#getName(Class)}.
-     *
-     * @param  cls the class that is registered as a new GType
-     * @return the name
-     * @deprecated see {@link TemplateTypes#getTemplateName}
-     */
-    @Deprecated
-    public static String getTemplateName(Class<?> cls) {
-        return TemplateTypes.getTemplateName(cls);
-    }
 
     /**
      * This will call {@code TemplateTypes#registerTemplate(Class)} when
@@ -87,22 +76,17 @@ public class Types {
      * @param instanceInit   static instance initializer function
      * @param constructor    memory-address constructor
      * @param flags          type flags
-     * @param <T>            the instance initializer function must accept the
-     *                       result of the memory address constructor
-     * @param <TC>           the class initializer function must accept a
-     *                       parameter that is a subclass of TypeClass
      * @return the new GType
      * @deprecated see {@link TemplateTypes#register(Type, String, MemoryLayout, Consumer, MemoryLayout, Consumer, Function, Set)}
      */
     @Deprecated
-    public static <T extends GObject, TC extends GObject.ObjectClass>
-    Type register(Type parentType,
+    public static Type register(Type parentType,
                   String typeName,
                   MemoryLayout classLayout,
-                  Consumer<TC> classInit,
+                  Consumer<TypeClass> classInit,
                   MemoryLayout instanceLayout,
-                  Consumer<T> instanceInit,
-                  Function<MemorySegment, T> constructor,
+                  Consumer<TypeInstance> instanceInit,
+                  Function<MemorySegment, ? extends Proxy> constructor,
                   Set<TypeFlags> flags) {
         return TemplateTypes.register(
                 parentType, typeName, classLayout, classInit, instanceLayout,

--- a/modules/gtk/src/main/java/io/github/jwharm/javagi/gtk/util/BuilderJavaScope.java
+++ b/modules/gtk/src/main/java/io/github/jwharm/javagi/gtk/util/BuilderJavaScope.java
@@ -32,7 +32,6 @@ import org.gnome.gtk.*;
 import java.lang.foreign.MemorySegment;
 import java.lang.reflect.Method;
 import java.util.Set;
-import java.util.function.BooleanSupplier;
 
 import static io.github.jwharm.javagi.Constants.LOG_DOMAIN;
 
@@ -115,36 +114,7 @@ public final class BuilderJavaScope extends BuilderCScope
             // Find method with the right name
             Class<? extends GObject> cls = currentObject.getClass();
             Method method = getMethodForName(cls, function);
-
-            // Signal that returns boolean
-            if (method.getReturnType().equals(Boolean.TYPE)) {
-                return new JavaClosure((BooleanSupplier) () -> {
-                    try {
-                        return (boolean) method.invoke(currentObject);
-                    } catch (Exception e) {
-                        GLib.log(LOG_DOMAIN, LogLevelFlags.LEVEL_CRITICAL,
-                                "Cannot invoke method %s in class %s: %s\n",
-                                function,
-                                currentObject.getClass().getName(),
-                                e.getMessage());
-                        return false;
-                    }
-                });
-
-            // Signal that returns void
-            } else {
-                return new JavaClosure((Runnable) () -> {
-                    try {
-                        method.invoke(currentObject);
-                    } catch (Exception e) {
-                        GLib.log(LOG_DOMAIN, LogLevelFlags.LEVEL_CRITICAL,
-                                "Cannot invoke method %s in class %s: %s\n",
-                                function,
-                                currentObject.getClass().getName(),
-                                e.getMessage());
-                    }
-                });
-            }
+            return new JavaClosure(currentObject, method);
         } catch (NoSuchMethodException e) {
             GLib.log(LOG_DOMAIN, LogLevelFlags.LEVEL_CRITICAL,
                     "Cannot find method %s in class %s\n",

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.9.0"
 }
 
 rootProject.name = "java-gi"


### PR DESCRIPTION
Add support for registering Java interfaces and enums in the GObject type system.
The API didn't change, but it is now possible to use `Types.register(klazz)` where `klazz` is a Java interface or enum, and it will do what was expected.

Fixes #127
