### PR TITLE
Marshal GBytes from and to a Java byte array

### DIFF
--- a/generator/src/main/java/io/github/jwharm/javagi/gir/Callable.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/gir/Callable.java
@@ -51,8 +51,9 @@ public sealed interface Callable
         if (attrBool("java-gi-dont-skip", false))
             return false;
 
-        // Do not generate unnamed, parameter-less constructors
+        // Do not generate unnamed, parameter-less class constructors
         if (this instanceof Constructor ctr
+                && ctr.parent() instanceof Class
                 && "new".equals(ctr.name())
                 && (ctr.parameters() == null || ctr.parameters().parameters().isEmpty()))
             return true;

--- a/generator/src/main/java/io/github/jwharm/javagi/gir/RegisteredType.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/gir/RegisteredType.java
@@ -100,6 +100,11 @@ public sealed interface RegisteredType
         return cType() != null && "GHashTable".equals(cType());
     }
 
+    /** Return true if this is GBytes */
+    default boolean checkIsGBytes() {
+        return cType() != null && "GBytes".equals(cType());
+    }
+
     default boolean isFloating() {
         // GObject has a ref_sink function, but we don't want to treat all
         // GObjects as floating references.

--- a/generator/src/main/java/io/github/jwharm/javagi/gir/TypeReference.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/gir/TypeReference.java
@@ -1,5 +1,5 @@
 /* Java-GI - Java language bindings for GObject-Introspection-based libraries
- * Copyright (C) 2022-2024 the Java-GI developers
+ * Copyright (C) 2022-2025 the Java-GI developers
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *
@@ -19,6 +19,7 @@
 
 package io.github.jwharm.javagi.gir;
 
+import com.squareup.javapoet.ArrayTypeName;
 import com.squareup.javapoet.TypeName;
 
 import java.lang.foreign.MemorySegment;
@@ -59,8 +60,12 @@ public interface TypeReference {
         // Get the target type
         var type = lookup();
 
-        // A TypeClass or TypeInterface is an inner class
         if (type instanceof Record rec) {
+            // GBytes is treated as a byte[]
+            if (rec.checkIsGBytes())
+                return ArrayTypeName.of(byte.class);
+
+            // A TypeClass or TypeInterface is an inner class
             var outer = rec.isGTypeStructFor();
             if (outer != null)
                 return outer.typeName().nestedClass(

--- a/generator/src/main/java/io/github/jwharm/javagi/patches/GLibPatch.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/patches/GLibPatch.java
@@ -1,5 +1,5 @@
 /* Java-GI - Java language bindings for GObject-Introspection-based libraries
- * Copyright (C) 2022-2024 Jan-Willem Harmannij
+ * Copyright (C) 2022-2025 Jan-Willem Harmannij
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *
@@ -56,6 +56,13 @@ public class GLibPatch implements Patch {
              */
             return remove(ns, Function.class, "name", "clear_error");
         }
+
+        /*
+         * GBytes is available in Java as a plain byte array. There are
+         * functions in the Interop class to read, write and free GBytes.
+         */
+        if (element instanceof Record r && "Bytes".equals(r.name()))
+            return r.withAttribute("java-gi-skip", "1");
 
         /*
          * GPid is defined as gint on Unix vs gpointer on Windows. The generated

--- a/generator/src/main/java/io/github/jwharm/javagi/patches/GObjectPatch.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/patches/GObjectPatch.java
@@ -119,6 +119,13 @@ public class GObjectPatch implements Patch {
         }
 
         /*
+         * GBytes is available in Java as a plain byte array. There are
+         * functions in the Interop class to read, write and free GBytes.
+         */
+        if (element instanceof Record r && "Bytes".equals(r.name()))
+            return r.withAttribute("java-gi-skip", "1");
+
+        /*
          * Closure construction functions return floating references.
          */
         if (element instanceof Record r && "Closure".equals(r.name()))

--- a/generator/src/main/java/io/github/jwharm/javagi/patches/GioPatch.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/patches/GioPatch.java
@@ -1,5 +1,5 @@
 /* Java-GI - Java language bindings for GObject-Introspection-based libraries
- * Copyright (C) 2022-2024 the Jan-Willem Harmannij
+ * Copyright (C) 2022-2025 the Jan-Willem Harmannij
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *
@@ -69,6 +69,16 @@ public class GioPatch implements Patch {
         if (element instanceof Method m
                 && "g_io_module_load".equals(m.callableAttrs().cIdentifier()))
             return m.withAttribute("name", "load_module");
+
+        /*
+         * The method "g_tls_certificate_get_dns_names" returns a GPtrArray of
+         * GBytes. Java-GI converts GPtrArray and GBytes into Java arrays, but
+         * doesn't support nesting them yet.
+         */
+        if (element instanceof Class c
+                && "TlsCertificate".equals(c.name())) {
+            return remove(c, Method.class, "name", "get_dns_names");
+        }
 
         /*
          * The method "g_data_input_stream_read_byte" overrides

--- a/modules/glib/src/test/java/io/github/jwharm/javagi/interop/BytesTest.java
+++ b/modules/glib/src/test/java/io/github/jwharm/javagi/interop/BytesTest.java
@@ -1,0 +1,53 @@
+/* Java-GI - Java language bindings for GObject-Introspection-based libraries
+ * Copyright (C) 2022-2025 Jan-Willem Harmannij
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.github.jwharm.javagi.interop;
+
+import io.github.jwharm.javagi.base.GErrorException;
+import org.gnome.glib.GString;
+import org.gnome.glib.KeyFile;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class BytesTest {
+
+    @Test
+    public void testFromGBytes() {
+        var input = "test";
+        var gstring = new GString(input);
+        var bytes = gstring.freeToBytes();
+        var output = new String(bytes);
+        assertEquals(input, output);
+    }
+
+    @Test
+    public void testToGBytes() throws GErrorException {
+        byte[] data = """
+            [MyGroup]
+            FirstKey=Hello
+            SecondKey=Goodbye
+            """.getBytes();
+        var keyFile = new KeyFile();
+        var success = keyFile.loadFromBytes(data);
+        assertTrue(success);
+        assertEquals("MyGroup", keyFile.getStartGroup());
+    }
+}


### PR DESCRIPTION
This PR will replace all `GBytes` in the generated Java API with `byte[]`. A `GBytes` is automatically allocated and destroyed before and after method calls.

There is one unsupported case in Gio: `TlsCertificate.getDnsNames()` which returns a GPtrArray with GBytes elements. This should result in a nested array in Java (`byte[][]`) but this is not yet implemented. Therefore, this method is currently not available in Java.

Fixes #130
