### PR TITLE
Fix memory layout generation for struct parameters

### DIFF
--- a/generator/src/main/java/org/javagi/generators/MemoryLayoutGenerator.java
+++ b/generator/src/main/java/org/javagi/generators/MemoryLayoutGenerator.java
@@ -223,7 +223,6 @@ public class MemoryLayoutGenerator {
         }
 
         // Plain value layout
-        String layout = getValueLayout(type, longAsInt);
-        return PartialStatement.of("$valueLayout:T." + layout);
+        return getValueLayout(type, longAsInt);
     }
 }

--- a/generator/src/main/java/org/javagi/generators/SignalGenerator.java
+++ b/generator/src/main/java/org/javagi/generators/SignalGenerator.java
@@ -163,10 +163,7 @@ public class SignalGenerator {
                     .forEach(p -> p.generate(builder));
 
         // Determine ValueLayout for return value
-        var returnLayout = PartialStatement.of(
-                generator.generateValueLayout(returnValue.anyType()),
-                "interop", ClassNames.INTEROP,
-                "valueLayout", ValueLayout.class);
+        var returnLayout = generator.generateValueLayout(returnValue.anyType());
 
         // Allocate memory for return value
         if (!returnValue.anyType().isVoid()) {

--- a/generator/src/main/java/org/javagi/generators/TypedValueGenerator.java
+++ b/generator/src/main/java/org/javagi/generators/TypedValueGenerator.java
@@ -22,7 +22,6 @@ package org.javagi.generators;
 import com.squareup.javapoet.*;
 import org.javagi.configuration.ClassNames;
 import org.javagi.gir.*;
-import org.javagi.util.Conversions;
 import org.javagi.util.PartialStatement;
 import org.javagi.gir.Class;
 import org.javagi.gir.Record;
@@ -850,12 +849,11 @@ class TypedValueGenerator {
     // Generate a statement that represents ValueLayout for this type.
     // Returns ValueLayout.ADDRESS for complex layouts.
     PartialStatement getValueLayout(AnyType anyType) {
-        String stmt = (anyType instanceof Type t && t.isLong())
-                ? "($interop:T.longAsInt() ? $valueLayout:T.JAVA_INT : $valueLayout:T.JAVA_LONG)"
-                : "$valueLayout:T." + Conversions.getValueLayoutPlain(anyType, false);
-        return PartialStatement.of(stmt,
-                "interop", ClassNames.INTEROP,
-                "valueLayout", ValueLayout.class);
+        return anyType instanceof Type t && t.isLong()
+                ? PartialStatement.of("$interop:T.longAsInt() ? $valueLayout:T.JAVA_INT : $valueLayout:T.JAVA_LONG",
+                        "valueLayout", ValueLayout.class,
+                        "interop", ClassNames.INTEROP)
+                : getValueLayoutPlain(anyType, false);
     }
 
     // Generate a statement that retrieves a ValueLayout for primitive types,

--- a/generator/src/main/java/org/javagi/gir/Type.java
+++ b/generator/src/main/java/org/javagi/gir/Type.java
@@ -126,7 +126,7 @@ public final class Type extends GirElement implements AnyType, TypeReference {
     public boolean isPointer() {
         String cType = cType();
         return cType != null
-                && (cType.endsWith("*") || cType.endsWith("gpointer"));
+                && (cType.endsWith("*") || cType.endsWith("gpointer") || cType.endsWith("gconstpointer"));
     }
 
     public boolean isProxy() {


### PR DESCRIPTION
When a struct is passed by value to a native function, we have to set the struct's memory layout in the FunctionDescriptor, not ValueLayout.ADDRESS.

This means we can't use simple strings ("ADDRESS", "JAVA_INT" etc.) to represent the memory layout anymore, because we need to include things like "typeName:T.getMemoryLayout()". So the relevant functions have been changed everywhere to use PartialStatements that maintain the relevant type information.