### PR TITLE
Return type of constructor functions

### DIFF
--- a/generator/src/main/java/io/github/jwharm/javagi/generators/ConstructorGenerator.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/generators/ConstructorGenerator.java
@@ -129,8 +129,7 @@ public class ConstructorGenerator {
         MethodSpec.Builder builder = MethodSpec.methodBuilder(methodName)
                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC);
 
-        // Override the specified return type
-        TypeName returnType = parent.typeName();
+        TypeName returnType = ctor.returnValue().anyType().typeName();
         builder.returns(returnType);
 
         // Javadoc

--- a/generator/src/main/java/io/github/jwharm/javagi/gir/GirElement.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/gir/GirElement.java
@@ -54,6 +54,10 @@ public abstract class GirElement implements Serializable, Node {
         this.parent = parent;
     }
 
+    public void setAttr(String key, String newValue) {
+        attributes.put(key, newValue);
+    }
+
     public String attr(String key) {
         return attributes.get(key);
     }


### PR DESCRIPTION
Do not override the return type of all constructor functions automatically.
For Gtk Widget constructors, override the return type with a GIR patch.

Fixes #160
