### PR TITLE
Let GListStore implement ListModelJavaListMutable

### DIFF
--- a/generator/src/main/java/io/github/jwharm/javagi/generators/ClassGenerator.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/generators/ClassGenerator.java
@@ -154,6 +154,9 @@ public class ClassGenerator extends RegisteredTypeGenerator {
                     .addMethod(gobjectConnectAfter())
                     .addMethod(gobjectEmit());
 
+        if ("GListStore".equals(cls.cType()))
+            builder.addMethod(gListStoreRemoveItem());
+
         if (hasDowncallHandles())
             builder.addType(downcallHandlesClass());
 
@@ -507,6 +510,25 @@ public class ClassGenerator extends RegisteredTypeGenerator {
                 .varargs(true)
                 .addStatement("return $T.emit(this, detailedSignal, params)",
                         ClassNames.SIGNALS)
+                .build();
+    }
+
+    private MethodSpec gListStoreRemoveItem() {
+        return MethodSpec.methodBuilder("removeItem")
+                .addJavadoc("""
+                    Removes the item from this ListStore that is at {@code position}.
+                    {@code position} must be smaller than the current length of the list.
+                    <p>
+                    Use g_list_store_splice() to remove multiple items at the same time
+                    efficiently.
+                    
+                    @param position the position of the item that is to be removed
+                    @deprecated renamed to {@link #removeAt(int)}
+                    """)
+                .addAnnotation(Deprecated.class)
+                .addModifiers(Modifier.PUBLIC)
+                .addParameter(int.class, "position")
+                .addStatement("removeAt(position)")
                 .build();
     }
 

--- a/generator/src/main/java/io/github/jwharm/javagi/patches/GioPatch.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/patches/GioPatch.java
@@ -141,17 +141,19 @@ public class GioPatch implements Patch {
             return element.withAttribute("java-gi-generic", "1")
                           .withAttribute("java-gi-list-interface", "1");
 
+        // ListStore implements ListModel<T> and supports splice
         if (element instanceof Class c && "ListStore".equals(c.name()))
-            return element.withAttribute("java-gi-generic", "1");
+            return element.withAttribute("java-gi-generic", "1")
+                    .withAttribute("java-gi-list-mutable", "1");
 
         /*
          * Because GListStore implements GListModel, which is patched to
          * implement java.util.List, its `void remove(int)` method conflicts
-         * with List's `boolean remove(int)`. Rename to `removeItem()`.
+         * with List's `boolean remove(int)`. Rename to `removeAt()`.
          */
         if (element instanceof Method m
                 && "g_list_store_remove".equals(m.callableAttrs().cIdentifier()))
-            return element.withAttribute("name", "remove_item");
+            return element.withAttribute("name", "remove_at");
 
         /*
          * File.prefixMatches() is defined as a virtual method with invoker


### PR DESCRIPTION
GListStore can be used as a java.util.List, but did not support mutation actions (add, remove, clear etc).

To make this work, the `ListStore.removeItem()` method was renamed to `removeAt()`, and a temporary `@Deprecated removeItem()` was added for backwards compatibility.