### PR TITLE
Postprocessing changes

### DIFF
--- a/generator/src/main/java/io/github/jwharm/javagi/generators/PostprocessingGenerator.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/generators/PostprocessingGenerator.java
@@ -22,22 +22,31 @@ package io.github.jwharm.javagi.generators;
 import com.squareup.javapoet.MethodSpec;
 import io.github.jwharm.javagi.configuration.ClassNames;
 import io.github.jwharm.javagi.gir.*;
+import io.github.jwharm.javagi.gir.Record;
 import io.github.jwharm.javagi.util.PartialStatement;
 
+import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
+import java.util.List;
 
 public class PostprocessingGenerator extends TypedValueGenerator {
 
-    private final Parameter p;
+    private final Callable func;
 
-    public PostprocessingGenerator(Parameter p) {
-        super(p);
-        this.p = p;
+    public PostprocessingGenerator(TypedValue value) {
+        super(value);
+        func = (Callable) switch (v) {
+            case ReturnValue _ -> v.parent();
+            case Parameter _ -> v.parent().parent();
+            default -> throw new IllegalStateException("Unexpected value: " + v);
+        };
     }
 
     public void generate(MethodSpec.Builder builder) {
         readPointer(builder);
+        refGObject(builder);
         freeGBytes(builder);
+        takeOwnership(builder);
     }
 
     public void generateUpcall(MethodSpec.Builder builder) {
@@ -47,11 +56,12 @@ public class PostprocessingGenerator extends TypedValueGenerator {
     }
 
     private void readPointer(MethodSpec.Builder builder) {
-        if (p.isOutParameter()
-                || (type != null
-                    && type.isPointer()
-                    && target instanceof Alias a
-                    && a.isValueWrapper())) {
+        if (v instanceof Parameter p
+                && (p.isOutParameter()
+                    || (type != null
+                        && type.isPointer()
+                        && target instanceof Alias a
+                        && a.isValueWrapper()))) {
 
             // Pointer to single value
             if (array == null) {
@@ -128,16 +138,158 @@ public class PostprocessingGenerator extends TypedValueGenerator {
         }
     }
 
+    // Generate a call to Interop.freeGBytes() --> g_bytes_unref()
     private void freeGBytes(MethodSpec.Builder builder) {
         if (target != null && target.checkIsGBytes()) {
-            if (!p.isOutParameter() && p.transferOwnership() == TransferOwnership.NONE) {
+            if (v instanceof Parameter p
+                    && !p.isOutParameter()
+                    && p.transferOwnership() == TransferOwnership.NONE) {
                 builder.addStatement("$1T.freeGBytes(_$2LGBytes)",
                         ClassNames.INTEROP, getName());
-            }
-            else if (p.isOutParameter() && p.transferOwnership() != TransferOwnership.NONE) {
+            } else if (v instanceof Parameter p
+                    && p.isOutParameter()
+                    && p.transferOwnership() != TransferOwnership.NONE) {
                 builder.addStatement("$1T.freeGBytes(_$2LPointer.get(ValueLayout.ADDRESS, 0))",
                         ClassNames.INTEROP, getName());
+            } else if (v instanceof ReturnValue rv
+                    && rv.transferOwnership() != TransferOwnership.NONE) {
+                builder.addStatement("$1T.freeGBytes($2L)",
+                        ClassNames.INTEROP, "_result");
             }
+        }
+    }
+
+    // Ref GObject when ownership is not transferred
+    private void refGObject(MethodSpec.Builder builder) {
+        if (v instanceof ReturnValue rv
+                && target != null
+                && target.checkIsGObject()
+                && rv.transferOwnership() == TransferOwnership.NONE
+                // don't call ref() from ref() itself
+                && (! "ref".equals(func.name()))
+                && (! "ref_sink".equals(func.name()))) {
+            builder.beginControlFlow("if (_returnValue instanceof $T _gobject)",
+                            ClassNames.G_OBJECT)
+                    .addStatement("$T.debug($S, _gobject.handle().address())",
+                            ClassNames.GLIB_LOGGER,
+                            "Ref " + getType() + " %ld")
+                    .addStatement("_gobject.ref()")
+                    .endControlFlow();
+        }
+    }
+
+    // Add cleaner to a struct/boxed/union pointer that we "own".
+    // * Only for return values and out-parameters
+    // * Exclude foreign types
+    // * GBytes has its own postprocessing
+    // * GList/GSList have their own cleaner
+    // * GTypeInstance/Class/Interface are special cases
+    private void takeOwnership(MethodSpec.Builder builder) {
+        if (v instanceof Parameter p && !p.isOutParameter())
+            return;
+
+        if (! (target instanceof StandardLayoutType)) // Record, Union or Boxed
+            return;
+
+        if (target instanceof Record r)
+            if (r.foreign() || r.checkIsGBytes() || r.checkIsGList())
+                return;
+
+        if (List.of("GTypeInstance", "GTypeClass", "GTypeInterface")
+                .contains(target.cType()))
+            return;
+
+        var paramName = switch (v) {
+            case ReturnValue _ -> "_returnValue";
+            case Parameter _ -> getName() + ".get()";
+            default -> throw new IllegalStateException("Unexpected value: " + v);
+        };
+
+        // With ownership transfer: Don't copy/ref the struct
+        if (v.transferOwnership() != TransferOwnership.NONE) {
+            builder.beginControlFlow("if ($1L != null)", paramName)
+                    .addStatement("$1T.takeOwnership($2L)",
+                            ClassNames.MEMORY_CLEANER, paramName);
+            new RegisteredTypeGenerator(target)
+                    .setFreeFunc(builder, paramName, target.typeName());
+            builder.endControlFlow();
+        }
+
+        // No ownership transfer: Copy/ref the struct
+        else {
+            // Lookup the copy/ref function and the memory layout
+            var slt = (StandardLayoutType) target;
+            var copyFunc = slt.copyFunction();
+            var hasMemoryLayout = new MemoryLayoutGenerator().canGenerate(slt);
+
+            // Don't automatically copy the return values of GLib functions
+            var skipNamespace = List.of("GLib", "GModule")
+                    .contains(target.namespace().name());
+
+            // No copy function, and unknown size: copying is impossible
+            if (skipNamespace || (!hasMemoryLayout && copyFunc == null)) {
+                return;
+            }
+
+            // Don't copy the result of ref(), ref_sink() or copy()
+            if (List.of("ref", "ref_sink", "copy").contains(func.name())
+                    || (copyFunc != null && copyFunc.name().equals(func.name()))) {
+            }
+
+            // No copy function, but known memory layout size: malloc() a new
+            // struct, and copy the contents manually
+            else if (hasMemoryLayout && copyFunc == null) {
+                var copyVar = v instanceof ReturnValue ? "_copy" : ("_" + getName() + "Copy");
+                builder.addStatement("$T $L = $T.malloc($T.getMemoryLayout().byteSize())",
+                            MemorySegment.class, copyVar, ClassNames.G_LIB, v.anyType().typeName())
+                        .addStatement("$T.copy($L.handle(), $L)",
+                            ClassNames.INTEROP, paramName, copyVar)
+                        .addStatement("$L.address = $L", paramName, copyVar);
+            }
+
+            // Copy function is an instance method
+            else if (copyFunc instanceof Method m) {
+                if (v instanceof ReturnValue)
+                    builder.addStatement("$1L = $1L.$2L()",
+                            paramName, MethodGenerator.getName(m));
+                else
+                    builder.addStatement("$1L.set($2L.$3L())",
+                            getName(), paramName, MethodGenerator.getName(m));
+            }
+
+            // Copy function is a function (static method)
+            else if (copyFunc instanceof Function f
+                    && f.parent() instanceof RegisteredType rt) {
+                // Call g_boxed_copy
+                if ("g_boxed_copy".equals(f.callableAttrs().cIdentifier())) {
+                    builder.addStatement(
+                            "$1L.address = $2T.$3L($4T.getType(), $1L.handle())",
+                            paramName,
+                            rt.typeName(),
+                            MethodGenerator.getName(f),
+                            v.anyType().typeName());
+                }
+                // Call the copy/ref function
+                else {
+                    if (v instanceof ReturnValue)
+                        builder.addStatement("$1L = $2T.$3L($1L)",
+                                paramName,
+                                rt.typeName(),
+                                MethodGenerator.getName(f));
+                    else
+                        builder.addStatement("$1L.set($2T.$3L($4L))",
+                                getName(),
+                                rt.typeName(),
+                                MethodGenerator.getName(f),
+                                paramName);
+                }
+            }
+
+            // Register the returned instance with the memory cleaner
+            builder.addStatement("$T.takeOwnership($L)",
+                    ClassNames.MEMORY_CLEANER, paramName);
+            new RegisteredTypeGenerator(target)
+                    .setFreeFunc(builder, paramName, target.typeName());
         }
     }
 
@@ -151,6 +303,7 @@ public class PostprocessingGenerator extends TypedValueGenerator {
     }
 
     private void writeOutParameter(MethodSpec.Builder builder) {
+        var p = (Parameter) v;
         if (!p.isOutParameter())
             return;
 
@@ -176,7 +329,9 @@ public class PostprocessingGenerator extends TypedValueGenerator {
     }
 
     private void freeGBytesUpcall(MethodSpec.Builder builder) {
-        if (target != null && target.checkIsGBytes()
+        if (v instanceof Parameter p
+                && target != null
+                && target.checkIsGBytes()
                 && p.transferOwnership() != TransferOwnership.NONE) {
             builder.addStatement("$1T.freeGBytes($2L)", ClassNames.INTEROP, getName());
         }

--- a/generator/src/main/java/io/github/jwharm/javagi/generators/TypedValueGenerator.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/generators/TypedValueGenerator.java
@@ -68,6 +68,10 @@ class TypedValueGenerator {
                     || p.isArrayLengthParameter()))
             return false;
 
+        // A NULL GList is just empty
+        if (type != null && type.checkIsGList())
+            return false;
+
         return ! (type != null
                     && !type.isPointer()
                     && (type.isPrimitive()

--- a/generator/src/main/java/io/github/jwharm/javagi/gir/AnyType.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/gir/AnyType.java
@@ -1,5 +1,5 @@
 /* Java-GI - Java language bindings for GObject-Introspection-based libraries
- * Copyright (C) 2022-2024 the Java-GI developers
+ * Copyright (C) 2022-2025 the Java-GI developers
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *
@@ -24,6 +24,7 @@ import com.squareup.javapoet.TypeName;
 public sealed interface AnyType extends Node permits Type, Array {
 
     TypeName typeName();
+    String toTypeTag();
 
     default String name() {
         return attr("name");

--- a/generator/src/main/java/io/github/jwharm/javagi/gir/Array.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/gir/Array.java
@@ -1,5 +1,5 @@
 /* Java-GI - Java language bindings for GObject-Introspection-based libraries
- * Copyright (C) 2022-2024 the Java-GI developers
+ * Copyright (C) 2022-2025 the Java-GI developers
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *
@@ -39,6 +39,10 @@ public final class Array extends GirElement implements AnyType {
     @Override
     public TypeName typeName() {
         return ArrayTypeName.of(anyType().typeName());
+    }
+
+    public String toTypeTag() {
+        return anyType().toTypeTag() + "Array";
     }
 
     public boolean zeroTerminated() {

--- a/generator/src/main/java/io/github/jwharm/javagi/gir/Boxed.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/gir/Boxed.java
@@ -1,5 +1,5 @@
 /* Java-GI - Java language bindings for GObject-Introspection-based libraries
- * Copyright (C) 2022-2024 the Java-GI developers
+ * Copyright (C) 2022-2025 the Java-GI developers
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *
@@ -30,7 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-public final class Boxed extends Multiplatform implements StandardLayoutType, FieldContainer {
+public final class Boxed extends Multiplatform implements StandardLayoutType {
 
     public Boxed(Map<String, String> attributes,
                  List<Node> children,

--- a/generator/src/main/java/io/github/jwharm/javagi/gir/FieldContainer.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/gir/FieldContainer.java
@@ -1,5 +1,5 @@
 /* Java-GI - Java language bindings for GObject-Introspection-based libraries
- * Copyright (C) 2022-2024 the Java-GI developers
+ * Copyright (C) 2022-2025 the Java-GI developers
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *
@@ -23,7 +23,7 @@ import java.util.List;
 
 public sealed interface FieldContainer
         extends RegisteredType
-        permits Class, Interface, Boxed, Record, Union {
+        permits StandardLayoutType, Class, Interface {
 
     List<Field> fields();
 

--- a/generator/src/main/java/io/github/jwharm/javagi/gir/InstanceParameter.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/gir/InstanceParameter.java
@@ -1,5 +1,5 @@
 /* Java-GI - Java language bindings for GObject-Introspection-based libraries
- * Copyright (C) 2022-2024 the Java-GI developers
+ * Copyright (C) 2022-2025 the Java-GI developers
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *
@@ -64,6 +64,7 @@ public final class InstanceParameter extends GirElement implements TypedValue {
         return attrBool("caller-allocates", true);
     }
 
+    @Override
     public TransferOwnership transferOwnership() {
         return TransferOwnership.from(attr("transfer-ownership"));
     }

--- a/generator/src/main/java/io/github/jwharm/javagi/gir/Property.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/gir/Property.java
@@ -1,5 +1,5 @@
 /* Java-GI - Java language bindings for GObject-Introspection-based libraries
- * Copyright (C) 2022-2024 the Java-GI developers
+ * Copyright (C) 2022-2025 the Java-GI developers
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *
@@ -64,6 +64,7 @@ public final class Property extends Multiplatform implements TypedValue {
         return attr("default-value");
     }
 
+    @Override
     public TransferOwnership transferOwnership() {
         return TransferOwnership.from(attr("transfer-ownership"));
     }

--- a/generator/src/main/java/io/github/jwharm/javagi/gir/Record.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/gir/Record.java
@@ -1,5 +1,5 @@
 /* Java-GI - Java language bindings for GObject-Introspection-based libraries
- * Copyright (C) 2022-2024 the Java-GI developers
+ * Copyright (C) 2022-2025 the Java-GI developers
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *
@@ -34,7 +34,7 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 
 public final class Record extends Multiplatform
-        implements StandardLayoutType, FieldContainer {
+        implements StandardLayoutType {
 
     public Record(Map<String, String> attributes,
                   List<Node> children,

--- a/generator/src/main/java/io/github/jwharm/javagi/gir/RegisteredType.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/gir/RegisteredType.java
@@ -31,7 +31,7 @@ import static io.github.jwharm.javagi.util.Conversions.uncapitalize;
 public sealed interface RegisteredType
         extends Node
         permits Alias, Callback, Class, FlaggedType,
-                Interface, Namespace, StandardLayoutType, FieldContainer {
+                Interface, Namespace, FieldContainer {
 
     RegisteredType mergeWith(RegisteredType rt);
     int platforms();

--- a/generator/src/main/java/io/github/jwharm/javagi/gir/ReturnValue.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/gir/ReturnValue.java
@@ -1,5 +1,5 @@
 /* Java-GI - Java language bindings for GObject-Introspection-based libraries
- * Copyright (C) 2022-2024 the Java-GI developers
+ * Copyright (C) 2022-2025 the Java-GI developers
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *
@@ -89,6 +89,7 @@ public final class ReturnValue extends GirElement implements TypedValue {
         return attrBool("allow-none", false);
     }
 
+    @Override
     public TransferOwnership transferOwnership() {
         return TransferOwnership.from(attr("transfer-ownership"));
     }

--- a/generator/src/main/java/io/github/jwharm/javagi/gir/StandardLayoutType.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/gir/StandardLayoutType.java
@@ -1,5 +1,5 @@
 /* Java-GI - Java language bindings for GObject-Introspection-based libraries
- * Copyright (C) 2022-2024 the Java-GI developers
+ * Copyright (C) 2022-2025 the Java-GI developers
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *
@@ -20,7 +20,7 @@
 package io.github.jwharm.javagi.gir;
 
 public sealed interface StandardLayoutType
-        extends RegisteredType
+        extends FieldContainer
         permits Boxed, Record, Union {
 
     default String cSymbolPrefix() {

--- a/generator/src/main/java/io/github/jwharm/javagi/gir/Type.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/gir/Type.java
@@ -1,5 +1,5 @@
 /* Java-GI - Java language bindings for GObject-Introspection-based libraries
- * Copyright (C) 2022-2024 the Java-GI developers
+ * Copyright (C) 2022-2025 the Java-GI developers
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *
@@ -174,17 +174,27 @@ public final class Type extends GirElement implements AnyType, TypeReference {
             int end = cType.indexOf("*");
             if (start == -1) start = 0; else start++;
             if (end == -1) end = cType.length();
-            return uncapitalize(cType.substring(start, end));
+            String typeTag = cType.substring(start, end);
+            if (typeTag.startsWith("_"))
+                typeTag = typeTag.substring(1);
+            return uncapitalize(typeTag);
         }
 
         String javaBaseType = toJavaBaseType(name());
-        if ("MemorySegment".equals(javaBaseType))
-            return "memorySegment";
-        if ("String".equals(javaBaseType))
-            return "string";
+        String typeTag;
+        if ("MemorySegment".equals(javaBaseType)) {
+            typeTag = "memorySegment";
+        } if ("String".equals(javaBaseType)) {
+            typeTag = "string";
+        } else {
+            RegisteredType target = lookup();
+            typeTag = target == null ? null : target.typeTag();
+        }
 
-        RegisteredType target = lookup();
-        return target == null ? null : target.typeTag();
+        if (isActuallyAnArray())
+            typeTag += "Array";
+
+        return typeTag;
     }
 
     private boolean overrideLongValue() {

--- a/generator/src/main/java/io/github/jwharm/javagi/gir/TypedValue.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/gir/TypedValue.java
@@ -1,5 +1,5 @@
 /* Java-GI - Java language bindings for GObject-Introspection-based libraries
- * Copyright (C) 2022-2024 the Java-GI developers
+ * Copyright (C) 2022-2025 the Java-GI developers
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *
@@ -45,6 +45,10 @@ public sealed interface TypedValue
             case Type type -> type.isActuallyAnArray()
                     || TypeName.get(String.class).equals(type.typeName());
         };
+    }
+
+    default TransferOwnership transferOwnership() {
+        return TransferOwnership.NONE;
     }
 
     default boolean isBitfield() {

--- a/generator/src/main/java/io/github/jwharm/javagi/gir/Union.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/gir/Union.java
@@ -1,5 +1,5 @@
 /* Java-GI - Java language bindings for GObject-Introspection-based libraries
- * Copyright (C) 2022-2024 the Java-GI developers
+ * Copyright (C) 2022-2025 the Java-GI developers
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *
@@ -27,7 +27,7 @@ import java.util.Objects;
 
 public final class Union
         extends Multiplatform
-        implements StandardLayoutType, FieldContainer {
+        implements StandardLayoutType {
 
     @Override
     public Namespace parent() {

--- a/modules/glib/src/main/java/io/github/jwharm/javagi/interop/Interop.java
+++ b/modules/glib/src/main/java/io/github/jwharm/javagi/interop/Interop.java
@@ -181,7 +181,6 @@ public class Interop {
      */
     public static MemorySegment reinterpret(MemorySegment address,
                                             long newSize) {
-
         if (address == null || address.byteSize() >= newSize)
             return address;
 
@@ -224,7 +223,6 @@ public class Interop {
      * @return the gtype from the provided get-type function
      */
     public static Type getType(String getTypeFunction) {
-
         if (getTypeFunction == null)
             return null;
 
@@ -582,7 +580,6 @@ public class Interop {
     public static String[] getStringArrayFrom(MemorySegment address,
                                               int length,
                                               boolean free) {
-
         if (address == null || NULL.equals(address))
             return null;
 
@@ -702,7 +699,6 @@ public class Interop {
      */
     public static MemorySegment[] getAddressArrayFrom(MemorySegment address,
                                                       boolean free) {
-
         if (address == null || NULL.equals(address))
             return null;
 
@@ -739,8 +735,10 @@ public class Interop {
                                                 long length,
                                                 Arena arena,
                                                 boolean free) {
-
         int[] intArray = getIntegerArrayFrom(address, length, arena, free);
+        if (intArray == null)
+            return null;
+
         boolean[] array = new boolean[intArray.length];
 
         for (int c = 0; c < intArray.length; c++)
@@ -762,9 +760,11 @@ public class Interop {
                                           long length,
                                           Arena arena,
                                           boolean free) {
+        if (address == null || NULL.equals(address))
+            return null;
 
         byte[] array = address.reinterpret(length, arena, null)
-                .toArray(ValueLayout.JAVA_BYTE);
+                              .toArray(ValueLayout.JAVA_BYTE);
 
         if (free)
             GLib.free(address);
@@ -783,6 +783,9 @@ public class Interop {
     public static byte[] getByteArrayFrom(MemorySegment address,
                                           Arena arena,
                                           boolean free) {
+        if (address == null || NULL.equals(address))
+            return null;
+
         // Find the null byte
         MemorySegment array = address.reinterpret(LONG_UNBOUNDED, arena, null);
         long idx = 0;
@@ -806,10 +809,12 @@ public class Interop {
                                                long length,
                                                Arena arena,
                                                boolean free) {
+        if (address == null || NULL.equals(address))
+            return null;
 
         long size = ValueLayout.JAVA_CHAR.byteSize();
         char[] array = address.reinterpret(length * size, arena, null)
-                .toArray(ValueLayout.JAVA_CHAR);
+                              .toArray(ValueLayout.JAVA_CHAR);
 
         if (free)
             GLib.free(address);
@@ -830,10 +835,12 @@ public class Interop {
                                               long length,
                                               Arena arena,
                                               boolean free) {
+        if (address == null || NULL.equals(address))
+            return null;
 
         long size = ValueLayout.JAVA_DOUBLE.byteSize();
         double[] array = address.reinterpret(length * size, arena, null)
-                .toArray(ValueLayout.JAVA_DOUBLE);
+                                .toArray(ValueLayout.JAVA_DOUBLE);
 
         if (free)
             GLib.free(address);
@@ -854,10 +861,12 @@ public class Interop {
                                             long length,
                                             Arena arena,
                                             boolean free) {
+        if (address == null || NULL.equals(address))
+            return null;
 
         long size = ValueLayout.JAVA_FLOAT.byteSize();
         float[] array = address.reinterpret(length * size, arena, null)
-                .toArray(ValueLayout.JAVA_FLOAT);
+                               .toArray(ValueLayout.JAVA_FLOAT);
 
         if (free)
             GLib.free(address);
@@ -878,10 +887,12 @@ public class Interop {
                                             long length,
                                             Arena arena,
                                             boolean free) {
+        if (address == null || NULL.equals(address))
+            return null;
 
         long size = ValueLayout.JAVA_INT.byteSize();
         int[] array = address.reinterpret(length * size, arena, null)
-                .toArray(ValueLayout.JAVA_INT);
+                             .toArray(ValueLayout.JAVA_INT);
 
         if (free)
             GLib.free(address);
@@ -900,6 +911,8 @@ public class Interop {
     public static int[] getIntegerArrayFrom(MemorySegment address,
                                             Arena arena,
                                             boolean free) {
+        if (address == null || NULL.equals(address))
+            return null;
 
         // Find the null byte
         MemorySegment array = address.reinterpret(INT_UNBOUNDED, arena, null);
@@ -924,10 +937,12 @@ public class Interop {
                                           long length,
                                           Arena arena,
                                           boolean free) {
+        if (address == null || NULL.equals(address))
+            return null;
 
         long size = ValueLayout.JAVA_LONG.byteSize();
         long[] array = address.reinterpret(length * size, arena, null)
-                .toArray(ValueLayout.JAVA_LONG);
+                              .toArray(ValueLayout.JAVA_LONG);
 
         if (free)
             GLib.free(address);
@@ -946,6 +961,8 @@ public class Interop {
     public static long[] getLongArrayFrom(MemorySegment address,
                                           Arena arena,
                                           boolean free) {
+        if (address == null || NULL.equals(address))
+            return null;
 
         // Find the null byte
         MemorySegment array = address.reinterpret(INT_UNBOUNDED, arena, null);
@@ -970,10 +987,12 @@ public class Interop {
                                             long length,
                                             Arena arena,
                                             boolean free) {
+        if (address == null || NULL.equals(address))
+            return null;
 
         long size = ValueLayout.JAVA_SHORT.byteSize();
         short[] array = address.reinterpret(length * size, arena, null)
-                .toArray(ValueLayout.JAVA_SHORT);
+                               .toArray(ValueLayout.JAVA_SHORT);
 
         if (free)
             GLib.free(address);
@@ -992,6 +1011,8 @@ public class Interop {
     public static short[] getShortArrayFrom(MemorySegment address,
                                             Arena arena,
                                             boolean free) {
+        if (address == null || NULL.equals(address))
+            return null;
 
         // Find the null byte
         MemorySegment array = address.reinterpret(INT_UNBOUNDED, arena, null);
@@ -1018,15 +1039,12 @@ public class Interop {
     T[] getProxyArrayFrom(MemorySegment address,
                           Class<T> cls,
                           Function<MemorySegment, T> make) {
-
         if (address == null || NULL.equals(address))
             return null;
 
         MemorySegment array = reinterpret(address, LONG_UNBOUNDED);
-
         long offset = 0;
-        while (!NULL.equals(
-                        array.get(ValueLayout.ADDRESS, offset))) {
+        while (!NULL.equals(array.get(ValueLayout.ADDRESS, offset))) {
             offset += ValueLayout.ADDRESS.byteSize();
         }
 
@@ -1049,7 +1067,6 @@ public class Interop {
                           int length,
                           Class<T> cls,
                           Function<MemorySegment, T> make) {
-
         if (address == null || NULL.equals(address))
             return null;
 
@@ -1080,7 +1097,6 @@ public class Interop {
                            Class<T> cls,
                            Function<MemorySegment, T> make,
                            MemoryLayout layout) {
-
         if (address == null || NULL.equals(address))
             return null;
 
@@ -1111,7 +1127,6 @@ public class Interop {
                                                  int length,
                                                  Class<T> cls,
                                                  Function<Integer, T> make) {
-
         if (address == null || NULL.equals(address))
             return null;
 
@@ -1137,6 +1152,8 @@ public class Interop {
     public static MemorySegment allocateNativeArray(String[] strings,
                                                     boolean zeroTerminated,
                                                     Arena arena) {
+        if (strings == null)
+            return NULL;
 
         int length = zeroTerminated ? strings.length + 1 : strings.length;
         var memorySegment = arena.allocate(ValueLayout.ADDRESS, length);
@@ -1166,6 +1183,8 @@ public class Interop {
     public static MemorySegment allocateNativeArray(String[][] strvs,
                                                     boolean zeroTerminated,
                                                     Arena arena) {
+        if (strvs == null)
+            return NULL;
 
         int length = zeroTerminated ? strvs.length + 1 : strvs.length;
         var memorySegment = arena.allocate(ValueLayout.ADDRESS, length);
@@ -1195,6 +1214,9 @@ public class Interop {
     public static MemorySegment allocateNativeArray(boolean[] array,
                                                     boolean zeroTerminated,
                                                     Arena arena) {
+        if (array == null)
+            return NULL;
+
         int[] intArray = new int[array.length];
         for (int i = 0; i < array.length; i++) {
             intArray[i] = array[i] ? 1 : 0;
@@ -1215,6 +1237,9 @@ public class Interop {
     public static MemorySegment allocateNativeArray(byte[] array,
                                                     boolean zeroTerminated,
                                                     Arena arena) {
+        if (array == null)
+            return NULL;
+
         byte[] copy = zeroTerminated ?
                 Arrays.copyOf(array, array.length + 1)
                 : array;
@@ -1234,6 +1259,9 @@ public class Interop {
     public static MemorySegment allocateNativeArray(char[] array,
                                                     boolean zeroTerminated,
                                                     Arena arena) {
+        if (array == null)
+            return NULL;
+
         char[] copy = zeroTerminated ?
                 Arrays.copyOf(array, array.length + 1)
                 : array;
@@ -1253,6 +1281,9 @@ public class Interop {
     public static MemorySegment allocateNativeArray(double[] array,
                                                     boolean zeroTerminated,
                                                     Arena arena) {
+        if (array == null)
+            return NULL;
+
         double[] copy = zeroTerminated ?
                 Arrays.copyOf(array, array.length + 1)
                 : array;
@@ -1272,6 +1303,9 @@ public class Interop {
     public static MemorySegment allocateNativeArray(float[] array,
                                                     boolean zeroTerminated,
                                                     Arena arena) {
+        if (array == null)
+            return NULL;
+
         float[] copy = zeroTerminated ?
                 Arrays.copyOf(array, array.length + 1)
                 : array;
@@ -1291,6 +1325,9 @@ public class Interop {
     public static MemorySegment allocateNativeArray(int[] array,
                                                     boolean zeroTerminated,
                                                     Arena arena) {
+        if (array == null)
+            return NULL;
+
         int[] copy = zeroTerminated ?
                 Arrays.copyOf(array, array.length + 1)
                 : array;
@@ -1309,6 +1346,9 @@ public class Interop {
     public static MemorySegment allocateNativeArray(long[] array,
                                                     boolean zeroTerminated,
                                                     Arena arena) {
+        if (array == null)
+            return NULL;
+
         long[] copy = zeroTerminated ?
                 Arrays.copyOf(array, array.length + 1)
                 : array;
@@ -1328,6 +1368,9 @@ public class Interop {
     public static MemorySegment allocateNativeArray(short[] array,
                                                     boolean zeroTerminated,
                                                     Arena arena) {
+        if (array == null)
+            return NULL;
+
         short[] copy = zeroTerminated ?
                 Arrays.copyOf(array, array.length + 1)
                 : array;
@@ -1347,6 +1390,8 @@ public class Interop {
     public static MemorySegment allocateNativeArray(Proxy[] array,
                                                     boolean zeroTerminated,
                                                     Arena arena) {
+        if (array == null)
+            return NULL;
 
         MemorySegment[] addressArray = new MemorySegment[array.length];
         for (int i = 0; i < array.length; i++) {
@@ -1372,6 +1417,8 @@ public class Interop {
                                                     MemoryLayout layout,
                                                     boolean zeroTerminated,
                                                     Arena arena) {
+        if (array == null)
+            return NULL;
 
         long size = layout.byteSize();
         int length = zeroTerminated ? array.length + 1 : array.length;
@@ -1408,6 +1455,9 @@ public class Interop {
     public static MemorySegment allocateNativeArray(MemorySegment[] array,
                                                     boolean zeroTerminated,
                                                     Arena arena) {
+
+        if (array == null)
+            return NULL;
 
         int length = zeroTerminated ? array.length + 1 : array.length;
         var memorySegment = arena.allocate(ValueLayout.ADDRESS, length);
@@ -1502,7 +1552,7 @@ public class Interop {
             MemorySegment _result;
             try {
                 _result = (MemorySegment) DowncallHandles.g_bytes_new.invokeExact(
-                        (MemorySegment) (data == null ? MemorySegment.NULL : allocateNativeArray(data, false, _arena)),
+                        (MemorySegment) (data == null ? NULL : allocateNativeArray(data, false, _arena)),
                         size);
             } catch (Throwable _err) {
                 throw new AssertionError(_err);


### PR DESCRIPTION
This PR merges a lot of the code that handles return values and out-parameters (take ownership, free native memory, check for null, etc). This code is now done in post-processing statements for both return values and out-parameters. As a result, all return values are now stored in a `_returnValue` variable before being returned. The post-processing statements (if any) are generated between those lines.

This not only improves the code generator internally (the MethodGenerator is now a lot simpler) but it also fixes bugs because out-parameters didn't always free native memory when they should. `soup_form_decode_multipart` is an example of this, that should now be fixed.