### PR TITLE
Refactor gobject constructors

### DIFF
--- a/generator/src/main/java/io/github/jwharm/javagi/configuration/ClassNames.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/configuration/ClassNames.java
@@ -31,6 +31,7 @@ public final class ClassNames {
     private static final String PKG_GIO             = "io.github.jwharm.javagi.gio";
     private static final String PKG_GOBJECT         = "io.github.jwharm.javagi.gobject";
     private static final String PKG_GOBJECT_TYPES   = "io.github.jwharm.javagi.gobject.types";
+    private static final String PKG_GTK_TYPES       = "io.github.jwharm.javagi.gtk.types";
 
     public static final ClassName CONSTANTS = get(PKG_TOPLEVEL, "Constants");
 
@@ -72,6 +73,8 @@ public final class ClassNames {
     public static final ClassName TYPE_CACHE = get(PKG_GOBJECT_TYPES, "TypeCache");
     public static final ClassName TYPES = get(PKG_GOBJECT_TYPES, "Types");
 
+    public static final ClassName TEMPLATE_TYPES = get(PKG_GTK_TYPES, "TemplateTypes");
+
     // Some frequently used class names
     public final static ClassName G_BYTE_ARRAY = get("org.gnome.glib", "ByteArray");
     public final static ClassName G_ERROR = get("org.gnome.glib", "GError");
@@ -86,6 +89,8 @@ public final class ClassNames {
     public final static ClassName G_TYPE_CLASS = get("org.gnome.gobject", "TypeClass");
     public final static ClassName G_TYPE_INTERFACE = get("org.gnome.gobject", "TypeInterface");
     public final static ClassName G_TYPE_INSTANCE = get("org.gnome.gobject", "TypeInstance");
+
+    public final static ClassName GTK_WIDGET = get("org.gnome.gtk", "Widget");
 
     // The type variable used for <T extends GObject>
     public final static TypeVariableName GENERIC_T = TypeVariableName.get("T", G_OBJECT);

--- a/generator/src/main/java/io/github/jwharm/javagi/generators/NamespaceGenerator.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/generators/NamespaceGenerator.java
@@ -141,31 +141,35 @@ public class NamespaceGenerator extends RegisteredTypeGenerator {
                 .addModifiers(Modifier.PRIVATE, Modifier.STATIC);
 
         for (Class c : ns.classes())
-            spec.addCode(register(c.constructorName(), c.typeName()));
+            spec.addCode(register(c.constructorName(), c.typeName(), c.typeClassName()));
 
         for (Interface i : ns.interfaces())
-            spec.addCode(register(i.constructorName(), i.typeName()));
+            spec.addCode(register(i.constructorName(), i.typeName(), i.typeClassName()));
 
         for (Alias a : ns.aliases()) {
             RegisteredType target = a.lookup();
             if (target instanceof Class c)
-                spec.addCode(register(c.constructorName(), a.typeName()));
+                spec.addCode(register(c.constructorName(), a.typeName(), c.typeClassName()));
             if (target instanceof Interface i)
-                spec.addCode(register(i.constructorName(), a.typeName()));
+                spec.addCode(register(i.constructorName(), a.typeName(), i.typeClassName()));
         }
 
         for (Boxed b : ns.boxeds())
-            spec.addCode(register(b.constructorName(), b.typeName()));
+            spec.addCode(register(b.constructorName(), b.typeName(), null));
 
         return spec.build();
     }
 
-    private CodeBlock register(PartialStatement constructor, ClassName typeName) {
+    private CodeBlock register(PartialStatement constructor,
+                               ClassName typeName,
+                               ClassName typeClassName) {
         var stmt = PartialStatement.of(
                     "$typeCache:T.register($typeName:T.class, $typeName:T.getType(), ",
                         "typeCache", ClassNames.TYPE_CACHE,
                         "typeName", typeName)
                 .add(constructor)
+                .add(typeClassName == null ? ", null" : ", $typeClassName:T::new",
+                        "typeClassName", typeClassName)
                 .add(");\n");
         return CodeBlock.builder()
                 .addNamed(stmt.format(), stmt.arguments())

--- a/generator/src/main/java/io/github/jwharm/javagi/gir/Callable.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/gir/Callable.java
@@ -1,5 +1,5 @@
 /* Java-GI - Java language bindings for GObject-Introspection-based libraries
- * Copyright (C) 2022-2024 the Java-GI developers
+ * Copyright (C) 2022-2025 the Java-GI developers
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *
@@ -50,6 +50,12 @@ public sealed interface Callable
         // Explicit override: do not skip
         if (attrBool("java-gi-dont-skip", false))
             return false;
+
+        // Do not generate unnamed, parameter-less constructors
+        if (this instanceof Constructor ctr
+                && "new".equals(ctr.name())
+                && (ctr.parameters() == null || ctr.parameters().parameters().isEmpty()))
+            return true;
 
         // Do not generate virtual methods in interfaces
         if (this instanceof VirtualMethod vm

--- a/generator/src/main/java/io/github/jwharm/javagi/gir/RegisteredType.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/gir/RegisteredType.java
@@ -1,5 +1,5 @@
 /* Java-GI - Java language bindings for GObject-Introspection-based libraries
- * Copyright (C) 2022-2024 the Java-GI developers
+ * Copyright (C) 2022-2025 the Java-GI developers
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *
@@ -44,6 +44,20 @@ public sealed interface RegisteredType
 
     default ClassName typeName() {
         return toJavaQualifiedType(name(), namespace());
+    }
+
+    default ClassName typeClassName() {
+        Record typeStruct = switch(this) {
+            case Class c -> c.typeStruct();
+            case Interface i -> i.typeStruct();
+            case Alias a -> switch(a.lookup()) {
+                case Class c -> c.typeStruct();
+                case Interface i -> i.typeStruct();
+                case null, default -> null;
+            };
+            default -> null;
+        };
+        return typeStruct == null ? null : typeStruct.typeName();
     }
 
     default String javaType() {

--- a/modules/gio/src/main/java/io/github/jwharm/javagi/gio/ListIndexModel.java
+++ b/modules/gio/src/main/java/io/github/jwharm/javagi/gio/ListIndexModel.java
@@ -1,5 +1,5 @@
 /* Java-GI - Java language bindings for GObject-Introspection-based libraries
- * Copyright (C) 2022-2024 Jan-Willem Harmannij
+ * Copyright (C) 2022-2025 Jan-Willem Harmannij
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *
@@ -19,11 +19,10 @@
 
 package io.github.jwharm.javagi.gio;
 
-import java.lang.foreign.*;
 import java.util.ArrayList;
 
 import io.github.jwharm.javagi.gobject.annotations.Property;
-import io.github.jwharm.javagi.gobject.types.Types;
+import io.github.jwharm.javagi.gobject.types.TypeCache;
 import org.gnome.gio.ListModel;
 import org.gnome.glib.Type;
 import org.gnome.gobject.*;
@@ -36,7 +35,6 @@ import org.gnome.gobject.*;
 public class ListIndexModel extends GObject
         implements ListModel<ListIndexModel.ListIndex> {
 
-    private static final Type gtype = Types.register(ListIndexModel.class);
     private ArrayList<ListIndex> items = new ArrayList<>();
 
     /**
@@ -45,27 +43,28 @@ public class ListIndexModel extends GObject
      * @return the GType
      */
     public static Type getType() {
-        return gtype;
+        return TypeCache.getType(ListIndexModel.class);
     }
 
     /**
      * Construct a ListIndexModel for the provided memory address.
      *
-     * @param address the memory address of the instance in native memory
+     * @param size the initial list size
      */
-    public ListIndexModel(MemorySegment address) {
-        super(address);
+    public ListIndexModel(int size) {
+        super();
+        setSize(size);
     }
 
     /**
      * Construct a new ListIndexModel with the provided size.
      *
      * @param size the initial size of the list model
+     * @deprecated Replaced with {@link #ListIndexModel(int)}
      */
+    @Deprecated
     public static ListIndexModel newInstance(int size) {
-        ListIndexModel model = GObject.newInstance(gtype);
-        model.setSize(size);
-        return model;
+        return new ListIndexModel(size);
     }
 
     /**
@@ -78,23 +77,23 @@ public class ListIndexModel extends GObject
         int oldSize = items.size();
         items = new ArrayList<>(size);
         for (int i = 0; i < size; i++)
-            items.add(ListIndex.newInstance(i));
+            items.add(new ListIndex(i));
         itemsChanged(0, oldSize, size);
     }
 
     /**
      * Get the gtype of {@link ListIndex}.
      *
-     * @return always returns the value of {@link ListIndex#gtype}
+     * @return always returns the value of {@link ListIndex#getType}
      */
     @Property(constructOnly = true)
     @Override
     public Type getItemType() {
-        return ListIndex.gtype;
+        return ListIndex.getType();
     }
 
     /**
-     * No-op. The item type is always {@link ListIndex#gtype}.
+     * No-op. The item type is always {@link ListIndex#getType}.
      *
      * @param itemType ignored
      */
@@ -131,9 +130,7 @@ public class ListIndexModel extends GObject
      * Small GObject-derived class with a numeric "index" field.
      */
     public static class ListIndex extends GObject {
-
-        private static final Type gtype = Types.register(ListIndex.class);
-        private int index;
+        private final int index;
 
         /**
          * Return the GType for the ListIndex.
@@ -141,28 +138,17 @@ public class ListIndexModel extends GObject
          * @return the GType
          */
         public static Type getType() {
-            return gtype;
+            return TypeCache.getType(ListIndex.class);
         }
 
         /**
          * Construct a new ListIndex Proxy instance.
          *
-         * @param address the memory address of the native object instance
+         * @param value the index value
          */
-        public ListIndex(MemorySegment address) {
-            super(address);
-        }
-
-        /**
-         * Construct a new ListIndex with the provided value.
-         *
-         * @param  value the value of the ListIndex instance
-         * @return a new ListIndex instance
-         */
-        public static ListIndex newInstance(int value) {
-            ListIndex instance = GObject.newInstance(gtype);
-            instance.index = value;
-            return instance;
+        public ListIndex(int value) {
+            super();
+            this.index = value;
         }
 
         /**

--- a/modules/gio/src/test/java/io/github/jwharm/javagi/test/gio/ListModelTest.java
+++ b/modules/gio/src/test/java/io/github/jwharm/javagi/test/gio/ListModelTest.java
@@ -23,7 +23,7 @@ public class ListModelTest {
     @Test
     public void createListModel() {
         // verify that ListIndexModel works as expected
-        var listIndexModel = ListIndexModel.newInstance(1000);
+        var listIndexModel = new ListIndexModel(1000);
         assertEquals(listIndexModel.getItemType(), ListIndexModel.ListIndex.getType());
         assertEquals(1000, listIndexModel.getNItems());
 

--- a/modules/gio/src/test/java/io/github/jwharm/javagi/test/gio/PropertiesTest.java
+++ b/modules/gio/src/test/java/io/github/jwharm/javagi/test/gio/PropertiesTest.java
@@ -1,5 +1,5 @@
 /* Java-GI - Java language bindings for GObject-Introspection-based libraries
- * Copyright (C) 2022-2023 Jan-Willem Harmannij
+ * Copyright (C) 2022-2025 Jan-Willem Harmannij
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *
@@ -23,7 +23,6 @@ import io.github.jwharm.javagi.gobject.types.Properties;
 
 import org.gnome.gio.Application;
 import org.gnome.gio.ApplicationFlags;
-import org.gnome.gobject.GObject;
 import org.junit.jupiter.api.Test;
 
 import java.util.Set;
@@ -39,14 +38,14 @@ public class PropertiesTest {
 
     @Test
     public void getProperty() {
-        Application app = new Application("io.github.jwharm.javagi.test.Application", ApplicationFlags.DEFAULT_FLAGS);
+        Application app = new Application("io.github.jwharm.javagi.test.Application");
         String applicationId = (String) app.getProperty("application-id");
         assertEquals("io.github.jwharm.javagi.test.Application", applicationId);
     }
 
     @Test
     public void setProperty() {
-        Application app = new Application("io.github.jwharm.javagi.test.Application", ApplicationFlags.DEFAULT_FLAGS);
+        Application app = new Application("io.github.jwharm.javagi.test.Application");
         app.setProperty("application-id", "my.example.Application");
         String applicationId = (String) Properties.getProperty(app, "application-id");
         assertEquals("my.example.Application", applicationId);
@@ -54,8 +53,7 @@ public class PropertiesTest {
 
     @Test
     public void newGObjectWithProperties() {
-        Application app = GObject.newInstance(
-                Application.getType(),
+        Application app = new Application(
                 "application-id", "io.github.jwharm.javagi.test.Application",
                 "flags", ApplicationFlags.DEFAULT_FLAGS);
         String applicationId = (String) Properties.getProperty(app, "application-id");
@@ -68,9 +66,7 @@ public class PropertiesTest {
         Application app = Application.builder()
                 .setApplicationId("javagi.test.Application1")
                 .setFlags(Set.of(ApplicationFlags.IS_SERVICE))
-                .onNotify("application-id", _ -> {
-                    notified.set(true);
-                })
+                .onNotify("application-id", _ -> notified.set(true))
                 .build();
 
         // Assert that the properties are set

--- a/modules/glib/src/main/java/io/github/jwharm/javagi/base/ProxyInstance.java
+++ b/modules/glib/src/main/java/io/github/jwharm/javagi/base/ProxyInstance.java
@@ -27,7 +27,7 @@ import java.util.Objects;
  */
 public class ProxyInstance implements Proxy {
 
-    private final MemorySegment address;
+    public MemorySegment address;
 
     /**
      * Create a new {@code ProxyInstance} object for an instance in native

--- a/modules/gobject/src/main/java/io/github/jwharm/javagi/gobject/InstanceCache.java
+++ b/modules/gobject/src/main/java/io/github/jwharm/javagi/gobject/InstanceCache.java
@@ -1,5 +1,5 @@
 /* Java-GI - Java language bindings for GObject-Introspection-based libraries
- * Copyright (C) 2022-2024 Jan-Willem Harmannij
+ * Copyright (C) 2022-2025 Jan-Willem Harmannij
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *
@@ -341,6 +341,18 @@ public class InstanceCache {
         return object;
     }
 
+    /**
+     * Construct a new GObject instance and set the provided Java proxy to
+     * its address.
+     *
+     * @param proxy      the Java Proxy for the newly constructed GObject
+     *                   instance
+     * @param objectType the GType, if {@code null} it will be queried from
+     *                   the TypeCache
+     * @param size       the size of the native instance
+     * @param properties pairs of property names and values (optional).
+     *                   A trailing {@code null} will be added automatically.
+     */
     public static void newGObject(GObject proxy,
                                   Type objectType,
                                   long size,

--- a/modules/gobject/src/main/java/io/github/jwharm/javagi/gobject/JavaClosure.java
+++ b/modules/gobject/src/main/java/io/github/jwharm/javagi/gobject/JavaClosure.java
@@ -1,5 +1,5 @@
 /* Java-GI - Java language bindings for GObject-Introspection-based libraries
- * Copyright (C) 2022-2023 Jan-Willem Harmannij
+ * Copyright (C) 2022-2025 Jan-Willem Harmannij
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *
@@ -25,7 +25,6 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.function.BooleanSupplier;
 
-import io.github.jwharm.javagi.interop.MemoryCleaner;
 import org.gnome.glib.GLib;
 import org.gnome.glib.LogLevelFlags;
 import org.gnome.gobject.Closure;

--- a/modules/gobject/src/main/java/io/github/jwharm/javagi/gobject/types/Overrides.java
+++ b/modules/gobject/src/main/java/io/github/jwharm/javagi/gobject/types/Overrides.java
@@ -1,5 +1,5 @@
 /* Java-GI - Java language bindings for GObject-Introspection-based libraries
- * Copyright (C) 2022-2023 Jan-Willem Harmannij
+ * Copyright (C) 2022-2025 Jan-Willem Harmannij
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *
@@ -93,9 +93,10 @@ public class Overrides {
      * @return a lambda to run during class initialization that will register
      *         the virtual functions
      */
-    public static Consumer<TypeClass> overrideClassMethods(Class<?> cls) {
+    public static <T extends TypeInstance, TC extends TypeClass>
+    Consumer<TypeClass> overrideClassMethods(Class<?> cls) {
 
-        Class<?> typeStruct = Types.getTypeClass(cls);
+        Class<TC> typeStruct = Types.getTypeClass(cls);
         if (typeStruct == null)
             return null;
         Class<?> parentClass = cls.getSuperclass();

--- a/modules/gobject/src/main/java/io/github/jwharm/javagi/gobject/types/TypeCache.java
+++ b/modules/gobject/src/main/java/io/github/jwharm/javagi/gobject/types/TypeCache.java
@@ -46,6 +46,9 @@ public class TypeCache {
     private final static Map<Type, Function<MemorySegment, ? extends Proxy>> typeRegister
             = new ConcurrentHashMap<>();
 
+    private final static Map<Type, Function<MemorySegment, ? extends Proxy>> typeClassRegister
+            = new ConcurrentHashMap<>();
+
     private final static Map<Class<?>, Type> classToTypeMap
             = new ConcurrentHashMap<>();
 
@@ -61,7 +64,7 @@ public class TypeCache {
      * Get the constructor from the type registry for the native object
      * instance at the given memory address. The applicable constructor is
      * determined based on the GType of the native object (as it was registered
-     * using {@link #register(Class, Type, Function)}).
+     * using {@link #register(Class, Type, Function, Function)}).
      *
      * @param address  address of TypeInstance object to obtain the type from
      * @param fallback if none was found, this constructor will be registered
@@ -194,6 +197,11 @@ public class TypeCache {
         return type;
     }
 
+    public static Function<MemorySegment, ? extends Proxy>
+    getTypeClassConstructor(@NotNull Type type) {
+        return typeClassRegister.get(type);
+    }
+
     /**
      * Register the type and constructor function for the provided class
      *
@@ -203,11 +211,14 @@ public class TypeCache {
      */
     public static void register(Class<?> cls,
                                 Type type,
-                                Function<MemorySegment, ? extends Proxy> ctor) {
+                                Function<MemorySegment, ? extends Proxy> ctor,
+                                Function<MemorySegment, ? extends Proxy> typeClassCtor) {
         requireNonNull(cls);
         if (type != null) {
             if (ctor != null)
                 typeRegister.put(type, ctor);
+            if (typeClassCtor != null)
+                typeClassRegister.put(type, typeClassCtor);
             classToTypeMap.put(cls, type);
         }
     }

--- a/modules/gobject/src/main/java/io/github/jwharm/javagi/gobject/types/TypeCache.java
+++ b/modules/gobject/src/main/java/io/github/jwharm/javagi/gobject/types/TypeCache.java
@@ -1,5 +1,5 @@
 /* Java-GI - Java language bindings for GObject-Introspection-based libraries
- * Copyright (C) 2022-2023 Jan-Willem Harmannij
+ * Copyright (C) 2022-2025 Jan-Willem Harmannij
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *
@@ -41,7 +41,7 @@ import static java.util.Objects.requireNonNull;
  * the GType of the native object instance.
  */
 public class TypeCache {
-    
+
     private final static Map<Type, Function<MemorySegment, ? extends Proxy>> typeRegister
             = new ConcurrentHashMap<>();
 
@@ -174,6 +174,16 @@ public class TypeCache {
                 typeRegister.put(type, ctor);
             classToTypeMap.put(cls, type);
         }
+    }
+
+    /**
+     * Check if this class is already cached.
+     *
+     * @param  cls the class to check
+     * @return true when the class is cached in the TypeCache
+     */
+    public static boolean contains(Class<?> cls) {
+        return classToTypeMap.containsKey(cls);
     }
 
     /**

--- a/modules/gobject/src/main/java/io/github/jwharm/javagi/gobject/types/TypeCache.java
+++ b/modules/gobject/src/main/java/io/github/jwharm/javagi/gobject/types/TypeCache.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
 import org.gnome.glib.Type;
+import org.gnome.gobject.GObject;
 import org.gnome.gobject.GObjects;
 import org.gnome.gobject.TypeInstance;
 
@@ -47,6 +48,14 @@ public class TypeCache {
 
     private final static Map<Class<?>, Type> classToTypeMap
             = new ConcurrentHashMap<>();
+
+    private static final Map<Class<? extends GObject>, Function<Class<? extends GObject>, Type>> typeRegisterFunctions
+            = new ConcurrentHashMap<>();
+
+    public static void setTypeRegisterFunction(Class<? extends GObject> cls,
+                                               Function<Class<? extends GObject>, Type> function) {
+        typeRegisterFunctions.put(cls, function);
+    }
 
     /**
      * Get the constructor from the type registry for the native object
@@ -143,18 +152,45 @@ public class TypeCache {
     }
 
     /**
-     * Return the GType that was registered for this class.
+     * Return the GType that was registered for this class. If no type was
+     * registered yet, this method will try to register it, and then return
+     * the GType.
      *
      * @param  cls a Java class
      * @return the cached GType
      */
     public static Type getType(Class<?> cls) {
         requireNonNull(cls);
+
+        // Class must be a GObject derived class
+        @SuppressWarnings("unchecked")
+        var gobjectClass = (Class<? extends GObject>) cls;
+
+        // Ensure the class is loaded and initialized. This is useful in case
+        // there's static initialization code that needs to be run.
         forceInit(cls);
+
+        // Is the class cached?
         var type = classToTypeMap.get(cls);
-        if (type == null)
+        if (type != null)
+            return type;
+
+        // Register the type: Determine which function to use
+        var classes = typeRegisterFunctions.keySet();
+        var mostSpecific = classes.stream()
+                .filter(c -> c.isAssignableFrom(cls))
+                .max((c0, c1) -> c0.isAssignableFrom(c1) ? -1 : c1.isAssignableFrom(c0) ? 1 : 0);
+
+        // No function found to register this class
+        if (mostSpecific.isEmpty())
             throw new IllegalArgumentException(
-                    "Class " + cls.getSimpleName() + " is not a registered GType");
+                    "Class " + cls.getSimpleName() + " cannot be registered");
+
+        // Run the type registration function
+        var function = typeRegisterFunctions.get(mostSpecific.get());
+
+        function.apply(gobjectClass);
+        type = classToTypeMap.get(cls);
         return type;
     }
 

--- a/modules/gobject/src/test/java/io/github/jwharm/javagi/test/gobject/ClosureTest.java
+++ b/modules/gobject/src/test/java/io/github/jwharm/javagi/test/gobject/ClosureTest.java
@@ -97,15 +97,11 @@ public class ClosureTest {
 
     // A simple GObject-derived class with a "num" property
     public static class NumObject extends GObject {
-//        public NumObject(MemorySegment address) {
-//            super(address);
-//        }
+        private int num;
 
         public NumObject() {
             super();
         }
-
-        private int num;
 
         @SuppressWarnings("unused")
         public void setNum(int num) {

--- a/modules/gobject/src/test/java/io/github/jwharm/javagi/test/gobject/ClosureTest.java
+++ b/modules/gobject/src/test/java/io/github/jwharm/javagi/test/gobject/ClosureTest.java
@@ -1,5 +1,5 @@
 /* Java-GI - Java language bindings for GObject-Introspection-based libraries
- * Copyright (C) 2022-2024 Jan-Willem Harmannij
+ * Copyright (C) 2022-2025 Jan-Willem Harmannij
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *
@@ -19,10 +19,7 @@
 
 package io.github.jwharm.javagi.test.gobject;
 
-import io.github.jwharm.javagi.gobject.annotations.Property;
-import io.github.jwharm.javagi.gobject.types.Types;
 import io.github.jwharm.javagi.gobject.JavaClosure;
-import org.gnome.glib.Type;
 import org.gnome.gobject.Binding;
 import org.gnome.gobject.BindingFlags;
 import org.gnome.gobject.GObject;
@@ -47,8 +44,8 @@ public class ClosureTest {
     @Test
     public void methodReference() {
         // Create 2 objects, both with a simple "num" property of type int
-        NumObject n1 = GObject.newInstance(NumObject.type);
-        NumObject n2 = GObject.newInstance(NumObject.type);
+        NumObject n1 = new NumObject();
+        NumObject n2 = new NumObject();
 
         // Create a JavaClosure for the "timesTwo" method
         Method timesTwo = null;
@@ -72,8 +69,8 @@ public class ClosureTest {
     @Test
     public void lambda() {
         // Create 2 objects, both with a simple "num" property of type int
-        NumObject n1 = GObject.newInstance(NumObject.type);
-        NumObject n2 = GObject.newInstance(NumObject.type);
+        NumObject n1 = new NumObject();
+        NumObject n2 = new NumObject();
         
         // Create a JavaClosure for the "timesTwo" method
         JavaClosure closure = new JavaClosure((MyInterface) this::timesTwo);
@@ -100,18 +97,22 @@ public class ClosureTest {
 
     // A simple GObject-derived class with a "num" property
     public static class NumObject extends GObject {
-        public static Type type = Types.register(NumObject.class);
-        public NumObject(MemorySegment address) {
-            super(address);
+//        public NumObject(MemorySegment address) {
+//            super(address);
+//        }
+
+        public NumObject() {
+            super();
         }
 
         private int num;
 
         @SuppressWarnings("unused")
-        @Property(name="num") public void setNum(int num) {
+        public void setNum(int num) {
             this.num = num;
         }
-        @Property(name="num") public int getNum() {
+
+        public int getNum() {
             return this.num;
         }
     }

--- a/modules/gobject/src/test/java/io/github/jwharm/javagi/test/gobject/DerivedClassTest.java
+++ b/modules/gobject/src/test/java/io/github/jwharm/javagi/test/gobject/DerivedClassTest.java
@@ -58,7 +58,7 @@ public class DerivedClassTest {
      */
     @Test
     public void initializersHaveRun() {
-        TestObject object = GObject.newInstance(TestObject.gtype);
+        TestObject ignored = GObject.newInstance(TestObject.gtype);
         assertTrue(classInitHasRun);
         assertTrue(instanceInitHasRun);
     }

--- a/modules/gobject/src/test/java/io/github/jwharm/javagi/test/gobject/DerivedClassTest.java
+++ b/modules/gobject/src/test/java/io/github/jwharm/javagi/test/gobject/DerivedClassTest.java
@@ -1,5 +1,5 @@
 /* Java-GI - Java language bindings for GObject-Introspection-based libraries
- * Copyright (C) 2022-2023 Jan-Willem Harmannij
+ * Copyright (C) 2022-2025 Jan-Willem Harmannij
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *
@@ -23,6 +23,7 @@ import io.github.jwharm.javagi.gobject.annotations.ClassInit;
 import io.github.jwharm.javagi.gobject.annotations.InstanceInit;
 import io.github.jwharm.javagi.gobject.annotations.Property;
 import io.github.jwharm.javagi.gobject.annotations.RegisteredType;
+import io.github.jwharm.javagi.gobject.types.TypeCache;
 import io.github.jwharm.javagi.gobject.types.Types;
 import org.gnome.glib.Type;
 import org.gnome.gobject.GObject;
@@ -124,6 +125,12 @@ public class DerivedClassTest {
         assertEquals(input2, object2.getProperty("bool-property"));
     }
 
+    @Test
+    public void autoRegisterType() {
+        new AutoRegistered();
+        assertTrue(TypeCache.contains(AutoRegistered.class));
+    }
+
     /**
      * Simple GObject-derived class used in the above tests
      */
@@ -175,6 +182,12 @@ public class DerivedClassTest {
         @Property
         public void setBoolProperty(boolean boolProperty) {
             this.boolProperty = boolProperty;
+        }
+    }
+
+    public static class AutoRegistered extends GObject {
+        public AutoRegistered() {
+            super();
         }
     }
 }

--- a/modules/gobject/src/test/java/io/github/jwharm/javagi/test/gobject/DerivedClassTest.java
+++ b/modules/gobject/src/test/java/io/github/jwharm/javagi/test/gobject/DerivedClassTest.java
@@ -135,13 +135,12 @@ public class DerivedClassTest {
         }
 
         public TestObject() {
-            super(TestObject.class);
+            super();
         }
 
         public TestObject(String stringValue, boolean booleanValue) {
-            super(TestObject.class,
-                    "string-property", stringValue,
-                    "bool-property", booleanValue);
+            super("string-property", stringValue,
+                  "bool-property", booleanValue);
         }
 
         @ClassInit
@@ -154,7 +153,7 @@ public class DerivedClassTest {
             instanceInitHasRun = true;
         }
 
-        private String stringProperty = null;
+        private String stringProperty;
 
         @Property(name="string-property")
         public String getStringProperty() {
@@ -166,7 +165,7 @@ public class DerivedClassTest {
             this.stringProperty = value;
         }
 
-        private boolean boolProperty = false;
+        private boolean boolProperty;
 
         @Property // name will be inferred: "bool-property"
         public boolean getBoolProperty() {

--- a/modules/gobject/src/test/java/io/github/jwharm/javagi/test/gobject/NewSignalTest.java
+++ b/modules/gobject/src/test/java/io/github/jwharm/javagi/test/gobject/NewSignalTest.java
@@ -1,5 +1,5 @@
 /* Java-GI - Java language bindings for GObject-Introspection-based libraries
- * Copyright (C) 2022-2023 Jan-Willem Harmannij
+ * Copyright (C) 2022-2025 Jan-Willem Harmannij
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *
@@ -19,16 +19,12 @@
 
 package io.github.jwharm.javagi.test.gobject;
 
-import io.github.jwharm.javagi.gobject.annotations.GType;
 import io.github.jwharm.javagi.gobject.annotations.Property;
 import io.github.jwharm.javagi.gobject.annotations.RegisteredType;
 import io.github.jwharm.javagi.gobject.annotations.Signal;
-import io.github.jwharm.javagi.gobject.types.Types;
-import org.gnome.glib.Type;
 import org.gnome.gobject.GObject;
 import org.junit.jupiter.api.Test;
 
-import java.lang.foreign.MemorySegment;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.IntConsumer;
 
@@ -48,11 +44,11 @@ public class NewSignalTest {
     @Test
     void registerSignal() {
         // Create a Counter object (see below) with limit 10
-        Counter counter = GObject.newInstance(Counter.getType(), "limit", 10);
+        Counter counter = new Counter(10);
         AtomicBoolean success = new AtomicBoolean(false);
 
         // Connect to the "limit-reached" signal
-        counter.connect("limit-reached", (Counter.LimitReached) (max) -> success.set(true));
+        counter.connect("limit-reached", (Counter.LimitReached) _ -> success.set(true));
 
         // First count to 9, this should not run the callback.
         for (int a = 0; a < 9; a++)
@@ -71,15 +67,8 @@ public class NewSignalTest {
      */
     @RegisteredType(name="TestCounter")
     public static class Counter extends GObject {
-        private static final Type gtype = Types.register(Counter.class);
-
-        @GType
-        public static Type getType() {
-            return gtype;
-        }
-
-        public Counter(MemorySegment address) {
-            super(address);
+        public Counter(int limit) {
+            super("limit", 10);
         }
 
         @Signal
@@ -93,12 +82,10 @@ public class NewSignalTest {
             return num;
         }
 
-        @Property(name="limit")
         public void setLimit(int limit) {
             this.limit = limit;
         }
 
-        @Property(name="limit")
         public int getLimit() {
             return this.limit;
         }

--- a/modules/gobject/src/test/java/io/github/jwharm/javagi/test/gobject/PropertyBindingTest.java
+++ b/modules/gobject/src/test/java/io/github/jwharm/javagi/test/gobject/PropertyBindingTest.java
@@ -1,5 +1,5 @@
 /* Java-GI - Java language bindings for GObject-Introspection-based libraries
- * Copyright (C) 2022-2024 Jan-Willem Harmannij
+ * Copyright (C) 2022-2025 Jan-Willem Harmannij
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *
@@ -20,12 +20,8 @@
 package io.github.jwharm.javagi.test.gobject;
 
 import io.github.jwharm.javagi.gobject.annotations.RegisteredType;
-import io.github.jwharm.javagi.gobject.types.Types;
-import org.gnome.glib.Type;
 import org.gnome.gobject.GObject;
 import org.junit.jupiter.api.Test;
-
-import java.lang.foreign.MemorySegment;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -36,8 +32,8 @@ public class PropertyBindingTest {
 
     @Test
     void testPropertyBinding() {
-        Speed kmh = Speed.create(0.0);
-        Speed mph = Speed.create(0.0);
+        Speed kmh = new Speed(0.0);
+        Speed mph = new Speed(0.0);
 
         kmh.<Double, Double>bindProperty("current-speed", mph, "current-speed")
                 .bidirectional()
@@ -53,8 +49,8 @@ public class PropertyBindingTest {
 
     @Test
     void testArgumentValidation() {
-        Speed kmh = Speed.create(0.0);
-        Speed mph = Speed.create(0.0);
+        Speed kmh = new Speed(0.0);
+        Speed mph = new Speed(0.0);
 
         try {
             kmh.<Double, Double>bindProperty("too-fast", mph, "too-fast")
@@ -85,22 +81,11 @@ public class PropertyBindingTest {
 
     @RegisteredType(name="Speed")
     public static class Speed extends GObject {
-        private static final Type type = Types.register(Speed.class);
-        private double currentSpeed = 0.0;
+        private double currentSpeed;
         private final double limit = 70.0;
 
-        public static Type getType() {
-            return type;
-        }
-
-        public Speed(MemorySegment address) {
-            super(address);
-        }
-
-        public static Speed create(double currentSpeed) {
-            return GObject.newInstance(getType(),
-                    "current-speed", currentSpeed,
-                    null);
+        public Speed(double currentSpeed) {
+            super("current-speed", currentSpeed);
         }
 
         public double getCurrentSpeed() {

--- a/modules/gobject/src/test/java/io/github/jwharm/javagi/test/gobject/PropertyTest.java
+++ b/modules/gobject/src/test/java/io/github/jwharm/javagi/test/gobject/PropertyTest.java
@@ -1,12 +1,28 @@
+/* Java-GI - Java language bindings for GObject-Introspection-based libraries
+ * Copyright (C) 2025 Jan-Willem Harmannij
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 package io.github.jwharm.javagi.test.gobject;
 
 import io.github.jwharm.javagi.gobject.annotations.Property;
 import io.github.jwharm.javagi.gobject.annotations.RegisteredType;
-import io.github.jwharm.javagi.gobject.types.Types;
 import org.gnome.gobject.GObject;
 import org.junit.jupiter.api.Test;
-
-import java.lang.foreign.MemorySegment;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -17,8 +33,7 @@ public class PropertyTest {
 
     @Test
     void testCustomProperties() {
-        Types.register(Dino.class);
-        var dino = GObject.newInstance(Dino.class);
+        var dino = new Dino();
         var gclass = (GObject.ObjectClass) dino.readGClass();
 
         // Check that the properties exist
@@ -79,8 +94,8 @@ public class PropertyTest {
         private int fgh;
         private long xyz;
 
-        public Dino(MemorySegment address) {
-            super(address);
+        public Dino() {
+            super();
         }
 
         // Int property with getter and setter

--- a/modules/gobject/src/test/java/io/github/jwharm/javagi/test/gobject/ToStringTest.java
+++ b/modules/gobject/src/test/java/io/github/jwharm/javagi/test/gobject/ToStringTest.java
@@ -1,3 +1,22 @@
+/* Java-GI - Java language bindings for GObject-Introspection-based libraries
+ * Copyright (C) 2025 Jan-Willem Harmannij
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 package io.github.jwharm.javagi.test.gobject;
 
 import io.github.jwharm.javagi.gobject.types.Types;

--- a/modules/gtk/src/main/java/io/github/jwharm/javagi/gtk/types/TemplateTypes.java
+++ b/modules/gtk/src/main/java/io/github/jwharm/javagi/gtk/types/TemplateTypes.java
@@ -1,5 +1,5 @@
 /* Java-GI - Java language bindings for GObject-Introspection-based libraries
- * Copyright (C) 2022-2024 Jan-Willem Harmannij
+ * Copyright (C) 2022-2025 Jan-Willem Harmannij
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *
@@ -220,7 +220,7 @@ public class TemplateTypes {
             }, Arena.global());
 
             // Install BuilderJavaScope to call Java signal handler methods
-            widgetClass.setTemplateScope(BuilderJavaScope.newInstance());
+            widgetClass.setTemplateScope(new BuilderJavaScope());
 
             for (Field field : cls.getDeclaredFields()) {
                 if (field.isAnnotationPresent(GtkChild.class)) {
@@ -288,6 +288,8 @@ public class TemplateTypes {
             Type parentType = TypeCache.getType(parentClass);
             MemoryLayout classLayout = generateClassLayout(cls, name);
             Function<MemorySegment, W> constructor = getAddressConstructor(cls);
+            Function<MemorySegment, ? extends Proxy> typeClassCtor =
+                    TypeCache.getTypeClassConstructor(parentType);
             Set<TypeFlags> flags = getTypeFlags(cls);
 
             // Chain template class init with user-defined class init function
@@ -329,6 +331,7 @@ public class TemplateTypes {
                     instanceLayout,
                     instanceInit,
                     constructor,
+                    typeClassCtor,
                     flags
             );
 

--- a/modules/gtk/src/main/java/io/github/jwharm/javagi/gtk/types/TemplateTypes.java
+++ b/modules/gtk/src/main/java/io/github/jwharm/javagi/gtk/types/TemplateTypes.java
@@ -350,15 +350,13 @@ public class TemplateTypes {
      * (GObject-derived) classes.
      *
      * @param  cls the class to register as a new GType
-     * @param  <T> the class must extend {@link GObject}
      * @return the new GType
      */
     @SuppressWarnings("unchecked")
-    public static <T extends GObject, W extends Widget>
-    Type register(Class<T> cls) {
+    public static Type register(Class<?> cls) {
         if (Widget.class.isAssignableFrom(cls)
                 && cls.isAnnotationPresent(GtkTemplate.class)) {
-            return registerTemplate((Class<W>) cls);
+            return registerTemplate((Class<? extends Widget>) cls);
         } else {
             return io.github.jwharm.javagi.gobject.types.Types.register(cls);
         }

--- a/modules/gtk/src/main/java/io/github/jwharm/javagi/gtk/util/BuilderJavaScope.java
+++ b/modules/gtk/src/main/java/io/github/jwharm/javagi/gtk/util/BuilderJavaScope.java
@@ -22,14 +22,12 @@ package io.github.jwharm.javagi.gtk.util;
 import io.github.jwharm.javagi.base.GErrorException;
 import io.github.jwharm.javagi.gtk.annotations.GtkCallback;
 import io.github.jwharm.javagi.gobject.JavaClosure;
-import io.github.jwharm.javagi.gtk.types.TemplateTypes;
 import org.gnome.glib.GLib;
 import org.gnome.glib.LogLevelFlags;
 import org.gnome.glib.Type;
 import org.gnome.gobject.*;
 import org.gnome.gtk.*;
 
-import java.lang.foreign.MemorySegment;
 import java.lang.reflect.Method;
 import java.util.Set;
 
@@ -49,33 +47,15 @@ import static io.github.jwharm.javagi.Constants.LOG_DOMAIN;
 public final class BuilderJavaScope extends BuilderCScope
         implements BuilderScope {
 
-    private static final Type gtype = TemplateTypes.register(BuilderJavaScope.class);
-
     static {
         Gtk.javagi$ensureInitialized();
     }
 
     /**
-     * Memory address constructor for instantiating a Java proxy object
-     * @param address the memory address of the native object
+     * Default constructor
      */
-    public BuilderJavaScope(MemorySegment address) {
-        super(address);
-    }
-
-    /**
-     * Return the GType of {@link BuilderJavaScope}
-     * @return the GType
-     */
-    public static Type getType() {
-        return gtype;
-    }
-
-    /**
-     * Instantiates a new {@link BuilderScope}
-     */
-    public static BuilderJavaScope newInstance() {
-        return GObject.newInstance(gtype);
+    public BuilderJavaScope() {
+        super();
     }
 
     /**

--- a/modules/gtk/src/test/java/io/github/jwharm/javagi/test/gtk/TemplateChildTest.java
+++ b/modules/gtk/src/test/java/io/github/jwharm/javagi/test/gtk/TemplateChildTest.java
@@ -1,5 +1,5 @@
 /* Java-GI - Java language bindings for GObject-Introspection-based libraries
- * Copyright (C) 2022-2023 Jan-Willem Harmannij
+ * Copyright (C) 2022-2025 Jan-Willem Harmannij
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *
@@ -22,11 +22,7 @@ package io.github.jwharm.javagi.test.gtk;
 import io.github.jwharm.javagi.base.GErrorException;
 import io.github.jwharm.javagi.gtk.annotations.GtkChild;
 import io.github.jwharm.javagi.gtk.annotations.GtkTemplate;
-import io.github.jwharm.javagi.gtk.types.TemplateTypes;
-import org.gnome.gio.ApplicationFlags;
 import org.gnome.gio.Resource;
-import org.gnome.glib.Type;
-import org.gnome.gobject.GObject;
 import org.gnome.gtk.Application;
 import org.gnome.gtk.Label;
 import org.gnome.gtk.ApplicationWindow;
@@ -55,10 +51,10 @@ public class TemplateChildTest {
         resource.resourcesRegister();
 
         // New Gtk application
-        Application app = new Application(TemplateChildTest.class.getName(), ApplicationFlags.DEFAULT_FLAGS);
+        Application app = new Application(TemplateChildTest.class.getName());
         app.onActivate(() -> {
             // New TestWindow (defined below)
-            TestWindow tw = GObject.newInstance(TestWindow.gtype);
+            TestWindow tw = new TestWindow();
 
             // Check that the label field is set to the value from the ui file
             assertEquals(tw.label.getLabel(), "Test Label");
@@ -66,7 +62,7 @@ public class TemplateChildTest {
             // Check that the "namedLabel" field (referring to the "label"
             // element in the XML using the annotation parameter "name", is set
             // to the expected value
-            TestWindow tw2 = GObject.newInstance(TestWindow.gtype);
+            TestWindow tw2 = new TestWindow();
             assertEquals(tw2.namedLabel.getLabel(), "Second Label");
 
             app.quit();
@@ -76,9 +72,8 @@ public class TemplateChildTest {
 
     @GtkTemplate(name="ChildTestWindow", ui="/io/github/jwharm/javagi/gtk/TemplateChildTest.ui")
     public static class TestWindow extends ApplicationWindow {
-        public static Type gtype = TemplateTypes.register(TestWindow.class);
-        public TestWindow(MemorySegment address ){
-            super(address);
+        public TestWindow( ){
+            super();
         }
 
         @GtkChild

--- a/modules/gtk/src/test/java/io/github/jwharm/javagi/test/gtk/TemplateSignalTest.java
+++ b/modules/gtk/src/test/java/io/github/jwharm/javagi/test/gtk/TemplateSignalTest.java
@@ -1,5 +1,5 @@
 /* Java-GI - Java language bindings for GObject-Introspection-based libraries
- * Copyright (C) 2022-2023 Jan-Willem Harmannij
+ * Copyright (C) 2022-2025 Jan-Willem Harmannij
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *
@@ -22,18 +22,12 @@ package io.github.jwharm.javagi.test.gtk;
 import io.github.jwharm.javagi.base.GErrorException;
 import io.github.jwharm.javagi.gtk.annotations.GtkChild;
 import io.github.jwharm.javagi.gtk.annotations.GtkTemplate;
-import io.github.jwharm.javagi.gtk.types.TemplateTypes;
-import org.gnome.gio.ApplicationFlags;
 import org.gnome.gio.Resource;
-import org.gnome.glib.Type;
-import org.gnome.gobject.GObject;
 import org.gnome.gtk.Application;
 import org.gnome.gtk.ApplicationWindow;
 import org.gnome.gtk.Button;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Isolated;
-
-import java.lang.foreign.MemorySegment;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -55,10 +49,10 @@ public class TemplateSignalTest {
         resource.resourcesRegister();
 
         // New Gtk application
-        Application app = new Application(TemplateSignalTest.class.getName(), ApplicationFlags.DEFAULT_FLAGS);
+        Application app = new Application(TemplateSignalTest.class.getName());
         app.onActivate(() -> {
             // New TestWindow (defined below)
-            TestWindow tw = GObject.newInstance(TestWindow.gtype);
+            TestWindow tw = new TestWindow();
 
             // Emit the "clicked" signal that should be connected to the `buttonClicked()` java method
             tw.button.emitClicked();
@@ -71,9 +65,8 @@ public class TemplateSignalTest {
 
     @GtkTemplate(name="SignalTestWindow", ui="/io/github/jwharm/javagi/gtk/TemplateSignalTest.ui")
     public static class TestWindow extends ApplicationWindow {
-        public static Type gtype = TemplateTypes.register(TestWindow.class);
-        public TestWindow(MemorySegment address ){
-            super(address);
+        public TestWindow(){
+            super();
         }
 
         @GtkChild


### PR DESCRIPTION
This PR refactors the Java-GI logic for registration and construction of GObject-derived classes.
- All generated GObject-derived classes now have a public constructor that takes a varargs parameter of property names and values.
- User-defined GObject-derived classes can user `super(...)` during construction. The `MemorySegment` constructor is not necessary anymore.
- When constructing an instance of a user-defined GObject-derived Java class, the Java instance will first be created (pointing to memory address `null`) and then `g_object_new` will be called. The Java instance will then be used for the instance initialization, and the memory address will be updated to the new GObject's address. This means it is no longer necessary to use static factory methods for construction.
- When a GType is not explicitly registered for a Java class, it is automatically registered. The call to `Types.register()` or `TemplateTypes.register()` is now optional.

As a result, all remaining boilerplate that was necessary for GObject-derived classes in Java has now become optional.
