### PR TITLE
Marshal GString from and to Java String

### DIFF
--- a/generator/src/main/java/org/javagi/generators/PreprocessingGenerator.java
+++ b/generator/src/main/java/org/javagi/generators/PreprocessingGenerator.java
@@ -51,6 +51,7 @@ public class PreprocessingGenerator extends TypedValueGenerator {
         scope(builder);
         transferOwnership(builder);
         createGBytes(builder);
+        createGString(builder);
     }
 
     public void generateUpcall(MethodSpec.Builder builder) {
@@ -492,6 +493,18 @@ public class PreprocessingGenerator extends TypedValueGenerator {
                         getName(), ValueLayout.class, ClassNames.INTEROP);
             } else {
                 builder.addStatement("$1T _$3LGBytes = $2T.toGBytes($3L)",
+                        MemorySegment.class, ClassNames.INTEROP, getName());
+            }
+        }
+    }
+
+    private void createGString(MethodSpec.Builder builder) {
+        if (target != null && target.checkIsGString()) {
+            if (p.isOutParameter()) {
+                builder.addStatement("_$1LPointer.set($2T.ADDRESS, 0L, $3T.toGString($1L == null ? null : $1L.get()))",
+                        getName(), ValueLayout.class, ClassNames.INTEROP);
+            } else {
+                builder.addStatement("$1T _$3LGString = $2T.toGString($3L)",
                         MemorySegment.class, ClassNames.INTEROP, getName());
             }
         }

--- a/generator/src/main/java/org/javagi/gir/RegisteredType.java
+++ b/generator/src/main/java/org/javagi/gir/RegisteredType.java
@@ -105,6 +105,11 @@ public sealed interface RegisteredType
         return cType() != null && "GBytes".equals(cType());
     }
 
