### PR TITLE
Add support for mutable lists

### DIFF
--- a/generator/src/main/java/io/github/jwharm/javagi/configuration/ClassNames.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/configuration/ClassNames.java
@@ -53,6 +53,9 @@ public final class ClassNames {
 
     public static final ClassName AUTO_CLOSEABLE = get(PKG_GIO, "AutoCloseable");
     public static final ClassName LIST_MODEL_JAVA_LIST = get(PKG_GIO, "ListModelJavaList");
+    public static final ClassName LIST_MODEL_JAVA_LIST_MUTABLE = get(PKG_GIO, "ListModelJavaListMutable");
+    public static final ClassName LIST_MODEL_JAVA_LIST_SPLICEABLE = get(PKG_GIO, "ListModelJavaListSpliceable");
+    public static final ClassName STRING_OBJECT = get("org.gnome.gtk", "StringObject");
 
     public static final ClassName BINDING_BUILDER = get(PKG_GOBJECT, "BindingBuilder");
     public static final ClassName BUILDER = get(PKG_GOBJECT, "Builder");

--- a/generator/src/main/java/io/github/jwharm/javagi/generators/ClassGenerator.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/generators/ClassGenerator.java
@@ -25,10 +25,13 @@ import io.github.jwharm.javagi.gir.Class;
 import io.github.jwharm.javagi.gir.Interface;
 import io.github.jwharm.javagi.gir.Record;
 import io.github.jwharm.javagi.util.GeneratedAnnotationBuilder;
+import org.jetbrains.annotations.NotNull;
 
 import javax.lang.model.element.Modifier;
 
 import java.lang.foreign.MemorySegment;
+import java.util.Arrays;
+import java.util.Collection;
 
 public class ClassGenerator extends RegisteredTypeGenerator {
 
@@ -53,12 +56,13 @@ public class ClassGenerator extends RegisteredTypeGenerator {
         if (cls.abstract_()) builder.addModifiers(Modifier.ABSTRACT);
         if (cls.final_()) builder.addModifiers(Modifier.FINAL);
         if (cls.generic()) builder.addTypeVariable(ClassNames.GENERIC_T);
+        TypeName actualGeneric = cls.actualGeneric();
 
         Class parentClass = cls.parentClass();
         if (parentClass != null)
             builder.superclass(parentClass.generic()
                     ? ParameterizedTypeName.get(parentClass.typeName(),
-                                                    ClassNames.GENERIC_T)
+                    actualGeneric)
                     : parentClass.typeName());
         else
             builder.superclass(ClassNames.G_TYPE_INSTANCE);
@@ -69,11 +73,27 @@ public class ClassGenerator extends RegisteredTypeGenerator {
             if (impl.lookup() instanceof Interface iface)
                 builder.addSuperinterface(iface.generic()
                         ? ParameterizedTypeName.get(iface.typeName(),
-                                                    ClassNames.GENERIC_T)
+                        actualGeneric)
                         : iface.typeName());
 
         if (cls.autoCloseable())
             builder.addSuperinterface(ClassNames.AUTO_CLOSEABLE);
+
+        if (cls.mutableList()) {
+            builder.addSuperinterface(ParameterizedTypeName.get(ClassNames.LIST_MODEL_JAVA_LIST_MUTABLE, actualGeneric));
+            if (actualGeneric.equals(ClassNames.STRING_OBJECT))
+                builder.addMethod(appendStringObjectUnwrapper());
+        }
+
+        if (cls.spliceableList()) {
+            if (actualGeneric instanceof TypeVariableName) throw new IllegalArgumentException("actualGeneric is a TypeVariableName");
+            builder.addSuperinterface(ParameterizedTypeName.get(ClassNames.LIST_MODEL_JAVA_LIST_SPLICEABLE, actualGeneric));
+            builder.addMethod(spliceCollectionWrapper(actualGeneric));
+            if (actualGeneric.equals(ClassNames.STRING_OBJECT)) {
+                builder.addMethod(spliceStringObjectUnwrapper());
+                builder.addMethod(appendStringObjectUnwrapper());
+            }
+        }
 
         if (cls.isFloating())
             builder.addSuperinterface(ClassNames.FLOATING);
@@ -454,6 +474,63 @@ public class ClassGenerator extends RegisteredTypeGenerator {
                 .varargs(true)
                 .addStatement("return $T.emit(this, detailedSignal, params)",
                         ClassNames.SIGNALS)
+                .build();
+    }
+
+    private MethodSpec spliceCollectionWrapper(TypeName actualGeneric) {
+        return MethodSpec.methodBuilder("splice")
+                .addJavadoc("""
+                        Modifies this list by removing {@code nRemovals} elements starting at
+                        {@code index} and replacing them with the elements in {@code additions}.
+                        
+                        @param index the index at which to splice the list
+                        @param nRemovals the number of elements to remove
+                        @param elements the elements to insert at the index
+                        @throws IndexOutOfBoundsException if the index is out of range
+                        """)
+                .addAnnotation(Override.class)
+                .addModifiers(Modifier.PUBLIC)
+                .addParameter(int.class, "index")
+                .addParameter(int.class, "nRemovals")
+                .addParameter(ParameterizedTypeName.get(
+                        ClassName.get(Collection.class),
+                        WildcardTypeName.subtypeOf(actualGeneric)
+                ).annotated(AnnotationSpec.builder(NotNull.class).build()), "additions")
+                .addStatement("splice(index, nRemovals, additions.toArray($T[]::new))", actualGeneric)
+                .build();
+    }
+
+    private MethodSpec spliceStringObjectUnwrapper() {
+        return MethodSpec.methodBuilder("splice")
+                .addJavadoc("""
+                        Modifies this list by removing {@code nRemovals} elements starting at
+                        {@code index} and replacing them with the elements in {@code additions}.
+                        
+                        @param index the index at which to splice the list
+                        @param nRemovals the number of elements to remove
+                        @param additions the elements to insert at the index
+                        @throws IndexOutOfBoundsException if the index is out of range
+                        """)
+                .addAnnotation(Override.class)
+                .addModifiers(Modifier.PUBLIC)
+                .addParameter(int.class, "index")
+                .addParameter(int.class, "nRemovals")
+                .addParameter(ArrayTypeName.of(ClassNames.STRING_OBJECT), "additions")
+                .addStatement("splice(index, nRemovals, additions == null ? null : $T.stream(additions).map($T::getString).toArray(String[]::new))", Arrays.class, ClassNames.STRING_OBJECT)
+                .build();
+    }
+
+    private MethodSpec appendStringObjectUnwrapper() {
+            return MethodSpec.methodBuilder("append")
+                .addJavadoc("""
+                        Adds the specified element to the end of this list.
+                        
+                        @param e element to be appended to this list
+                        """)
+                .addAnnotation(Override.class)
+                .addModifiers(Modifier.PUBLIC)
+                .addParameter(ClassNames.STRING_OBJECT, "e")
+                .addStatement("append(e.getString())")
                 .build();
     }
 }

--- a/generator/src/main/java/io/github/jwharm/javagi/generators/ClassGenerator.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/generators/ClassGenerator.java
@@ -32,6 +32,7 @@ import javax.lang.model.element.Modifier;
 import java.lang.foreign.MemorySegment;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Objects;
 
 public class ClassGenerator extends RegisteredTypeGenerator {
 
@@ -118,6 +119,9 @@ public class ClassGenerator extends RegisteredTypeGenerator {
 
         builder.addMethod(parentAccessor());
         builder.addMethod(memoryAddressConstructor());
+
+        if (cls.toStringTarget() != null)
+            builder.addMethod(toStringRedirect(cls.toStringTarget()));
 
         addConstructors(builder);
         addFunctions(builder);
@@ -531,6 +535,20 @@ public class ClassGenerator extends RegisteredTypeGenerator {
                 .addModifiers(Modifier.PUBLIC)
                 .addParameter(ClassNames.STRING_OBJECT, "e")
                 .addStatement("append(e.getString())")
+                .build();
+    }
+
+    private MethodSpec toStringRedirect(String target) {
+        return MethodSpec.methodBuilder("toString")
+                .addJavadoc("""
+                        Returns a string representation of the object.
+                        
+                        @return a string representation of the object
+                        """)
+                .addAnnotation(Override.class)
+                .addModifiers(Modifier.PUBLIC)
+                .returns(String.class)
+                .addStatement("return $T.toString($L())", Objects.class, target)
                 .build();
     }
 }

--- a/generator/src/main/java/io/github/jwharm/javagi/gir/Class.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/gir/Class.java
@@ -19,10 +19,13 @@
 
 package io.github.jwharm.javagi.gir;
 
+import com.squareup.javapoet.TypeName;
+import io.github.jwharm.javagi.configuration.ClassNames;
 import io.github.jwharm.javagi.util.PartialStatement;
 
 import static io.github.jwharm.javagi.util.CollectionUtils.*;
 import static io.github.jwharm.javagi.util.Conversions.toJavaIdentifier;
+import static io.github.jwharm.javagi.util.Conversions.toJavaQualifiedType;
 
 import java.util.List;
 import java.util.Map;
@@ -74,6 +77,8 @@ public final class Class extends Multiplatform
     }
 
     public boolean generic() {
+        if (!ClassNames.GENERIC_T.equals(actualGeneric())) return false;
+
         if (attrBool("java-gi-generic", false))
             return true;
 
@@ -82,6 +87,21 @@ public final class Class extends Multiplatform
                 return true;
 
         return false;
+    }
+
+    public TypeName actualGeneric() {
+        String actualGenericName = attr("java-gi-generic-actual");
+        if (actualGenericName == null)
+            return ClassNames.GENERIC_T;
+        return toJavaQualifiedType(actualGenericName, namespace());
+    }
+
+    public boolean mutableList() {
+        return attrBool("java-gi-list-mutable", false);
+    }
+
+    public boolean spliceableList() {
+        return attrBool("java-gi-list-spliceable", false);
     }
 
     public boolean autoCloseable() {

--- a/generator/src/main/java/io/github/jwharm/javagi/gir/Class.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/gir/Class.java
@@ -104,6 +104,10 @@ public final class Class extends Multiplatform
         return attrBool("java-gi-list-spliceable", false);
     }
 
+    public String toStringTarget() {
+        return attr("java-gi-to-string");
+    }
+
     public boolean autoCloseable() {
         return attrBool("java-gi-auto-closeable", false);
     }

--- a/generator/src/main/java/io/github/jwharm/javagi/patches/GtkPatch.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/patches/GtkPatch.java
@@ -247,6 +247,11 @@ public class GtkPatch implements Patch {
             return c.withAttribute("java-gi-generic-actual", "Gtk.StringObject")
                     .withAttribute("java-gi-list-spliceable", "1");
 
+        if (element instanceof Class i && "StringObject".equals(i.name()))
+            return i.withAttribute("java-gi-to-string", "getString");
+        if (element instanceof Class i && "StringFilter".equals(i.name()))
+            return i.withAttribute("java-gi-to-string", "getSearch");
+
         return element;
     }
 }

