### PR TITLE
Fix memory leaks in GLib callback functions

### DIFF
--- a/generator/src/main/java/io/github/jwharm/javagi/configuration/ClassNames.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/configuration/ClassNames.java
@@ -52,7 +52,6 @@ public final class ClassNames {
     public static final ClassName MEMORY_CLEANER = get(PKG_INTEROP, "MemoryCleaner");
     public static final ClassName INTEROP = get(PKG_INTEROP, "Interop");
     public static final ClassName PLATFORM = get(PKG_INTEROP, "Platform");
-    public static final ClassName VARARGS_UTIL = get(PKG_INTEROP, "VarargsUtil");
 
     public static final ClassName AUTO_CLOSEABLE = get(PKG_GIO, "AutoCloseable");
     public static final ClassName LIST_MODEL_JAVA_LIST = get(PKG_GIO, "ListModelJavaList");
@@ -80,8 +79,8 @@ public final class ClassNames {
     public final static ClassName G_ERROR = get("org.gnome.glib", "GError");
     public final static ClassName G_LIB = get("org.gnome.glib", "GLib");
     public final static ClassName G_LOG_LEVEL_FLAGS = get("org.gnome.glib", "LogLevelFlags");
+    public final static ClassName G_SOURCE_ONCE_FUNC = get("org.gnome.glib", "SourceOnceFunc");
     public final static ClassName G_TYPE = get("org.gnome.glib", "Type");
-    public final static ClassName G_VARIANT = get("org.gnome.glib", "Variant");
 
     public final static ClassName G_OBJECT = get("org.gnome.gobject", "GObject");
     public final static ClassName G_OBJECTS = get("org.gnome.gobject", "GObjects");

--- a/generator/src/main/java/io/github/jwharm/javagi/patches/GLibPatch.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/patches/GLibPatch.java
@@ -51,6 +51,15 @@ public class GLibPatch implements Patch {
             ns = add(ns, gtype);
 
             /*
+             * These functions don't clean up the memory allocated for the
+             * callback function. It is replaced in Java-GI by wrappers
+             * around their respective "full" functions.
+             */
+            ns = remove(ns, Function.class, "name", "idle_add_once");
+            ns = remove(ns, Function.class, "name", "timeout_add_once");
+            ns = remove(ns, Function.class, "name", "timeout_add_seconds_once");
+
+            /*
              * g_clear_error has attribute throws="1" but no gerror** parameter
              * (or any other parameters) in the gir file.
              */


### PR DESCRIPTION
The GLib functions `g_idle_add_once`, `g_timeout_add_once` and `g_timeout_add_seconds_once` don't notify the caller when the callback function has finished. This causes a memory leak in Java-GI, because the arena in which the callback upcall stub was allocated, is never closed.

Because these three functions are simple wrappers around `g_idle_add_full`, `g_timeout_add_full` and `g_timeout_add_seconds_full`, which do notify the caller to free the callback allocation, they have been reimplemented in Java as custom wrappers that call the "full" functions and then return `G_SOURCE_REMOVE`.