### PR TITLE
Implement malloc-based SegmentAllocator

### DIFF
--- a/generator/src/main/java/org/javagi/generators/TypedValueGenerator.java
+++ b/generator/src/main/java/org/javagi/generators/TypedValueGenerator.java
@@ -232,12 +232,12 @@ class TypedValueGenerator {
         // When ownership is transferred, we must not free the allocated
         // memory -> use global scope
         var transfer = v instanceof Parameter p ? p.transferOwnership() : NONE;
-        String allocator = (transfer == CONTAINER || transfer == FULL) ? "$arena:T.global()" : "_arena";
+        String allocator = (transfer == CONTAINER || transfer == FULL) ? "$interop:T.mallocAllocator()" : "_arena";
 
         // String[][]
         if (array.anyType() instanceof Array inner
                 && inner.anyType() instanceof Type t && t.isString()) {
-            String elemAllocator = transfer == FULL ? "$arena:T.global()" : "_arena";
+            String elemAllocator = transfer == FULL ? "$interop:T.mallocAllocator()" : "_arena";
             return PartialStatement.of(
                     "$interop:T.allocateNativeArray(" + identifier + ", "
                             + array.zeroTerminated() + ", " + allocator + ", " + elemAllocator + ")",


### PR DESCRIPTION
When a memory segment is passed to a native function with full ownership transfer, the native function will free the memory. Until now, java-gi used `Arena.global()` to allocate this memory, to prevent a double-free, but this is not guaranteed to work. It is better to actually use malloc to allocate the memory.

The `malloc` function we use is `g_try_malloc0`. This means the newly allocated memory will be zero-initialized. If the allocation fails, it returns `null`. In that case, java-gi will raise an `InteropException`.

The allocator contains a workaround to be able to allocate zero-length memory segments (common in Java, but not supported by `g_malloc`).