### PR TITLE
Rename toString_() and notify_() methods

### DIFF
--- a/generator/src/main/java/io/github/jwharm/javagi/generators/MethodGenerator.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/generators/MethodGenerator.java
@@ -51,8 +51,7 @@ public class MethodGenerator {
     }
 
     public static String getName(Callable func) {
-        String name = toJavaIdentifier(func.name());
-        return replaceJavaObjectMethodNames(name, func.parent() instanceof Interface);
+        return toJavaIdentifier(func.name());
     }
 
     public static boolean isGeneric(Callable func) {

--- a/generator/src/main/java/io/github/jwharm/javagi/util/Conversions.java
+++ b/generator/src/main/java/io/github/jwharm/javagi/util/Conversions.java
@@ -25,7 +25,6 @@ import io.github.jwharm.javagi.configuration.ModuleInfo;
 import io.github.jwharm.javagi.gir.*;
 
 import java.lang.foreign.MemorySegment;
-import java.lang.reflect.Modifier;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -158,26 +157,6 @@ public class Conversions {
                 .anyMatch(kw -> kw.equalsIgnoreCase(name))
                         ? ns.cIdentifierPrefix() + name
                         : name;
-    }
-
-
-    /**
-     * Overriding java.lang.Object methods is not allowed in default methods
-     * (in interfaces), and overriding its final methods is not allowed in any
-     * case, so we append an underscore to those method names.
-     *
-     * @param  name the name of the method to check
-     * @param  all  whether to check against all Object methods (instead of
-     *              only the final methods).
-     * @return the method name, possibly renamed
-     */
-    public static String replaceJavaObjectMethodNames(String name, boolean all) {
-        for (java.lang.reflect.Method m : Object.class.getMethods())
-            if (m.getName().equals(name))
-                if (all || Modifier.isFinal(m.getModifiers()))
-                    return name + "_";
-
-        return name;
     }
 
     /**

--- a/modules/main/gio/Gio-2.0.metadata
+++ b/modules/main/gio/Gio-2.0.metadata
@@ -95,3 +95,10 @@ ListStore.remove name=remove_at
  */
 File.prefix_matches invoker=()
 
+/*
+ * Icon.toString() and SocketConnectable.toString() are default
+ * methods. Default methods are not allowed to override
+ * java.lang.Object methods, so we rename them.
+ */
+Icon.to_string name=serialize_to_string
+SocketConnectable.to_string name=format_as_string


### PR DESCRIPTION
Until now, Java-GI automatically renamed methods with the same name as methods in `java.lang.Object`. The reason for this is that default methods in Java interfaces are not allowed to override methods in Object. There were two places where this caused a compile error:

- `g_icon_to_string`
- `g_socket_connectable_to_string`

With the automatic renaming, these methods were available in Java-GI as `Icon.toString_()` and `SocketConnectable.toString_()`. However, the method `g_object_notify` was impacted too, and it was available in Java-GI as `GObject.notify_()`.

I could have changed the automatic renaming to exclude `g_object_notify` but I decided to revert this entirely, and add manually rename the two `to_string` methods in Gio with metadata.

This is the result:

- `org.gnome.gio.Icon.toString_()` is now available as `serializeToString()`
- `org.gnome.gio.SocketConnectable.toString_()` is now available as `formatAsString()`
- `org.gnome.gobject.GObject.notify_()` is now available as `notify()`
