### PR TITLE
Run Meson using Gradle with working Up-To-Date checking

### DIFF
--- a/.github/workflows/publish-maven.yml
+++ b/.github/workflows/publish-maven.yml
@@ -41,12 +41,6 @@ jobs:
           packages: meson pkg-config libglib2.0-dev libgirepository1.0-dev libcairo2-dev
           version: 1.0
 
-      - name: Build gobject-introspection-tests
-        working-directory: java-gi/ext/gobject-introspection-tests
-        run: |
-          meson setup build
-          meson compile -C build
-
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 

--- a/buildSrc/src/main/kotlin/java-gi.library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-gi.library-conventions.gradle.kts
@@ -1,135 +1,37 @@
-import org.apache.tools.ant.taskdefs.condition.Os
 import com.vanniktech.maven.publish.SonatypeHost
 
-/*
- * Common build settings for Java-GI modules:
- *
- * - Load plugins
- * - Set maven repositories
- * - Load common dependencies
- * - Set group and Java-GI version number
- * - Set JDK version
- * - Configure 'generateSources' action
- * - Set OS-specific library paths and parameters for unit tests
- * - Set common POM metadata and enable signing
- */
-
 plugins {
-    id("java-library")
+    id("java-gi.module")
     id("com.vanniktech.maven.publish")
 }
 
