### PR TITLE
Property minimum, maximum and default values

### DIFF
--- a/modules/gobject/src/main/java/io/github/jwharm/javagi/gobject/annotations/Property.java
+++ b/modules/gobject/src/main/java/io/github/jwharm/javagi/gobject/annotations/Property.java
@@ -38,6 +38,8 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface Property {
+    String NOT_SET = "JAVA-GI-DEFAULT-PLACEHOLDER-VALUE";
+
     String name() default "";
     Class<? extends ParamSpec> type() default ParamSpec.class;
     boolean skip() default false;
@@ -47,4 +49,7 @@ public @interface Property {
     boolean constructOnly() default false;
     boolean explicitNotify() default false;
     boolean deprecated() default false;
+    String minimumValue() default NOT_SET;
+    String maximumValue() default NOT_SET;
+    String defaultValue() default NOT_SET;
 }

--- a/modules/gobject/src/main/java/io/github/jwharm/javagi/gobject/types/Properties.java
+++ b/modules/gobject/src/main/java/io/github/jwharm/javagi/gobject/types/Properties.java
@@ -494,8 +494,12 @@ public class Properties {
     private void inferProperties(Class<?> cls) {
         Map<String, Method> possibleGetters = new HashMap<>();
 
+        // Create a sorted list of Methods so the getters are processed first
+        var methods = cls.getDeclaredMethods();
+        Arrays.sort(methods, Comparator.comparing(Method::getName));
+
         // Methods with annotation @Property
-        for (var method : cls.getDeclaredMethods()) {
+        for (var method : methods) {
             if (method.isAnnotationPresent(Property.class)) {
                 Property p = method.getAnnotation(Property.class);
                 if (p.skip())

--- a/modules/gobject/src/main/java/io/github/jwharm/javagi/gobject/types/Properties.java
+++ b/modules/gobject/src/main/java/io/github/jwharm/javagi/gobject/types/Properties.java
@@ -250,7 +250,7 @@ public class Properties {
      * Infer the ParamSpec class from the Java class that is used in the
      * getter/setter method.
      */
-    private static Class<? extends ParamSpec> inferType(Class<?> type) {
+    private static Class<? extends ParamSpec> getParamSpecClass(Class<?> type) {
         if (type.equals(boolean.class) || type.equals(Boolean.class))
             return ParamSpecBoolean.class;
 
@@ -314,21 +314,24 @@ public class Properties {
     /*
      * Create a ParamSpec of the requested class.
      */
-    private static ParamSpec createParamSpec(Class<? extends ParamSpec> pClass,
-                                             String name,
-                                             Set<ParamFlags> flags,
-                                             String min, String max, String def) {
+    private void createParamSpec(Class<? extends ParamSpec> pClass,
+                                 String name,
+                                 Set<ParamFlags> flags,
+                                 String min, String max, String def) {
+        ParamSpec paramSpec;
         if (pClass.equals(ParamSpecBoolean.class)) {
             checkParameters(name, min, max, def, true);
             var defVal = !notSet(def) && Boolean.parseBoolean(def);
-            return GObjects.paramSpecBoolean(name, name, name, defVal, flags);
+            defaultValues.put(index, defVal);
+            paramSpec = GObjects.paramSpecBoolean(name, name, name, defVal, flags);
         }
 
         else if (pClass.equals(ParamSpecChar.class)) {
             var minVal = notSet(min) ? Byte.MIN_VALUE : Byte.parseByte(min);
             var maxVal = notSet(max) ? Byte.MAX_VALUE : Byte.parseByte(max);
             var defVal = notSet(def) ? (byte) 0 : Byte.parseByte(def);
-            return GObjects.paramSpecChar(name, name, name,
+            defaultValues.put(index, defVal);
+            paramSpec = GObjects.paramSpecChar(name, name, name,
                     minVal, maxVal, defVal, flags);
         }
 
@@ -336,7 +339,8 @@ public class Properties {
             var minVal = notSet(min) ? -Double.MIN_VALUE : Double.parseDouble(min);
             var maxVal = notSet(max) ? Double.MAX_VALUE : Double.parseDouble(max);
             var defVal = notSet(def) ? 0.0d : Double.parseDouble(def);
-            return GObjects.paramSpecDouble(name, name, name,
+            defaultValues.put(index, defVal);
+            paramSpec = GObjects.paramSpecDouble(name, name, name,
                     minVal, maxVal, defVal, flags);
         }
 
@@ -344,21 +348,24 @@ public class Properties {
             var minVal = notSet(min) ? -Float.MIN_VALUE : Float.parseFloat(min);
             var maxVal = notSet(max) ? Float.MAX_VALUE : Float.parseFloat(max);
             var defVal = notSet(def) ? 0.0f : Float.parseFloat(def);
-            return GObjects.paramSpecFloat(name, name, name,
+            defaultValues.put(index, defVal);
+            paramSpec = GObjects.paramSpecFloat(name, name, name,
                     minVal, maxVal, defVal, flags);
         }
 
         else if (pClass.equals(ParamSpecGType.class)) {
             checkParameters(name, min, max, def, true);
             var defVal = notSet(def) ? Types.NONE : GObjects.typeFromName(def);
-            return GObjects.paramSpecGtype(name, name, name, defVal, flags);
+            defaultValues.put(index, defVal);
+            paramSpec = GObjects.paramSpecGtype(name, name, name, defVal, flags);
         }
 
         else if (pClass.equals(ParamSpecInt.class)) {
             var minVal = notSet(min) ? Integer.MIN_VALUE : Integer.parseInt(min);
             var maxVal = notSet(max) ? Integer.MAX_VALUE : Integer.parseInt(max);
             var defVal = notSet(def) ? 0 : Integer.parseInt(def);
-            return GObjects.paramSpecInt(name, name, name,
+            defaultValues.put(index, defVal);
+            paramSpec = GObjects.paramSpecInt(name, name, name,
                     minVal, maxVal, defVal, flags);
         }
 
@@ -366,7 +373,8 @@ public class Properties {
             var minVal = notSet(min) ? Long.MIN_VALUE : Long.parseLong(min);
             var maxVal = notSet(max) ? Long.MAX_VALUE : Long.parseLong(max);
             var defVal = notSet(def) ? 0L : Long.parseLong(def);
-            return GObjects.paramSpecInt64(name, name, name,
+            defaultValues.put(index, defVal);
+            paramSpec = GObjects.paramSpecInt64(name, name, name,
                     minVal, maxVal, defVal, flags);
         }
 
@@ -374,26 +382,29 @@ public class Properties {
             var minVal = notSet(min) ? Integer.MIN_VALUE : Integer.parseInt(min);
             var maxVal = notSet(max) ? Integer.MAX_VALUE : Integer.parseInt(max);
             var defVal = notSet(def) ? 0 : Integer.parseInt(def);
-            return GObjects.paramSpecLong(name, name, name,
+            defaultValues.put(index, defVal);
+            paramSpec = GObjects.paramSpecLong(name, name, name,
                     minVal, maxVal, defVal, flags);
             }
 
         else if (pClass.equals(ParamSpecPointer.class)) {
             checkParameters(name, min, max, def, false);
-            return GObjects.paramSpecPointer(name, name, name, flags);
+            paramSpec = GObjects.paramSpecPointer(name, name, name, flags);
         }
 
         else if (pClass.equals(ParamSpecString.class)) {
             checkParameters(name, min, max, def, true);
             var defVal = notSet(def) ? null : def;
-            return GObjects.paramSpecString(name, name, name, defVal, flags);
+            defaultValues.put(index, defVal);
+            paramSpec = GObjects.paramSpecString(name, name, name, defVal, flags);
         }
 
         else if (pClass.equals(ParamSpecUChar.class)) {
             var minVal = notSet(min) ? (byte) 0 : Byte.parseByte(min);
             var maxVal = notSet(max) ? Byte.MAX_VALUE : Byte.parseByte(max);
             var defVal = notSet(def) ? (byte) 0 : Byte.parseByte(def);
-            return GObjects.paramSpecUchar(name, name, name,
+            defaultValues.put(index, defVal);
+            paramSpec = GObjects.paramSpecUchar(name, name, name,
                     minVal, maxVal, defVal, flags);
         }
 
@@ -401,7 +412,8 @@ public class Properties {
             var minVal = notSet(min) ? 0 : Integer.parseInt(min);
             var maxVal = notSet(max) ? Integer.MAX_VALUE : Integer.parseInt(max);
             var defVal = notSet(def) ? 0 : Integer.parseInt(def);
-            return GObjects.paramSpecUint(name, name, name,
+            defaultValues.put(index, defVal);
+            paramSpec = GObjects.paramSpecUint(name, name, name,
                     minVal, maxVal, defVal, flags);
         }
 
@@ -409,7 +421,8 @@ public class Properties {
             var minVal = notSet(min) ? 0L : Long.parseLong(min);
             var maxVal = notSet(max) ? Long.MAX_VALUE : Long.parseLong(max);
             var defVal = notSet(def) ? 0L : Long.parseLong(def);
-            return GObjects.paramSpecUint64(name, name, name,
+            defaultValues.put(index, defVal);
+            paramSpec = GObjects.paramSpecUint64(name, name, name,
                     minVal, maxVal, defVal, flags);
         }
 
@@ -417,18 +430,24 @@ public class Properties {
             var minVal = notSet(min) ? 0 : Integer.parseInt(min);
             var maxVal = notSet(max) ? Integer.MAX_VALUE : Integer.parseInt(max);
             var defVal = notSet(def) ? 0 : Integer.parseInt(def);
-            return GObjects.paramSpecUlong(name, name, name,
+            defaultValues.put(index, defVal);
+            paramSpec = GObjects.paramSpecUlong(name, name, name,
                     minVal, maxVal, defVal, flags);
         }
 
         else if (pClass.equals(ParamSpecUnichar.class)) {
             checkParameters(name, min, max, def, true);
             var defVal = notSet(def) ? 0 : Integer.parseInt(def);
-            return GObjects.paramSpecUnichar(name, name, name, defVal, flags);
+            defaultValues.put(index, defVal);
+            paramSpec = GObjects.paramSpecUnichar(name, name, name, defVal, flags);
         }
 
-        throw new IllegalArgumentException(
-                "Unsupported property type: " + pClass.getSimpleName());
+        else {
+            throw new IllegalArgumentException(
+                    "Unsupported property type: " + pClass.getSimpleName());
+        }
+
+        paramSpecs.put(index, paramSpec);
     }
 
     /*
@@ -457,6 +476,7 @@ public class Properties {
     private final Map<Integer, Method> getters;
     private final Map<Integer, Method> setters;
     private final Map<Integer, ParamSpec> paramSpecs;
+    private final Map<Integer, Object> defaultValues;
     private int index = 0;
 
     public Properties() {
@@ -464,6 +484,7 @@ public class Properties {
         getters = new HashMap<>();
         setters = new HashMap<>();
         paramSpecs = new HashMap<>();
+        defaultValues = new HashMap<>();
     }
 
     /*
@@ -496,18 +517,17 @@ public class Properties {
                     }
                 } else {
                     index++;
-                    var flags = getFlags(p);
-                    Class<?> javaType = getJavaType(method);
-                    var paramSpecClass = inferType(javaType);
-                    var paramSpec = createParamSpec(
-                            paramSpecClass, name, flags,
-                            p.minimumValue(), p.maximumValue(), p.defaultValue());
-                    paramSpecs.put(index, paramSpec);
                     names.put(index, name);
                     if (method.getReturnType().equals(void.class))
                         setters.put(index, method);
                     else
                         getters.put(index, method);
+
+                    var flags = getFlags(p);
+                    var javaType = getJavaType(method);
+                    var paramSpecClass = getParamSpecClass(javaType);
+                    createParamSpec(paramSpecClass, name, flags,
+                            p.minimumValue(), p.maximumValue(), p.defaultValue());
                 }
             }
         }
@@ -544,12 +564,11 @@ public class Properties {
                     names.put(index, name);
                     getters.put(index, getter);
                     setters.put(index, method);
-                    Class<?> javaType = getJavaType(method);
-                    Class<? extends ParamSpec> paramSpecClass = inferType(javaType);
-                    Set<ParamFlags> flags = EnumSet.of(ParamFlags.READABLE, ParamFlags.WRITABLE);
-                    ParamSpec paramSpec = createParamSpec(
-                            paramSpecClass, name, flags, NOT_SET, NOT_SET, NOT_SET);
-                    paramSpecs.put(index, paramSpec);
+
+                    var javaType = getJavaType(method);
+                    var paramSpecClass = getParamSpecClass(javaType);
+                    var flags = EnumSet.of(ParamFlags.READABLE, ParamFlags.WRITABLE);
+                    createParamSpec(paramSpecClass, name, flags, NOT_SET, NOT_SET, NOT_SET);
                 }
             }
         }
@@ -587,7 +606,11 @@ public class Properties {
                 if (name == null) name = "";
                 Method getter = getters.get(propertyId);
 
-                if (getter == null) {
+                Object output = null;
+
+                if (getter == null && defaultValues.containsKey(propertyId)) {
+                    output = defaultValues.get(propertyId);
+                } else if (getter == null) {
                     GLib.log(LOG_DOMAIN, LogLevelFlags.LEVEL_CRITICAL,
                             "No getter method defined for property with ID=%d and name='%s' in %s\n",
                             propertyId, name, cls.getSimpleName());
@@ -595,27 +618,36 @@ public class Properties {
                 }
 
                 // Invoke the getter method
-                Object output;
-                try {
-                    output = getter.invoke(object);
-                } catch (InvocationTargetException e) {
-                    // Log exceptions thrown by the getter method
-                    Throwable t = e.getTargetException();
-                    GLib.log(LOG_DOMAIN, LogLevelFlags.LEVEL_CRITICAL,
-                            "%s.getProperty('%s'): %s\n",
-                            cls.getSimpleName(), name, t.toString());
-                    return;
-                } catch (IllegalAccessException e) {
-                    // Tried to call a private method
-                    GLib.log(LOG_DOMAIN, LogLevelFlags.LEVEL_CRITICAL,
-                            "IllegalAccessException calling %s.getProperty('%s')\n",
-                            cls.getSimpleName(), name);
-                    return;
+                if (output == null && getter != null) {
+                    try {
+                        output = getter.invoke(object);
+                    } catch (InvocationTargetException e) {
+                        // Log exceptions thrown by the getter method
+                        Throwable t = e.getTargetException();
+                        GLib.log(LOG_DOMAIN, LogLevelFlags.LEVEL_CRITICAL,
+                                "%s.getProperty('%s'): %s\n",
+                                cls.getSimpleName(), name, t.toString());
+                        return;
+                    } catch (IllegalAccessException e) {
+                        // Tried to call a private method
+                        GLib.log(LOG_DOMAIN, LogLevelFlags.LEVEL_CRITICAL,
+                                "IllegalAccessException calling %s.getProperty('%s')\n",
+                                cls.getSimpleName(), name);
+                        return;
+                    }
                 }
 
                 // Convert return value to GValue
-                if (output != null)
-                    ValueUtil.objectToValue(output, value);
+                if (output != null) {
+                    var success = ValueUtil.objectToValue(output, value);
+                    if (!success) {
+                        GLib.log(LOG_DOMAIN, LogLevelFlags.LEVEL_CRITICAL,
+                                "Error in %s.getProperty('%s'): Cannot write return-value " +
+                                        "with Java type %s into GValue with GType %s\n",
+                                cls.getSimpleName(), name, output.getClass().getSimpleName(),
+                                value == null ? "null" : GObjects.typeName(value.readGType()));
+                    }
+                }
             }, Arena.global());
 
             // Override the set_property virtual method

--- a/modules/gobject/src/main/java/io/github/jwharm/javagi/gobject/types/Properties.java
+++ b/modules/gobject/src/main/java/io/github/jwharm/javagi/gobject/types/Properties.java
@@ -501,7 +501,7 @@ public class Properties {
                     var paramSpecClass = inferType(javaType);
                     var paramSpec = createParamSpec(
                             paramSpecClass, name, flags,
-                            p.maximumValue(), p.maximumValue(), p.defaultValue());
+                            p.minimumValue(), p.maximumValue(), p.defaultValue());
                     paramSpecs.put(index, paramSpec);
                     names.put(index, name);
                     if (method.getReturnType().equals(void.class))

--- a/modules/gobject/src/test/java/io/github/jwharm/javagi/test/gobject/PropertyTest.java
+++ b/modules/gobject/src/test/java/io/github/jwharm/javagi/test/gobject/PropertyTest.java
@@ -44,13 +44,20 @@ public class PropertyTest {
         dino.setProperty("abc", 6);
         assertEquals(6, dino.getProperty("abc"));
 
-        // Too low value
-        dino.setProperty("abc", 3);
-        assertEquals(6, dino.getProperty("abc"));
-
-        // Too high value
-        dino.setProperty("abc", 32);
-        assertEquals(6, dino.getProperty("abc"));
+        /*
+         * Tests for invalid values (too low or too high) are disabled here,
+         * to prevent CRITICAL GObject errors on the command-line output when
+         * executing testcases.
+         * Uncomment the following lines to run these tests.
+         *
+         * // Too low value
+         * dino.setProperty("abc", 3);
+         * assertEquals(6, dino.getProperty("abc"));
+         *
+         * // Too high value
+         * dino.setProperty("abc", 32);
+         * assertEquals(6, dino.getProperty("abc"));
+         */
 
         // Check default value from `@Property` annotation
         assertEquals(30, dino.getProperty("fgh")); // default

--- a/modules/gobject/src/test/java/io/github/jwharm/javagi/test/gobject/PropertyTest.java
+++ b/modules/gobject/src/test/java/io/github/jwharm/javagi/test/gobject/PropertyTest.java
@@ -8,8 +8,7 @@ import org.junit.jupiter.api.Test;
 
 import java.lang.foreign.MemorySegment;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class PropertyTest {
 
@@ -25,6 +24,28 @@ public class PropertyTest {
 
         assertNull(gclass.findProperty("baz"));
         assertNull(gclass.findProperty("qux"));
+
+        // Valid value
+        dino.setProperty("abc", 6);
+        assertEquals(6, dino.getProperty("abc"));
+
+        // Too low value
+        dino.setProperty("abc", 3);
+        assertEquals(6, dino.getProperty("abc"));
+
+        // Too high value
+        dino.setProperty("abc", 32);
+        assertEquals(6, dino.getProperty("abc"));
+
+        // Update to another valid value
+        dino.setProperty("abc", 15);
+        assertEquals(15, dino.getProperty("abc"));
+
+        // Check default value
+        var spec = gclass.findProperty("abc");
+        assertNotNull(spec);
+        var defaultValue = spec.getDefaultValue().getInt();
+        assertEquals(10, defaultValue);
     }
 
     @SuppressWarnings("unused")
@@ -34,6 +55,7 @@ public class PropertyTest {
         private boolean bar;
         private String baz;
         private float qux;
+        private int abc;
 
         public Dino(MemorySegment address) {
             super(address);
@@ -73,6 +95,16 @@ public class PropertyTest {
         @Property(skip=true)
         public void setQux(float qux) {
             this.qux = qux;
+        }
+
+        @Property(minimumValue = "5", defaultValue = "10", maximumValue = "20")
+        public int getAbc() {
+            return abc;
+        }
+
+        @Property(minimumValue = "5", defaultValue = "10", maximumValue = "20")
+        public void setAbc(int abc) {
+            this.abc = abc;
         }
     }
 }

--- a/modules/gobject/src/test/java/io/github/jwharm/javagi/test/gobject/PropertyTest.java
+++ b/modules/gobject/src/test/java/io/github/jwharm/javagi/test/gobject/PropertyTest.java
@@ -124,7 +124,7 @@ public class PropertyTest {
             return abc;
         }
 
-        @Property(minimumValue = "5", defaultValue = "10", maximumValue = "20")
+        @Property
         public void setAbc(int abc) {
             this.abc = abc;
         }


### PR DESCRIPTION
With this PR, it will become possible to specify minimum, maximum and default values for GObject properties declared in Java classes with the `@Property` annotation.

For example:

```java
@Property(minimumValue = "1", maximumValue = "12", defaultValue = "1")
public void setMonth(int month) {
    this.month = month;
}
```

The `@Property` parameters `minimumValue`, `maximumValue` and `defaultValue` expect String values. They are transformed by Java-GI to the proper type using `Boolean.parseBoolean()`, `Integer.parseInt()` etcetera.

Using these three parameters, Java developers can set the minimum, maximum and default values on the `GParamSpec` of a property that they defined in Java.
* The minimum and maximum values are not enforced by Java-GI, so on the Java side the benefits are negligible. In most cases it is advisable to implement minimum and maximum property values in Java itself.
* The default value is returned by Java-GI for properties that have only a setter method in Java.

For properties with a getter and setter method, either both or neither methods must be annotated with `@Property` (or else they will not be recognized by Java-GI as a pair). The annotation parameters must be specified on the getter. They can be specified on the setter too, but only the parameters on the getter are actually used.
