### PR TITLE
Generate methods for unions

### DIFF
--- a/generator/src/main/java/io/github/jwharm/javagi/generators/UnionGenerator.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/generators/UnionGenerator.java
@@ -64,6 +64,7 @@ public class UnionGenerator extends RegisteredTypeGenerator {
             builder.addMethod(getTypeMethod());
 
         addConstructors(builder);
+        addMethods(builder);
         addFunctions(builder);
 
         if (hasDowncallHandles())


### PR DESCRIPTION
Generate methods defined on `<union>` elements in GIR files.
In the default set of bindings, this will only add a set of methods on `GMutex`. Other types were not impacted.
