### PR TITLE
Make updating the release the default action

### DIFF
--- a/.github/workflows/windows-gtk.yml
+++ b/.github/workflows/windows-gtk.yml
@@ -7,6 +7,7 @@ on:
         description: 'Upload artifacts as release'
         required: true
         type: boolean
+        default: true
       gtktag:
         description: 'The GTK tag to clone'
         required: true


### PR DESCRIPTION
To make the artifacts built by the GTK CI actually available to users, they need to be downloadable from somewhere.
I had intended GitHub Releases to be that place, but it seems like you didn't enable publishing to it the last time you ran the action (the option to do so was intended for testing, since Actions artifacts get deleted after some time and need login to access, but potentially broken builds shouldn't be released).
With this change, the corresponding checkbox is checked by default, which better represents the intended use.