-repositories {
-    mavenCentral()
-}
-
-dependencies {
-    compileOnly(libs.annotations)
-    testImplementation(libs.junit.jupiter)
-    testRuntimeOnly(libs.junit.platform.launcher)
-}
-
-group = "io.github.jwharm.javagi"
-version = libs.versions.javagi.get()
-
-java {
-    toolchain.languageVersion = JavaLanguageVersion.of(libs.versions.jdk.get())
-}
-
-// Regression-test modules are located under "modules/test"
-val isTestModule = project.projectDir.toPath().startsWith(rootDir.toPath().resolve("modules/test"))
-
-// Register a build service that will parse and cache GIR files
-gradle.sharedServices.registerIfAbsent("gir", GirParserService::class) {
-    val mainGirFilesLocation = rootDir.resolve("ext/gir-files")
-    val testGirFilesLocation = rootDir.resolve("ext/gobject-introspection-tests/build")
-    parameters.inputDirectories.from(mainGirFilesLocation, testGirFilesLocation)
-}
-
-// Register the task that will generate Java sources from GIR files
-val generateSources by tasks.registering(GenerateSources::class) {
-    mainJavaSourcesDirectory = layout.projectDirectory.dir("src/main/java")
-    outputDirectory = layout.buildDirectory.dir("generated/sources/java-gi")
-}
-
-// Add the generated sources to the main sourceSet
-sourceSets["main"].java.srcDir(generateSources)
-
-tasks.withType<JavaCompile>().configureEach {
-    options.encoding = "UTF-8"
-}
-
-tasks.withType<Javadoc>().configureEach {
-    options {
-        this as StandardJavadocDocletOptions
-        addStringOption("tag", "apiNote:a:API Note:")
-        addStringOption("Xdoclint:none", "-quiet")
-        encoding = "UTF-8"
-    }
-}
-
-tasks.withType<Test>().configureEach {
-    // Don't run tests in Github action. The native libraries aren't installed.
-    if (System.getenv().containsKey("CI")) {
-        enabled = false
-    }
-
-    useJUnitPlatform()
-
-    // Log standard output and error streams when running tests
-    testLogging.showStandardStreams = true
-
-    // Configure library path for macOS (Homebrew) and set MacOS-specific JVM parameter
-    if (Os.isFamily(Os.FAMILY_MAC)) {
-        jvmArgs("-Djava.library.path=../../../ext/gobject-introspection-tests/build:"
-                + "/opt/homebrew/lib")
-        jvmArgs("-XstartOnFirstThread")
-    }
-
-    // Configure library path for Arch, Fedora and Debian/Ubuntu
-    else if (Os.isFamily(Os.FAMILY_UNIX)) {
-        jvmArgs("-Djava.library.path=../../../ext/gobject-introspection-tests/build:"
-                + "/usr/lib64:/lib64:/lib:/usr/lib:/lib/x86_64-linux-gnu")
-    }
-
-    // Configure library path for Windows (MSYS2)
-    else if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-        jvmArgs("-Djava.library.path=../../../ext/gobject-introspection-tests/build;"
-                + "C:/msys64/mingw64/bin")
-    }
-
-    jvmArgs("--enable-native-access=ALL-UNNAMED")
-}
-
-if (!isTestModule) {
-    mavenPublishing {
-        publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
-        signAllPublications()
-        coordinates("io.github.jwharm.javagi", project.name, project.version.toString())
-        pom {
-            val capitalizedId = project.name.replaceFirstChar(Char::titlecase)
-            name = capitalizedId
-            description = "Java language bindings for $capitalizedId, generated with Java-GI"
-            url = "https://jwharm.github.io/java-gi/"
-            licenses {
-                license {
-                    name = "GNU Lesser General Public License, version 2.1"
-                    url = "https://www.gnu.org/licenses/lgpl-2.1.txt"
-                }
+mavenPublishing {
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+    signAllPublications()
+    coordinates("io.github.jwharm.javagi", project.name, project.version.toString())
+    pom {
+        val capitalizedId = project.name.replaceFirstChar(Char::titlecase)
+        name = capitalizedId
+        description = "Java language bindings for $capitalizedId, generated with Java-GI"
+        url = "https://jwharm.github.io/java-gi/"
+        licenses {
+            license {
+                name = "GNU Lesser General Public License, version 2.1"
+                url = "https://www.gnu.org/licenses/lgpl-2.1.txt"
             }
-            developers {
-                developer {
-                    id = "jwharm"
-                    name = "Jan-Willem Harmannij"
-                    email = "jwharmannij@gmail.com"
-                    url = "https://github.com/jwharm"
-                }
+        }
+        developers {
+            developer {
+                id = "jwharm"
+                name = "Jan-Willem Harmannij"
+                email = "jwharmannij@gmail.com"
+                url = "https://github.com/jwharm"
             }
-            scm {
-                connection = "scm:git:git://github.com/jwharm/java-gi.git"
-                developerConnection = "scm:git:ssh://github.com:jwharm/java-gi.git"
-                url = "http://github.com/jwharm/java-gi/tree/master"
-            }
+        }
+        scm {
+            connection = "scm:git:git://github.com/jwharm/java-gi.git"
+            developerConnection = "scm:git:ssh://github.com:jwharm/java-gi.git"
+            url = "https://github.com/jwharm/java-gi/tree/master"
         }
     }
 }

--- a/buildSrc/src/main/kotlin/java-gi.module.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-gi.module.gradle.kts
@@ -1,0 +1,96 @@
+import org.apache.tools.ant.taskdefs.condition.Os
+
+/*
+ * Common build settings for Java-GI modules:
+ *
+ * - Load plugins
+ * - Set maven repositories
+ * - Load common dependencies
+ * - Set group and Java-GI version number
+ * - Set JDK version
+ * - Configure 'generateSources' action
+ * - Set OS-specific library paths and parameters for unit tests
+ * - Set common POM metadata and enable signing
+ */
+
+plugins {
+    id("java-library")
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    compileOnly(libs.annotations)
+    testImplementation(libs.junit.jupiter)
+    testRuntimeOnly(libs.junit.platform.launcher)
+}
+
+group = "io.github.jwharm.javagi"
+version = libs.versions.javagi.get()
+
+java {
+    toolchain.languageVersion = JavaLanguageVersion.of(libs.versions.jdk.get())
+}
+
+// Register a build service that will parse and cache GIR files
+gradle.sharedServices.registerIfAbsent("gir", GirParserService::class) {
+    parameters.inputDirectories.from(project(":ext").projectDir.resolve("gir-files"))
+}
+
+// Register the task that will generate Java sources from GIR files
+val generateSources by tasks.registering(GenerateSources::class) {
+    mainJavaSourcesDirectory = layout.projectDirectory.dir("src/main/java")
+    outputDirectory = layout.buildDirectory.dir("generated/sources/java-gi")
+}
+
+// Add the generated sources to the main sourceSet
+sourceSets["main"].java.srcDir(generateSources)
+
+tasks.withType<JavaCompile>().configureEach {
+    options.encoding = "UTF-8"
+}
+
+tasks.withType<Javadoc>().configureEach {
+    options {
+        this as StandardJavadocDocletOptions
+        addStringOption("tag", "apiNote:a:API Note:")
+        addStringOption("Xdoclint:none", "-quiet")
+        encoding = "UTF-8"
+    }
+}
+
+tasks.withType<Test>().configureEach {
+    // Don't run tests in Github action. The native libraries aren't installed.
+    if (System.getenv().containsKey("CI")) {
+        enabled = false
+    }
+
+    useJUnitPlatform()
+
+    // Log standard output and error streams when running tests
+    testLogging.showStandardStreams = true
+
+    val ext = project(":ext")
+    val testGirPath = ext.layout.buildDirectory.dir("testgir").map { it.asFile.absolutePath }
+    dependsOn(ext.tasks.named("buildGir"))
+
+    // Configure library path for macOS (Homebrew) and set MacOS-specific JVM parameter
+    if (Os.isFamily(Os.FAMILY_MAC)) {
+        jvmArgs("-Djava.library.path=$testGirPath:/opt/homebrew/lib")
+        jvmArgs("-XstartOnFirstThread")
+    }
+
+    // Configure library path for Arch, Fedora and Debian/Ubuntu
+    else if (Os.isFamily(Os.FAMILY_UNIX)) {
+        jvmArgs("-Djava.library.path=$testGirPath:/usr/lib64:/lib64:/lib:/usr/lib:/lib/x86_64-linux-gnu")
+    }
+
+    // Configure library path for Windows (MSYS2)
+    else if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+        jvmArgs("-Djava.library.path=$testGirPath;C:/msys64/mingw64/bin")
+    }
+
+    jvmArgs("--enable-native-access=ALL-UNNAMED")
+}

--- a/buildSrc/src/main/kotlin/java-gi.test-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-gi.test-conventions.gradle.kts
@@ -1,0 +1,16 @@
+plugins {
+    id("java-gi.module")
+}
+
+with(gradle.sharedServices.registrations["gir"].service.get() as GirParserService) {
+    parameters.inputDirectories.from(project(":ext")
+        .layout.buildDirectory
+        .dir("testgir")
+    )
+}
+
+afterEvaluate {
+    tasks.withType<GenerateSources>().configureEach {
+        dependsOn(project(":ext").tasks.named("buildGir"))
+    }
+}

--- a/ext/build.gradle.kts
+++ b/ext/build.gradle.kts
@@ -1,0 +1,17 @@
+tasks {
+    val sourceDir = layout.projectDirectory.dir("gobject-introspection-tests")
+    val buildDir = layout.buildDirectory.dir("testgir")
+
+    val buildGir by registering(Exec::class) {
+        group = "build"
+        description = "Runs the meson build for gir-files"
+
+        commandLine("sh", "-c", """
+            meson setup "${buildDir.get().asFile.absolutePath}" "${sourceDir.asFile.absolutePath}" && \
+            meson compile -C "${buildDir.get().asFile.absolutePath}"
+        """.trimIndent())
+        workingDir = sourceDir.asFile
+        inputs.dir(sourceDir)
+        outputs.dir(buildDir)
+    }
+}

--- a/generator/build.gradle.kts
+++ b/generator/build.gradle.kts
@@ -29,6 +29,9 @@ application {
     applicationDefaultJvmArgs = listOf("-Dapp.version=$version")
 }
 
+// This task should really be in ext, but that would mean this module
+// would have to be `include`d, which would mean we couldn't use it in our build
+
 // Include the gir-files repository as a zip file with the java-gi command-line
 // utility. To decrease size, the documentation is excluded.
 tasks.register<Zip>("includeGirFiles") {

--- a/modules/test/gimarshallingtests/build.gradle.kts
+++ b/modules/test/gimarshallingtests/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("java-gi.library-conventions")
+    id("java-gi.test-conventions")
 }
 
 dependencies {

--- a/modules/test/regress/build.gradle.kts
+++ b/modules/test/regress/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("java-gi.library-conventions")
+    id("java-gi.test-conventions")
 }
 
 dependencies {

--- a/modules/test/regressunix/build.gradle.kts
+++ b/modules/test/regressunix/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("java-gi.library-conventions")
+    id("java-gi.test-conventions")
 }
 
 dependencies {

--- a/modules/test/utility/build.gradle.kts
+++ b/modules/test/utility/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("java-gi.library-conventions")
+    id("java-gi.test-conventions")
 }
 
 dependencies {

--- a/modules/test/warnlib/build.gradle.kts
+++ b/modules/test/warnlib/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("java-gi.library-conventions")
+    id("java-gi.test-conventions")
 }
 
 dependencies {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -42,3 +42,5 @@ for (p in rootProject.children) {
         File(settingsDir, "modules/test/${p.name}")
     ).firstOrNull { it.exists() }!!
 }
+
+include("ext")


### PR DESCRIPTION
This effectively reverts https://github.com/jwharm/java-gi/commit/b6b5540a694cdc69f4ea78b69cb6d9569f4b785c and https://github.com/jwharm/java-gi/commit/e458bfe84575bc0a8134ae4a0ddeeb9b271c35b9
The key here is the combination of having only a single build task and specifying its `inputs` and `outputs`, since these are what the up-to-date tracking in Gradle is built on.
To avoid the build completely for non-test modules, this PR also splits the library convention plugin into two: a `test` plugin for test modules with the test GIR dependency, and the `library` module for actual libraries with maven publishing, with common parts factored out into a third script.