--- a/generator/src/main/java/io/github/jwharm/javagi/patches/GtkPatch.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/patches/GtkPatch.java
@@ -221,17 +221,31 @@ public class GtkPatch implements Patch {
         /*
          * Because these classes implement GListModel, which is patched to
          * implement java.util.List, their `void remove(int)` method conflicts
-         * with List's `boolean remove(int)`. Rename to `removeItem()`.
+         * with List's `boolean remove(int)`. Rename to `removeAt()`.
          */
         if (element instanceof Method m
                 && "gtk_multi_filter_remove".equals(m.callableAttrs().cIdentifier()))
-            return element.withAttribute("name", "remove_filter");
+            return element.withAttribute("name", "remove_at");
         else if (element instanceof Method m
                 && "gtk_string_list_remove".equals(m.callableAttrs().cIdentifier()))
-            return element.withAttribute("name", "remove_string");
+            return element.withAttribute("name", "remove_at");
         else if (element instanceof Method m
                 && "gtk_multi_sorter_remove".equals(m.callableAttrs().cIdentifier()))
-            return element.withAttribute("name", "remove_sorter");
+            return element.withAttribute("name", "remove_at");
+
+        if (element instanceof Class c && "MultiFilter".equals(c.name()))
+            return c.withAttribute("java-gi-generic-actual", "Gtk.Filter")
+                    .withAttribute("java-gi-list-mutable", "1");
+        if (element instanceof Class c && "AnyFilter".equals(c.name()))
+            return c.withAttribute("java-gi-generic-actual", "Gtk.Filter");
+        if (element instanceof Class c && "EveryFilter".equals(c.name()))
+            return c.withAttribute("java-gi-generic-actual", "Gtk.Filter");
+        if (element instanceof Class c && "MultiSorter".equals(c.name()))
+            return c.withAttribute("java-gi-generic-actual", "Gtk.Sorter")
+                    .withAttribute("java-gi-list-mutable", "1");
+        if (element instanceof Class c && "StringList".equals(c.name()))
+            return c.withAttribute("java-gi-generic-actual", "Gtk.StringObject")
+                    .withAttribute("java-gi-list-spliceable", "1");
 
         return element;
     }

