### PR TITLE
Improve handling of boxed types

### DIFF
--- a/generator/src/main/java/org/javagi/configuration/ClassNames.java
+++ b/generator/src/main/java/org/javagi/configuration/ClassNames.java
@@ -58,6 +58,7 @@ public final class ClassNames {
     public static final ClassName STRING_OBJECT = get("org.gnome.gtk", "StringObject");
 
     public static final ClassName BINDING_BUILDER = get(PKG_GOBJECT, "BindingBuilder");
+    public static final ClassName BOXED_UTIL = get(PKG_GOBJECT, "BoxedUtil");
     public static final ClassName BUILDER = get(PKG_GOBJECT, "Builder");
     public static final ClassName BUILDER_INTERFACE = get(PKG_GOBJECT, "BuilderInterface");
     public static final ClassName INSTANCE_CACHE = get(PKG_GOBJECT, "InstanceCache");

--- a/generator/src/main/java/org/javagi/gir/StandardLayoutType.java
+++ b/generator/src/main/java/org/javagi/gir/StandardLayoutType.java
@@ -19,8 +19,6 @@
 
 package org.javagi.gir;
 
-import java.util.List;
-
 public sealed interface StandardLayoutType
         extends FieldContainer
         permits Boxed, Record, Union {
@@ -38,17 +36,6 @@ public sealed interface StandardLayoutType
             return callable;
 
         return null;
-    }
-
-    default boolean isBoxedType() {
-        if (getTypeFunc() == null)
-            return false;
-
-        if (cType() == null)
-            return true;
-
-        // GValue and GVariant have a get-type func, but are not boxed types
-        return !List.of("GValue", "GVariant", "GClosure").contains(cType());
     }
 
     default Callable copyFunction() {

--- a/generator/src/main/resources/metadata/GLib-2.0.metadata
+++ b/generator/src/main/resources/metadata/GLib-2.0.metadata
@@ -52,4 +52,10 @@ SList     java-gi-custom
 // Use g_variant_print as the Variant.toString() method in Java.
 Variant java-gi-to-string="print(true)"
 
+/*
+ * g_string_free cannot be used by the MemoryCleaner because it has an
+ * extra boolean argument. But this causes Java-GI to treat it as a
+ * boxed type, causing compile errors in the GLib module.
+ * This is a temporary workaround.
+ */
 String free-function="g_string_free"

--- a/generator/src/main/resources/metadata/GLib-2.0.metadata
+++ b/generator/src/main/resources/metadata/GLib-2.0.metadata
@@ -51,3 +51,5 @@ SList     java-gi-custom
 
 // Use g_variant_print as the Variant.toString() method in Java.
 Variant java-gi-to-string="print(true)"
+
+String free-function="g_string_free"

--- a/modules/main/gobject/src/main/java/org/javagi/gobject/BoxedUtil.java
+++ b/modules/main/gobject/src/main/java/org/javagi/gobject/BoxedUtil.java
@@ -1,0 +1,91 @@
+/* Java-GI - Java language bindings for GObject-Introspection-based libraries
+ * Copyright (C) 2022-2025 Jan-Willem Harmannij
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.javagi.gobject;
+
+import org.gnome.glib.Type;
+import org.gnome.gobject.GObjects;
+import org.javagi.base.Proxy;
+import org.javagi.gobject.types.Types;
+import org.javagi.interop.Interop;
+
+import java.lang.foreign.MemorySegment;
+import java.util.function.Consumer;
+
+/**
+ * Utility functions for boxed types
+ */
+public class BoxedUtil {
+
+    /**
+     * Checks if {@code type} is a boxed type.
+     *
+     * @param  type A {@link Type} value
+     * @return {@code true} if {@code type} is a boxed type
+     */
+    public static boolean isBoxed(Type type) {
+        return GObjects.typeFundamental(type).equals(Types.BOXED);
+    }
+
+    /**
+     * Make a copy of {@code struct}. If {@code type} is a boxed type, use
+     * {@code g_boxed_copy}, or else, {@code malloc} a new struct and copy
+     * {@code size} bytes from {@code struct} to it.
+     *
+     * @param type   the type, possibly a boxed type
+     * @param struct the struct to be copied
+     * @param size   the size of the struct (only used when {@code type} is not
+     *               a boxed type)
+     * @return the newly created copy of {@code struct}. The caller has
+     *         ownership and is responsible for freeing it.
+     */
+    public static <T extends Proxy> MemorySegment copy(Type type, T struct, long size) {
+        if (struct == null || struct.handle() == null)
+            return null;
+
+        if (struct.handle().equals(MemorySegment.NULL))
+            return MemorySegment.NULL;
+
+        if (type != null && isBoxed(type))
+            return GObjects.boxedCopy(type, struct.handle());
+
+        MemorySegment copy = Interop.mallocAllocator().allocate(size);
+        Interop.copy(struct.handle(), copy, size);
+        return copy;
+    }
+
+    /**
+     * Free {@code struct}. If {@code type} is a boxed type, use
+     * {@code g_boxed_free}, or else, apply {@code freeFunc} on {@code struct}.
+     *
+     * @param type     the type, possibly a boxed type
+     * @param struct   the struct to be freed
+     * @param freeFunc a function that will free {@code struct} (only used when
+     *                 {@code type} is not a boxed type)
+     */
+    public static <T extends Proxy> void free(Type type, T struct, Consumer<T> freeFunc) {
+        if (struct == null || struct.handle() == null || struct.handle().equals(MemorySegment.NULL))
+            return;
+
+        if (type != null && isBoxed(type))
+            GObjects.boxedFree(type, struct.handle());
+        else if (freeFunc != null)
+            freeFunc.accept(struct);
+    }
+}

--- a/modules/test/gimarshallingtests/src/test/java/org/javagi/gimarshallingtests/TestStructBoxed.java
+++ b/modules/test/gimarshallingtests/src/test/java/org/javagi/gimarshallingtests/TestStructBoxed.java
@@ -1,0 +1,68 @@
+/* Java-GI - Java language bindings for GObject-Introspection-based libraries
+ * Copyright (C) 2025 Jan-Willem Harmannij
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.javagi.gimarshallingtests;
+
+import org.gnome.gi.gimarshallingtests.BoxedStruct;
+import org.javagi.base.Out;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TestStructBoxed {
+    @Test
+    void returnv() {
+        BoxedStruct struct = BoxedStruct.returnv();
+        assertNotNull(struct);
+        assertEquals(42, struct.readLong());
+        assertEquals("hello", struct.readString());
+        assertArrayEquals(new String[] {"0", "1", "2"}, struct.readGStrv());
+    }
+
+    @Test
+    void inv() {
+        BoxedStruct struct = new BoxedStruct();
+        struct.writeLong(42);
+        struct.inv();
+    }
+
+    @Test
+    void out() {
+        var v = new Out<BoxedStruct>();
+        BoxedStruct.out(v);
+        assertNotNull(v.get());
+        assertEquals(42, v.get().readLong());
+    }
+
+    @Test
+    void outUninitialized() {
+        var v = new Out<BoxedStruct>();
+        assertFalse(BoxedStruct.outUninitialized(v));
+    }
+
+    @Test
+    void inout() {
+        BoxedStruct struct = new BoxedStruct();
+        struct.writeLong(42);
+        var v = new Out<>(struct);
+        BoxedStruct.inout(v);
+        assertNotNull(v.get());
+        assertEquals(0, v.get().readLong());
+    }
+}

--- a/modules/test/gimarshallingtests/src/test/java/org/javagi/gimarshallingtests/TestStructPointer.java
+++ b/modules/test/gimarshallingtests/src/test/java/org/javagi/gimarshallingtests/TestStructPointer.java
@@ -19,27 +19,21 @@
 
 package org.javagi.gimarshallingtests;
 
-import org.gnome.gi.gimarshallingtests.SimpleStruct;
+import org.gnome.gi.gimarshallingtests.PointerStruct;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class TestSimpleStruct {
+public class TestStructPointer {
     @Test
     void returnv() {
-        SimpleStruct struct = SimpleStruct.returnv();
+        PointerStruct struct = PointerStruct.returnv();
         assertNotNull(struct);
-        assertEquals(6, struct.readLong());
-        assertEquals(7, struct.readInt8());
+        assertEquals(42, struct.readLong());
     }
 
     @Test
     void inv() {
-        new SimpleStruct(6, (byte) 7).inv();
-    }
-
-    @Test
-    void method() {
-        new SimpleStruct(6, (byte) 7).method();
+        new PointerStruct(42).inv();
     }
 }

--- a/modules/test/gimarshallingtests/src/test/java/org/javagi/gimarshallingtests/TestStructSimple.java
+++ b/modules/test/gimarshallingtests/src/test/java/org/javagi/gimarshallingtests/TestStructSimple.java
@@ -1,0 +1,45 @@
+/* Java-GI - Java language bindings for GObject-Introspection-based libraries
+ * Copyright (C) 2025 Jan-Willem Harmannij
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.javagi.gimarshallingtests;
+
+import org.gnome.gi.gimarshallingtests.SimpleStruct;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TestStructSimple {
+    @Test
+    void returnv() {
+        SimpleStruct struct = SimpleStruct.returnv();
+        assertNotNull(struct);
+        assertEquals(6, struct.readLong());
+        assertEquals(7, struct.readInt8());
+    }
+
+    @Test
+    void inv() {
+        new SimpleStruct(6, (byte) 7).inv();
+    }
+
+    @Test
+    void method() {
+        new SimpleStruct(6, (byte) 7).method();
+    }
+}


### PR DESCRIPTION
Copy and free actions for structs was not always working correctly, because Java-GI incorrectly assumed all structs with a `get_type()` function are boxed types. This PR adds a new utility class for working with boxed types, `BoxedUtil`, and uses it to:
- check if a struct is boxed
- copy a struct, using `g_boxed_copy` if it is a boxed type without a known copy-function
- free a struct, using `g_boxed_free` if it is a boxed type without a known free-function
