### PR TITLE
Auto properties

### DIFF
--- a/modules/gio/src/main/java/io/github/jwharm/javagi/gio/ListIndexModel.java
+++ b/modules/gio/src/main/java/io/github/jwharm/javagi/gio/ListIndexModel.java
@@ -87,7 +87,7 @@ public class ListIndexModel extends GObject
      *
      * @return always returns the value of {@link ListIndex#gtype}
      */
-    @Property(name="item-type", constructOnly = true)
+    @Property(constructOnly = true)
     @Override
     public Type getItemType() {
         return ListIndex.gtype;
@@ -98,7 +98,8 @@ public class ListIndexModel extends GObject
      *
      * @param itemType ignored
      */
-    @Property(name="item-type")
+    @SuppressWarnings("unused")
+    @Property(constructOnly = true)
     public void setItemType(Type itemType) {
     }
 

--- a/modules/gio/src/test/java/io/github/jwharm/javagi/test/gio/ListModelTest.java
+++ b/modules/gio/src/test/java/io/github/jwharm/javagi/test/gio/ListModelTest.java
@@ -27,7 +27,7 @@ public class ListModelTest {
         assertEquals(listIndexModel.getItemType(), ListIndexModel.ListIndex.getType());
         assertEquals(1000, listIndexModel.getNItems());
 
-        var item500 = (ListIndexModel.ListIndex) listIndexModel.getItem(500);
+        var item500 = listIndexModel.getItem(500);
         assertNotNull(item500);
         assertEquals(500, item500.getIndex());
 

--- a/modules/gobject/src/main/java/io/github/jwharm/javagi/gobject/annotations/Property.java
+++ b/modules/gobject/src/main/java/io/github/jwharm/javagi/gobject/annotations/Property.java
@@ -1,5 +1,5 @@
 /* Java-GI - Java language bindings for GObject-Introspection-based libraries
- * Copyright (C) 2022-2023 Jan-Willem Harmannij
+ * Copyright (C) 2022-2024 Jan-Willem Harmannij
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *
@@ -26,6 +26,15 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * The {@code @Property} annotation is used to indicate that a method (or pair
+ * of methods) is a property, to set a property name and flags, or to specify
+ * that a pair of get- and set-methods are not properties (using
+ * {@code skip=false}).
+ * <p>
+ * Always set the {@code @Property} annotation with the same parameters on both
+ * the get- and set-method.
+ */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface Property {
@@ -38,6 +47,4 @@ public @interface Property {
     boolean constructOnly() default false;
     boolean explicitNotify() default false;
     boolean deprecated() default false;
-
-
 }

--- a/modules/gobject/src/main/java/io/github/jwharm/javagi/gobject/annotations/Property.java
+++ b/modules/gobject/src/main/java/io/github/jwharm/javagi/gobject/annotations/Property.java
@@ -31,10 +31,13 @@ import java.lang.annotation.Target;
 public @interface Property {
     String name() default "";
     Class<? extends ParamSpec> type() default ParamSpec.class;
+    boolean skip() default false;
     boolean readable() default true;
     boolean writable() default true;
     boolean construct() default false;
     boolean constructOnly() default false;
     boolean explicitNotify() default false;
     boolean deprecated() default false;
+
+
 }

--- a/modules/gobject/src/main/java/io/github/jwharm/javagi/gobject/types/Types.java
+++ b/modules/gobject/src/main/java/io/github/jwharm/javagi/gobject/types/Types.java
@@ -1223,7 +1223,7 @@ public class Types {
             Consumer<TypeClass> signalsInit;
             if (isGObjectBased(cls)) {
                 signalsInit = Signals.installSignals(cls);
-                propertiesInit = Properties.installProperties(cls);
+                propertiesInit = new Properties().installProperties(cls);
             } else {
                 signalsInit = null;
                 propertiesInit = null;

--- a/modules/gobject/src/test/java/io/github/jwharm/javagi/test/gobject/PropertyBindingTest.java
+++ b/modules/gobject/src/test/java/io/github/jwharm/javagi/test/gobject/PropertyBindingTest.java
@@ -19,7 +19,7 @@
 
 package io.github.jwharm.javagi.test.gobject;
 
-import io.github.jwharm.javagi.gobject.annotations.Property;
+import io.github.jwharm.javagi.gobject.annotations.RegisteredType;
 import io.github.jwharm.javagi.gobject.types.Types;
 import org.gnome.glib.Type;
 import org.gnome.gobject.GObject;
@@ -83,6 +83,7 @@ public class PropertyBindingTest {
         assertTrue((boolean) mph.getProperty("too-fast"));
     }
 
+    @RegisteredType(name="Speed")
     public static class Speed extends GObject {
         private static final Type type = Types.register(Speed.class);
         private double currentSpeed = 0.0;
@@ -102,22 +103,18 @@ public class PropertyBindingTest {
                     null);
         }
 
-        @Property
         public double getCurrentSpeed() {
             return currentSpeed;
         }
 
-        @Property
         public void setCurrentSpeed(double currentSpeed) {
             this.currentSpeed = currentSpeed;
         }
 
-        @Property
         public boolean getTooFast() {
             return currentSpeed > limit;
         }
 
-        @Property
         public void setTooFast(boolean tooFast) {
             if (tooFast)
                 setProperty("current-speed", limit + 10.0);

--- a/modules/gobject/src/test/java/io/github/jwharm/javagi/test/gobject/PropertyTest.java
+++ b/modules/gobject/src/test/java/io/github/jwharm/javagi/test/gobject/PropertyTest.java
@@ -1,0 +1,78 @@
+package io.github.jwharm.javagi.test.gobject;
+
+import io.github.jwharm.javagi.gobject.annotations.Property;
+import io.github.jwharm.javagi.gobject.annotations.RegisteredType;
+import io.github.jwharm.javagi.gobject.types.Types;
+import org.gnome.gobject.GObject;
+import org.junit.jupiter.api.Test;
+
+import java.lang.foreign.MemorySegment;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class PropertyTest {
+
+    @Test
+    void testCustomProperties() {
+        Types.register(Dino.class);
+        var dino = GObject.newInstance(Dino.class);
+        var gclass = (GObject.ObjectClass) dino.readGClass();
+
+        assertNotNull(gclass.findProperty("foo"));
+        assertNotNull(gclass.findProperty("bar"));
+        assertNotNull(gclass.findProperty("baz2"));
+
+        assertNull(gclass.findProperty("baz"));
+        assertNull(gclass.findProperty("qux"));
+    }
+
+    @SuppressWarnings("unused")
+    @RegisteredType(name="Dino")
+    public static class Dino extends GObject{
+        private int foo;
+        private boolean bar;
+        private String baz;
+        private float qux;
+
+        public Dino(MemorySegment address) {
+            super(address);
+        }
+
+        public int getFoo() {
+            return foo;
+        }
+
+        public void setFoo(int foo) {
+            this.foo = foo;
+        }
+
+        public boolean isBar() {
+            return bar;
+        }
+
+        public void setBar(boolean bar) {
+            this.bar = bar;
+        }
+
+        @Property(name="baz2")
+        public String readBaz() {
+            return baz;
+        }
+
+        @Property(name="baz2")
+        public void writeBaz(String baz) {
+            this.baz = baz;
+        }
+
+        @Property(skip=true)
+        public float getQux() {
+            return qux;
+        }
+
+        @Property(skip=true)
+        public void setQux(float qux) {
+            this.qux = qux;
+        }
+    }
+}

--- a/modules/gtk/src/main/java/io/github/jwharm/javagi/gtk/types/TemplateTypes.java
+++ b/modules/gtk/src/main/java/io/github/jwharm/javagi/gtk/types/TemplateTypes.java
@@ -292,7 +292,7 @@ public class TemplateTypes {
 
             // Chain template class init with user-defined class init function
             var overridesInit = Overrides.overrideClassMethods(cls);
-            var propertiesInit = Properties.installProperties(cls);
+            var propertiesInit = new Properties().installProperties(cls);
             var signalsInit = Signals.installSignals(cls);
             var templateClassInit = getTemplateClassInit(cls, instanceLayout);
             var userDefinedClassInit = getClassInit(cls);


### PR DESCRIPTION
With this PR, Java-GI will automatically create GObject properties for pairs of `get` and `set` methods (also known as JavaBean properties). It is still possible to override this behavior with the existing `@Property` annotation.

The change should be backwards compatible. If not, annotate problematic methods with `@Property(skip=true)`.
