### PR TITLE
Static factory methods for constructors in abstract classes

### DIFF
--- a/generator/src/main/java/io/github/jwharm/javagi/generators/ConstructorGenerator.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/generators/ConstructorGenerator.java
@@ -23,6 +23,7 @@ import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.TypeName;
 import io.github.jwharm.javagi.configuration.ClassNames;
 import io.github.jwharm.javagi.gir.*;
+import io.github.jwharm.javagi.gir.Class;
 import io.github.jwharm.javagi.util.PartialStatement;
 import io.github.jwharm.javagi.util.Platform;
 
@@ -62,6 +63,7 @@ public class ConstructorGenerator {
 
     public Iterable<MethodSpec> generate() {
         MethodSpec constructor = ctor.name().equals("new")
+                    && (! (parent instanceof Class c && c.abstract_()))
                 ? constructor()
                 : namedConstructor();
 


### PR DESCRIPTION
Always generate a static factory method instead of a constructor in Java when the GIR contains constructors in an abstract class. Fixes #184