--- a/modules/gio/src/main/java/io/github/jwharm/javagi/gio/ListModelJavaList.java
+++ b/modules/gio/src/main/java/io/github/jwharm/javagi/gio/ListModelJavaList.java
@@ -410,6 +410,8 @@ public interface ListModelJavaList<E extends GObject> extends List<E> {
 
         @Override
         public E getItem(int position) {
+            if (position < 0 || position >= size())
+                throw new IndexOutOfBoundsException();
             return list.getItem(position + fromIndex);
         }
     }

--- a/modules/gio/src/main/java/io/github/jwharm/javagi/gio/ListModelJavaList.java
+++ b/modules/gio/src/main/java/io/github/jwharm/javagi/gio/ListModelJavaList.java
@@ -396,7 +396,7 @@ public interface ListModelJavaList<E extends GObject> extends List<E> {
         protected final int toIndex;
 
         public SubList(List list, int fromIndex, int toIndex) {
-            if (fromIndex < 0 || fromIndex > toIndex || toIndex > size())
+            if (fromIndex < 0 || fromIndex > toIndex || toIndex > list.size())
                 throw new IndexOutOfBoundsException();
             this.list = Objects.requireNonNull(list);
             this.fromIndex = fromIndex;

--- a/modules/gio/src/main/java/io/github/jwharm/javagi/gio/ListModelJavaList.java
+++ b/modules/gio/src/main/java/io/github/jwharm/javagi/gio/ListModelJavaList.java
@@ -393,7 +393,7 @@ public interface ListModelJavaList<E extends GObject> extends List<E> {
     class SubList<E extends GObject, List extends ListModelJavaList<E>> implements ListModelJavaList<E> {
         protected final List list;
         protected final int fromIndex;
-        protected final int toIndex;
+        protected int toIndex;
 
         public SubList(List list, int fromIndex, int toIndex) {
             if (fromIndex < 0 || fromIndex > toIndex || toIndex > list.size())

--- a/modules/gio/src/main/java/io/github/jwharm/javagi/gio/ListModelJavaListMutable.java
+++ b/modules/gio/src/main/java/io/github/jwharm/javagi/gio/ListModelJavaListMutable.java
@@ -96,6 +96,8 @@ public interface ListModelJavaListMutable<E extends GObject> extends ListModelJa
 
         @Override
         public void removeAt(int index) {
+            if (index < 0 || index >= size())
+                throw new IndexOutOfBoundsException();
             list.removeAt(index + fromIndex);
         }
 

--- a/modules/gio/src/main/java/io/github/jwharm/javagi/gio/ListModelJavaListMutable.java
+++ b/modules/gio/src/main/java/io/github/jwharm/javagi/gio/ListModelJavaListMutable.java
@@ -99,11 +99,13 @@ public interface ListModelJavaListMutable<E extends GObject> extends ListModelJa
             if (index < 0 || index >= size())
                 throw new IndexOutOfBoundsException();
             list.removeAt(index + fromIndex);
+            toIndex--;
         }
 
         @Override
         public void append(E e) {
             list.add(toIndex, e);
+            toIndex++;
         }
     }
 }

--- a/modules/gio/src/main/java/io/github/jwharm/javagi/gio/ListModelJavaListMutable.java
+++ b/modules/gio/src/main/java/io/github/jwharm/javagi/gio/ListModelJavaListMutable.java
@@ -1,0 +1,107 @@
+package io.github.jwharm.javagi.gio;
+
+import org.gnome.gobject.GObject;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public interface ListModelJavaListMutable<E extends GObject> extends ListModelJavaList<E> {
+
+    void removeAt(int index);
+    void append(E e);
+
+    /**
+     * {@inheritDoc}
+     *
+     * @apiNote This implementation delegates to {@link #append(GObject)}.
+     */
+    @Override
+    default boolean add(E e) {
+        append(e);
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @apiNote This implementation removes all subsequent elements, appends the new element, and then appends the removed elements, skipping the element at the specified index.
+     */
+    @Override
+    default E set(int index, E element) {
+        int size = size();
+        if (index < 0 || index >= size)
+            throw new IndexOutOfBoundsException();
+        List<E> subList = subList(index, size);
+        List<E> buffer = List.copyOf(subList);
+        subList.clear();
+        append(element);
+        boolean first = true;
+        E result = null;
+        for (E e : buffer) {
+            if (first) {
+                result = e;
+                first = false;
+            } else {
+                append(e);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @apiNote This implementation removes all subsequent elements, appends the new element, and then appends all the removed elements.
+     */
+    @Override
+    default void add(int index, E element) {
+        int size = size();
+        if (index < 0 || index > size)
+            throw new IndexOutOfBoundsException();
+        List<E> subList = subList(index, size);
+        List<E> buffer = List.copyOf(subList);
+        subList.clear();
+        append(element);
+        for (E e : buffer) {
+            append(e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @apiNote This implementation delegates to {@link #removeAt(int)} and {@link #getItem(int)}.
+     */
+    @Override
+    default E remove(int index) {
+        E e = getItem(index);
+        removeAt(index);
+        return e;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    default @NotNull List<E> subList(int fromIndex, int toIndex) {
+        return new SubList<>(this, fromIndex, toIndex);
+    }
+
+    @ApiStatus.Internal
+    class SubList<E extends GObject, List extends ListModelJavaListMutable<E>> extends ListModelJavaList.SubList<E, List> implements ListModelJavaListMutable<E> {
+        public SubList(List list, int fromIndex, int toIndex) {
+            super(list, fromIndex, toIndex);
+        }
+
+        @Override
+        public void removeAt(int index) {
+            list.removeAt(index + fromIndex);
+        }
+
+        @Override
+        public void append(E e) {
+            list.add(toIndex, e);
+        }
+    }
+}

--- a/modules/gio/src/main/java/io/github/jwharm/javagi/gio/ListModelJavaListSpliceable.java
+++ b/modules/gio/src/main/java/io/github/jwharm/javagi/gio/ListModelJavaListSpliceable.java
@@ -82,11 +82,15 @@ public interface ListModelJavaListSpliceable<E extends GObject> extends ListMode
 
         @Override
         public void splice(int position, int nRemovals, @Nullable E[] additions) {
+            if (position < 0 || nRemovals < 0 || position + nRemovals > size())
+                throw new IndexOutOfBoundsException();
             list.splice(position + fromIndex, nRemovals, additions);
         }
 
         @Override
         public void splice(int position, int nRemovals, @NotNull Collection<? extends E> additions) {
+            if (position < 0 || nRemovals < 0 || position + nRemovals > size())
+                throw new IndexOutOfBoundsException();
             list.splice(position + fromIndex, nRemovals, additions);
         }
     }

--- a/modules/gio/src/main/java/io/github/jwharm/javagi/gio/ListModelJavaListSpliceable.java
+++ b/modules/gio/src/main/java/io/github/jwharm/javagi/gio/ListModelJavaListSpliceable.java
@@ -1,0 +1,93 @@
+package io.github.jwharm.javagi.gio;
+
+import org.gnome.gobject.GObject;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+
+public interface ListModelJavaListSpliceable<E extends GObject> extends ListModelJavaListMutable<E> {
+
+    void splice(int position, int nRemovals, @Nullable E[] additions);
+    void splice(int position, int nRemovals, @NotNull Collection<? extends E> additions);
+
+    /**
+     * {@inheritDoc}
+     *
+     * @apiNote This implementation delegates to {@link #splice(int, int, E[])}.
+     */
+    @Override
+    default void clear() {
+        splice(0, size(), (E[]) null);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @apiNote This implementation delegates to {@link #splice(int, int, Collection)}.
+     */
+    @Override
+    default E set(int index, E element) {
+        return ListModelJavaListMutable.super.set(index, element);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @apiNote This implementation delegates to {@link #splice(int, int, Collection)}.
+     */
+    @Override
+    default void add(int index, E element) {
+        ListModelJavaListMutable.super.add(index, element);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @apiNote This implementation delegates to {@link #splice(int, int, Collection)}.
+     */
+    @Override
+    default boolean addAll(@NotNull Collection<? extends E> c) {
+        splice(size(), 0, Objects.requireNonNull(c));
+        return !c.isEmpty();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @apiNote This implementation delegates to {@link #splice(int, int, Collection)}.
+     */
+    @Override
+    default boolean addAll(int index, @NotNull Collection<? extends E> c) {
+        splice(index, 0, Objects.requireNonNull(c));
+        return !c.isEmpty();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    default @NotNull List<E> subList(int fromIndex, int toIndex) {
+        return new SubList<>(this, fromIndex, toIndex);
+    }
+
+    @ApiStatus.Internal
+    class SubList<E extends GObject, List extends ListModelJavaListSpliceable<E>> extends ListModelJavaListMutable.SubList<E, List> implements ListModelJavaListSpliceable<E> {
+        public SubList(List list, int fromIndex, int toIndex) {
+            super(list, fromIndex, toIndex);
+        }
+
+        @Override
+        public void splice(int position, int nRemovals, @Nullable E[] additions) {
+            list.splice(position + fromIndex, nRemovals, additions);
+        }
+
+        @Override
+        public void splice(int position, int nRemovals, @NotNull Collection<? extends E> additions) {
+            list.splice(position + fromIndex, nRemovals, additions);
+        }
+    }
+}

--- a/modules/gio/src/main/java/io/github/jwharm/javagi/gio/ListModelJavaListSpliceable.java
+++ b/modules/gio/src/main/java/io/github/jwharm/javagi/gio/ListModelJavaListSpliceable.java
@@ -85,6 +85,8 @@ public interface ListModelJavaListSpliceable<E extends GObject> extends ListMode
             if (position < 0 || nRemovals < 0 || position + nRemovals > size())
                 throw new IndexOutOfBoundsException();
             list.splice(position + fromIndex, nRemovals, additions);
+            toIndex -= nRemovals;
+            toIndex += additions == null ? 0 : additions.length;
         }
 
         @Override
@@ -92,6 +94,8 @@ public interface ListModelJavaListSpliceable<E extends GObject> extends ListMode
             if (position < 0 || nRemovals < 0 || position + nRemovals > size())
                 throw new IndexOutOfBoundsException();
             list.splice(position + fromIndex, nRemovals, additions);
+            toIndex -= nRemovals;
+            toIndex += additions.size();
         }
     }
 }

--- a/modules/gtk/src/test/java/io/github/jwharm/javagi/test/gtk/MutableListTest.java
+++ b/modules/gtk/src/test/java/io/github/jwharm/javagi/test/gtk/MutableListTest.java
@@ -1,0 +1,44 @@
+package io.github.jwharm.javagi.test.gtk;
+
+import org.gnome.gtk.*;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class MutableListTest {
+    @Test
+    public void testMutableList() {
+        Gtk.init();
+
+        AnyFilter list = new AnyFilter();
+        assertEquals(0, list.size());
+
+        list.add(StringFilter.builder().setSearch("a").build());
+        list.add(StringFilter.builder().setSearch("b").build());
+        list.add(StringFilter.builder().setSearch("c").build());
+
+        assertEquals(3, list.size());
+
+        list.set(0, StringFilter.builder().setSearch("d").build());
+
+        assertEquals(3, list.size());
+        assertEquals("d", list.get(0).toString());
+
+        list.add(1, StringFilter.builder().setSearch("e").build());
+
+        assertEquals(4, list.size());
+        assertEquals("d", list.get(0).toString());
+        assertEquals("e", list.get(1).toString());
+        assertEquals("b", list.get(2).toString());
+
+        list.remove(1);
+
+        assertEquals(3, list.size());
+        assertEquals("d", list.get(0).toString());
+        assertEquals("b", list.get(1).toString());
+
+        list.clear();
+
+        assertEquals(0, list.size());
+    }
+}

--- a/modules/gtk/src/test/java/io/github/jwharm/javagi/test/gtk/SpliceableListTest.java
+++ b/modules/gtk/src/test/java/io/github/jwharm/javagi/test/gtk/SpliceableListTest.java
@@ -1,0 +1,61 @@
+package io.github.jwharm.javagi.test.gtk;
+
+import org.gnome.gtk.Gtk;
+import org.gnome.gtk.StringList;
+import org.gnome.gtk.StringObject;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class SpliceableListTest {
+    @Test
+    public void testSpliceableList() {
+        Gtk.init();
+
+        StringList list = new StringList();
+        assertEquals(0, list.size());
+
+        list.append("a");
+        list.append("b");
+        list.append("c");
+
+        assertEquals(3, list.size());
+
+        list.set(0, new StringObject("d"));
+
+        assertEquals(3, list.size());
+        assertEquals("d", list.getFirst().toString());
+
+        list.add(1, new StringObject("e"));
+
+        assertEquals(4, list.size());
+        assertEquals("d", list.get(0).toString());
+        assertEquals("e", list.get(1).toString());
+        assertEquals("b", list.get(2).toString());
+
+        list.clear();
+
+        assertEquals(0, list.size());
+
+        list.addAll(List.of(new StringObject("a"), new StringObject("b"), new StringObject("c")));
+
+        assertEquals(3, list.size());
+        assertEquals("a", list.get(0).toString());
+        assertEquals("b", list.get(1).toString());
+        assertEquals("c", list.get(2).toString());
+
+        list.removeAt(1);
+
+        assertEquals(2, list.size());
+
+        list.addAll(1, List.of(new StringObject("d"), new StringObject("e")));
+
+        assertEquals(4, list.size());
+        assertEquals("a", list.get(0).toString());
+        assertEquals("d", list.get(1).toString());
+        assertEquals("e", list.get(2).toString());
+        assertEquals("c", list.get(3).toString());
+    }
+}


### PR DESCRIPTION
Some lists in GTK support mutation via `append`, `remove` and `splice`.
This implements the required methods to allow mutation on them.
Additionally, this allows patches to pick implementation classes for generics where appropriate (like `StringObject` for `StringList` as its documentation suggests)