### PR TITLE
Publish to Maven Central Portal with JReleaser

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -4,12 +4,14 @@ plugins {
 
 repositories {
     mavenCentral()
+    gradlePluginPortal()
 }
 
 dependencies {
     implementation(libs.javapoet)
     implementation(libs.annotations)
     implementation(libs.javagi.generator)
+    implementation(libs.jreleaser)
 }
 
 tasks.withType<JavaCompile>().configureEach {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,5 @@
 org.gradle.jvmargs=-Xmx4096M
 org.gradle.caching=true
 org.gradle.parallel=true
-org.gradle.configuration-cache=true
 
 girFilesLocation=ext/gir-files

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ picocli = "4.7.7"
 javapoet = "1.13.0"
 annotations = "26.0.2"
 junit = "5.12.2"
+jreleaser = "1.17.0"
 
 [libraries]
 javagi-generator = { module = "io.github.jwharm.javagi:generator", version.ref = "javagi" }
@@ -15,3 +16,4 @@ javapoet = { module = "com.squareup:javapoet", version.ref = "javapoet" }
 annotations = { module = "org.jetbrains:annotations", version.ref = "annotations" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
+jreleaser = { module = "org.jreleaser:org.jreleaser.gradle.plugin", version.ref = "jreleaser" }


### PR DESCRIPTION
As recommended by Sonatype, I've configured JReleaser to publish Java-GI artifacts to Maven Central Portal (instead of the old OSSRH staging api).