### PR TITLE
Lock pkgconf version

### DIFF
--- a/.github/workflows/windows-gtk.yml
+++ b/.github/workflows/windows-gtk.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Clone pkgconf
         uses: actions/checkout@v4
         with:
+          ref: 664b53d5c4920e66e4a57c7515ccfd1bd1477bac # Last commit before unistd.h dependency
           repository: 'pkgconf/pkgconf'
           submodules: recursive
           path: pkgconf


### PR DESCRIPTION
Apparently, just a few hours before #219 was merged, pkgconf had the following commit, which introduced a dependency on unistd.h: https://github.com/pkgconf/pkgconf/commit/230b45c00c8d9c108db798c90d63b2ad54837625

Since this header doesn't exist with MSVC, that means the latest version isn't as easily built.
As such, this PR just locks the pkgconf version to the latest commit that works.