+    /** Return true if this is GString */
+    default boolean checkIsGString() {
+        return cType() != null && "GString".equals(cType());
+    }
+
     /** Return true if this is GValue */
     default boolean checkIsGValue() {
         return cType() != null && "GValue".equals(cType());

--- a/generator/src/main/java/org/javagi/gir/TypeReference.java
+++ b/generator/src/main/java/org/javagi/gir/TypeReference.java
@@ -65,6 +65,10 @@ public interface TypeReference {
             if (rec.checkIsGBytes())
                 return ArrayTypeName.of(byte.class);
 
+            // GString is treated as a String
+            if (rec.checkIsGString())
+                return TypeName.get(String.class);
+
             // A TypeClass or TypeInterface is an inner class
             var outer = rec.isGTypeStructFor();
             if (outer != null)

--- a/generator/src/main/java/org/javagi/metadata/MetadataParser.java
+++ b/generator/src/main/java/org/javagi/metadata/MetadataParser.java
@@ -19,10 +19,7 @@
 
 package org.javagi.metadata;
 
-import org.javagi.gir.Node;
-import org.javagi.gir.Parameters;
-import org.javagi.gir.Repository;
-import org.javagi.gir.TypeReference;
+import org.javagi.gir.*;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -301,7 +298,9 @@ public class MetadataParser {
                 var matchesEverything = "*".equals(pattern);
 
                 // node name matches pattern?
-                var name = child.attr("name");
+                var name = child instanceof Boxed
+                        ? child.attr("glib:name")
+                        : child.attr("name");
                 var matchesPattern = name != null && patternSpec.matcher(name).matches();
 
                 if (matchesEverything || matchesPattern) {

--- a/generator/src/main/java/org/javagi/util/Conversions.java
+++ b/generator/src/main/java/org/javagi/util/Conversions.java
@@ -155,7 +155,7 @@ public class Conversions {
         if (ns == null)
             return name;
 
-        return Stream.of("String", "Object", "Error", "Builder")
+        return Stream.of("Object", "Error", "Builder")
                 .anyMatch(kw -> kw.equalsIgnoreCase(name))
                         ? ns.cIdentifierPrefix() + name
                         : name;

--- a/generator/src/main/resources/metadata/GLib-2.0.metadata
+++ b/generator/src/main/resources/metadata/GLib-2.0.metadata
@@ -22,6 +22,9 @@ clear_list#function.list_ptr direction=inout transfer-ownership=full
  */
 Bytes java-gi-skip
 
+// Likewise, GString is available in Java as a java.lang.String.
+String java-gi-skip
+
 /*
  * GVariant has a method "get_type" that clashes with the "getType()"
  * method that is generated in Java. Therefore, it is renamed to

--- a/generator/src/main/resources/metadata/GObject-2.0.metadata
+++ b/generator/src/main/resources/metadata/GObject-2.0.metadata
@@ -48,3 +48,6 @@ CClosure.new*#function java-gi-skip
 
 // Implement GValue.toString() with g_strdup_value_contents()
 Value java-gi-to-string="org.gnome.gobject.GObjects.strdupValueContents(this)"
+
+// GString is marshaled to a java.lang.String
+String java-gi-skip

--- a/modules/main/glib/src/test/java/org/javagi/glib/BytesTest.java
+++ b/modules/main/glib/src/test/java/org/javagi/glib/BytesTest.java
@@ -19,8 +19,9 @@
 
 package org.javagi.glib;
 
+import org.gnome.glib.ChecksumType;
+import org.gnome.glib.GLib;
 import org.javagi.base.GErrorException;
-import org.gnome.glib.GString;
 import org.gnome.glib.KeyFile;
 import org.junit.jupiter.api.Test;
 
@@ -31,11 +32,9 @@ public class BytesTest {
 
     @Test
     public void testFromGBytes() {
-        var input = "test";
-        var gstring = new GString(input);
-        var bytes = gstring.freeToBytes();
-        var output = new String(bytes);
-        assertEquals(input, output);
+        var expected = "e2fc714c4727ee9395f324cd2e7f331f";
+        var computed = GLib.computeChecksumForBytes(ChecksumType.MD5, "abcd".getBytes());
+        assertEquals(expected, computed);
     }
 
     @Test

--- a/modules/main/glib/src/test/java/org/javagi/glib/MarshalTest.java
+++ b/modules/main/glib/src/test/java/org/javagi/glib/MarshalTest.java
@@ -2,7 +2,7 @@ package org.javagi.glib;
 
 import org.javagi.base.Proxy;
 import org.javagi.interop.Interop;
-import org.gnome.glib.GString;
+import org.gnome.glib.Date;
 import org.gnome.glib.OptionFlags;
 import org.gnome.glib.Variant;
 import org.junit.jupiter.api.Test;
@@ -13,7 +13,6 @@ import java.util.Arrays;
 
 import static org.javagi.base.TransferOwnership.NONE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test conversion of strings and arrays to native memory and back
@@ -175,15 +174,18 @@ public class MarshalTest {
     @Test
     void testStructArray() {
         try (Arena arena = Arena.ofConfined()) {
-            GString[] input = {
-                    new GString("abc"),
-                    new GString((String) null),
-                    new GString("12345 67890")
+            Date[] input = {
+                    new Date(),
+                    new Date(),
+                    new Date()
             };
-            MemorySegment allocation = Interop.allocateNativeArray(input, GString.getMemoryLayout(), false, arena);
-            GString[] output = Interop.getStructArrayFrom(allocation, 3, GString.class, GString::new, GString.getMemoryLayout());
+            input[0].setParse("01/01/2000");
+            input[1].setParse("01/01/2001");
+            input[2].setParse("01/01/2002");
+            MemorySegment allocation = Interop.allocateNativeArray(input, Date.getMemoryLayout(), false, arena);
+            Date[] output = Interop.getStructArrayFrom(allocation, 3, Date.class, Date::new, Date.getMemoryLayout());
             for (int i = 0; i < input.length; i++)
-                assertTrue(input[i].equal(output[i]));
+                assertEquals(input[i].getYear(), output[i].getYear());
         }
     }
 


### PR DESCRIPTION
With this PR, `GString` is marshaled to and from `java.lang.String` automatically by Java-GI. The class `org.gnome.glib.GString` is no longer generated.