### PR TITLE
Fix double `ref()` in static factory methods

### DIFF
--- a/generator/src/main/java/io/github/jwharm/javagi/generators/ConstructorGenerator.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/generators/ConstructorGenerator.java
@@ -170,19 +170,8 @@ public class ConstructorGenerator {
 
         // Ref GObject
         if (parent.checkIsGObject()) {
-            builder.addNamedCode(PartialStatement.of("var _object = ")
-                                    .add(stmt)
-                                    .add(";\n")
-                                    .format(),
-                            stmt.arguments())
-                    .beginControlFlow("if (_object instanceof $T _gobject)",
-                            ClassNames.G_OBJECT)
-                    .addStatement("$T.debug($S, _gobject.handle().address())",
-                            ClassNames.GLIB_LOGGER,
-                            "Ref " + returnType + " %ld")
-                    .addStatement("_gobject.ref()")
-                    .endControlFlow()
-                    .addStatement("return ($T) _object", returnType);
+            builder.addNamedCode(PartialStatement.of("return ")
+                    .add(stmt).add(";\n").format(),stmt.arguments());
         }
 
         // GVariant constructors return floating references


### PR DESCRIPTION
For named constructors, Java-GI generates a static factory method. This method calls the native constructor function, and then calls `InstanceCache.getForType()` to wrap it in a Java proxy object with the correct class. Finally, it calls `object.ref()` on the object, but this is unnecessary because the InstanceCache already added a toggle reference. This will prevent the object from being garbage-collected later, so it's a memory leak. This PR removes the double `ref()`.