### PR TITLE
Add `toString()` methods for GType and GVariant

### DIFF
--- a/generator/src/main/java/io/github/jwharm/javagi/configuration/ClassNames.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/configuration/ClassNames.java
@@ -73,6 +73,7 @@ public final class ClassNames {
     public final static ClassName G_LIB = get("org.gnome.glib", "GLib");
     public final static ClassName G_LOG_LEVEL_FLAGS = get("org.gnome.glib", "LogLevelFlags");
     public final static ClassName G_TYPE = get("org.gnome.glib", "Type");
+    public final static ClassName G_VARIANT = get("org.gnome.glib", "Variant");
 
     public final static ClassName G_OBJECT = get("org.gnome.gobject", "GObject");
     public final static ClassName G_OBJECTS = get("org.gnome.gobject", "GObjects");

--- a/generator/src/main/java/io/github/jwharm/javagi/generators/AliasGenerator.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/generators/AliasGenerator.java
@@ -86,6 +86,10 @@ public class AliasGenerator extends RegisteredTypeGenerator {
         if (alias.infoAttrs().deprecated())
             builder.addAnnotation(Deprecated.class);
 
+        if ("GType".equals(alias.cType())
+                && "GObject".equals(alias.parent().name()))
+            builder.addMethod(gtypeToString());
+
         return builder.addModifiers(Modifier.PUBLIC).build();
     }
 
@@ -184,6 +188,21 @@ public class AliasGenerator extends RegisteredTypeGenerator {
         return spec.endControlFlow()
                 .addStatement("if (free) $T.free(address)", ClassNames.G_LIB)
                 .addStatement("return array")
+                .build();
+    }
+
+    private MethodSpec gtypeToString() {
+        return MethodSpec.methodBuilder("toString")
+                .addJavadoc("""
+                        Return the name of a Type using {@link $1T#typeName($2T)}.
+                        
+                        @return the name of the Type
+                        """, ClassNames.G_OBJECTS, ClassNames.G_TYPE)
+                .addModifiers(Modifier.PUBLIC)
+                .addAnnotation(Override.class)
+                .returns(String.class)
+                .addStatement("return $T.typeName(this)",
+                        ClassNames.G_OBJECTS)
                 .build();
     }
 }

--- a/generator/src/main/java/io/github/jwharm/javagi/generators/RecordGenerator.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/generators/RecordGenerator.java
@@ -141,6 +141,9 @@ public class RecordGenerator extends RegisteredTypeGenerator {
         if ("GValue".equals(rec.cType()))
             builder.addMethod(gvalueToString());
 
+        if ("GVariant".equals(rec.cType()))
+            builder.addMethod(gvariantToString());
+
         return builder.build();
     }
 
@@ -362,6 +365,21 @@ public class RecordGenerator extends RegisteredTypeGenerator {
                 .returns(String.class)
                 .addStatement("return $T.strdupValueContents(this)",
                         ClassNames.G_OBJECTS)
+                .build();
+    }
+
+    private MethodSpec gvariantToString() {
+        return MethodSpec.methodBuilder("toString")
+                .addJavadoc("""
+                        Return a newly allocated String using {@link #print},
+                        which pretty-prints the value and type information of a {@link $T}.
+                        
+                        @return the newly allocated String.
+                        """, ClassNames.G_VARIANT)
+                .addModifiers(Modifier.PUBLIC)
+                .addAnnotation(Override.class)
+                .returns(String.class)
+                .addStatement("return print(true)")
                 .build();
     }
 }

--- a/generator/src/main/java/io/github/jwharm/javagi/patches/GObjectPatch.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/patches/GObjectPatch.java
@@ -66,10 +66,9 @@ public class GObjectPatch implements Patch {
         }
 
         /*
-         * GLib and GObject both define gtype as an alias to gsize. We replace
-         * the gtype declaration in GObject with an alias for the GLib gtype,
-         * so it will inherit in Java and the instances of both classes can be
-         * used interchangeably in many cases.
+         * Replace the gtype declaration in GObject with an alias for the GLib
+         * gtype that was added there, so it will inherit in Java and the
+         * instances of both classes can be used interchangeably in many cases.
          */
         if (element instanceof Alias a && "Type".equals(a.name())) {
             Type type = new Type(

--- a/modules/gobject/src/test/java/io/github/jwharm/javagi/test/gobject/ToStringTest.java
+++ b/modules/gobject/src/test/java/io/github/jwharm/javagi/test/gobject/ToStringTest.java
@@ -1,6 +1,7 @@
 package io.github.jwharm.javagi.test.gobject;
 
 import io.github.jwharm.javagi.gobject.types.Types;
+import org.gnome.glib.Variant;
 import org.gnome.gobject.Value;
 import org.junit.jupiter.api.Test;
 
@@ -9,14 +10,10 @@ import java.lang.foreign.Arena;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * {@code org.gnome.Value.toString()} is injected with a patch.
- * Test if it works.
- * <p>
- * If this test fails because the actual value is something like
- * {@code org.gnome.gobject.Value@31e4bb20}, it means the
- * {@code toString()} method doesn't exist (the patch was not applied).
+ * GValue, GType and GVariant have an extra {@code toString()} method.
+ * Test if these methods work as expected.
  */
-public class ValueToStringTest {
+public class ToStringTest {
 
     @Test
     public void testValueToString() {
@@ -34,5 +31,16 @@ public class ValueToStringTest {
         vStr.setString("abc");
         assertEquals("\"abc\"", vStr.toString());
         vStr.unset();
+    }
+
+    @Test
+    public void testVariantToString() {
+        var vInt = new Variant("u", 40);
+        assertEquals("uint32 40", vInt.toString());
+    }
+
+    @Test
+    public void testTypeToString() {
+        // todo
     }
 }


### PR DESCRIPTION
This PR adds a `toString()` method to the Java classes for GType and GVariant for easier printing and debugging.

The `Type.toString()` method calls `g_type_name()`. It is added on the Type class in GObject, because `g_type_name` is in the GObject namespace, so it's pretty useless as long as Java-GI is completely built around the Type class in GLib.

The `Variant.toString()` method calls `g_variant_print(true)` so it displays both the value and the type information.