### PR TITLE
Add GObject constructor that takes a Java class as first argument

### DIFF
--- a/generator/src/main/java/io/github/jwharm/javagi/configuration/ClassNames.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/configuration/ClassNames.java
@@ -50,6 +50,7 @@ public final class ClassNames {
     public static final ClassName MEMORY_CLEANER = get(PKG_INTEROP, "MemoryCleaner");
     public static final ClassName INTEROP = get(PKG_INTEROP, "Interop");
     public static final ClassName PLATFORM = get(PKG_INTEROP, "Platform");
+    public static final ClassName VARARGS_UTIL = get(PKG_INTEROP, "VarargsUtil");
 
     public static final ClassName AUTO_CLOSEABLE = get(PKG_GIO, "AutoCloseable");
     public static final ClassName LIST_MODEL_JAVA_LIST = get(PKG_GIO, "ListModelJavaList");

--- a/modules/glib/src/main/java/io/github/jwharm/javagi/interop/VarargsUtil.java
+++ b/modules/glib/src/main/java/io/github/jwharm/javagi/interop/VarargsUtil.java
@@ -1,0 +1,60 @@
+/* Java-GI - Java language bindings for GObject-Introspection-based libraries
+ * Copyright (C) 2022-2025 Jan-Willem Harmannij
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.github.jwharm.javagi.interop;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Arrays;
+
+/**
+ * Utility functions to split an array of variadic arguments into a first
+ * argument and a null-terminated array of remaining arguments.
+ */
+public class VarargsUtil {
+
+    /**
+     * Return the first array element.
+     *
+     * @param  array input array, can be {@code null}
+     * @param  <T>   array element type
+     * @return the first element, or {@code null} if the input array is
+     *         {@code null} or empty
+     */
+    public static <T> @Nullable T first(@Nullable T @Nullable[] array) {
+        return array == null || array.length == 0 ? null : array[0];
+    }
+
+    /**
+     * Return all but the first array elements, terminated with a {@code null}.
+     * For example, {@code [1, 2, 3]} returns {@code [2, 3, null]}.
+     *
+     * @param  array input array, can be {@code null}
+     * @param  <T>   array element type
+     * @return a new array of all elements except the first, terminated with a
+     *         {@code null}, or {@code null} if the input array is {@code null}
+     *         or empty
+     */
+    @SuppressWarnings("unchecked") // cast is safe because the array is empty
+    public static <T> @Nullable T @Nullable[] rest(@Nullable T @Nullable[] array) {
+        return array == null ? null
+                : array.length == 0 ? (T[]) new Object[] {}
+                : Arrays.copyOfRange(array, 1, array.length + 1);
+    }
+}

--- a/modules/gobject/src/test/java/io/github/jwharm/javagi/test/gobject/DerivedClassTest.java
+++ b/modules/gobject/src/test/java/io/github/jwharm/javagi/test/gobject/DerivedClassTest.java
@@ -112,6 +112,18 @@ public class DerivedClassTest {
         assertEquals(input2, object.getProperty("bool-property"));
     }
 
+    @Test
+    public void constructWithClassParameter() {
+        TestObject object = new TestObject();
+        assertEquals(object.readGClass().readGType(), TestObject.gtype);
+
+        String input1 = "abc";
+        boolean input2 = true;
+        TestObject object2 = new TestObject(input1, input2);
+        assertEquals(input1, object2.getProperty("string-property"));
+        assertEquals(input2, object2.getProperty("bool-property"));
+    }
+
     /**
      * Simple GObject-derived class used in the above tests
      */
@@ -120,6 +132,16 @@ public class DerivedClassTest {
         public static Type gtype = Types.register(TestObject.class);
         public TestObject(MemorySegment address) {
             super(address);
+        }
+
+        public TestObject() {
+            super(TestObject.class);
+        }
+
+        public TestObject(String stringValue, boolean booleanValue) {
+            super(TestObject.class,
+                    "string-property", stringValue,
+                    "bool-property", booleanValue);
         }
 
         @ClassInit


### PR DESCRIPTION
Generate a GObject constructor that takes a Java class as first argument instead of a GType, followed by varargs for (optionally) specifying property names and values.

A new utility class `VarargsUtil` was created that simplifies splitting the varargs into a "first" and "rest" component like `g_object_new` expects, and also adds a `null` at the end, in case the user forgets it.

This was a missing piece from #164.