### PR TITLE
Literal suffixes

### DIFF
--- a/generator/src/main/java/org/javagi/generators/TypedValueGenerator.java
+++ b/generator/src/main/java/org/javagi/generators/TypedValueGenerator.java
@@ -761,8 +761,8 @@ class TypedValueGenerator {
 
         } catch (NumberFormatException nfe) {
             // Do not write anything
-            System.out.printf("Skipping <constant name=\"%s\" value=\"%s\">: Value not allowed%n",
-                    v.name(), value);
+            System.out.printf("Skipping <constant name=\"%s\" value=\"%s\">: %s%n",
+                    v.name(), value, nfe.getMessage());
             return null;
         }
     }

--- a/generator/src/main/java/org/javagi/util/Numbers.java
+++ b/generator/src/main/java/org/javagi/util/Numbers.java
@@ -19,24 +19,39 @@
 
 package org.javagi.util;
 
+import java.util.Set;
+
 /**
  * Utility class for parsing numbers where it is unknown whether they are signed
  */
 public class Numbers {
-    public static Byte parseByte(String s) throws NumberFormatException {
+    public static Byte parseByte(String str) throws NumberFormatException {
+        String s = stripSuffix(str);
         return negative(s) ? Byte.parseByte(s) : (byte) Integer.parseInt(s);
     }
 
-    public static Short parseShort(String s) throws NumberFormatException {
+    public static Short parseShort(String str) throws NumberFormatException {
+        String s = stripSuffix(str);
         return negative(s) ? Short.parseShort(s) : (short) Integer.parseInt(s);
     }
 
-    public static Integer parseInt(String s) throws NumberFormatException {
+    public static Integer parseInt(String str) throws NumberFormatException {
+        String s = stripSuffix(str);
         return negative(s) ? Integer.parseInt(s) : Integer.parseUnsignedInt(s);
     }
 
-    public static Long parseLong(String s) throws NumberFormatException {
+    public static Long parseLong(String str) throws NumberFormatException {
+        String s = stripSuffix(str);
         return negative(s) ? Long.parseLong(s) : Long.parseUnsignedLong(s);
+    }
+
+    private static String stripSuffix(String str) {
+        // suffixes for double, unsigned, long and float
+        Set<Character> suffixes = Set.of('D', 'U', 'L', 'F');
+        String result = str;
+        while (suffixes.contains(result.charAt(Character.toUpperCase(result.length() - 1))))
+            result = result.substring(0, result.length() - 1);
+        return result;
     }
 
     private static boolean negative(String s) {

--- a/modules/test/regress/Regress-1.0.metadata
+++ b/modules/test/regress/Regress-1.0.metadata
@@ -1,0 +1,5 @@
+/* Incorrect value of constant larger than 32 bits:
+ * https://gitlab.gnome.org/GNOME/gobject-introspection/-/issues/526
+ * Change the type to a gint64.
+ */
+ANNOTATION_CALCULATED_LARGE.gint#type name=gint64 c:type=gint64

--- a/modules/test/regress/build.gradle.kts
+++ b/modules/test/regress/build.gradle.kts
@@ -10,4 +10,5 @@ dependencies {
 
 tasks.withType<GenerateSources> {
     namespace = "Regress"
+    metadata = file("Regress-1.0.metadata")
 }


### PR DESCRIPTION
- Handle constant declarations where the value has a suffix (for examplle "ul" for unsigned long or "f" for float).
- Workaround an issue in the Regress gir file
