### PR TITLE
Add gir version in gradle build files

### DIFF
--- a/buildSrc/src/main/java/GenerateSources.java
+++ b/buildSrc/src/main/java/GenerateSources.java
@@ -43,6 +43,9 @@ public abstract class GenerateSources extends DefaultTask {
     @Input
     public abstract Property<String> getNamespace();
 
+    @Input
+    public abstract Property<String> getVersion();
+
     @InputFiles
     public abstract DirectoryProperty getMainJavaSourcesDirectory();
 
@@ -53,11 +56,12 @@ public abstract class GenerateSources extends DefaultTask {
     void execute() {
         try {
             var buildService = getGirParserService().get();
-            var namespace = getNamespace().get();
-            var library = buildService.getLibrary(namespace);
+            var name = getNamespace().get();
+            var version = getVersion().get();
+            var library = buildService.getLibrary(name, version);
             var packages = getPackages();
             var outputDirectory = getOutputDirectory().get().getAsFile();
-            generate(namespace, library, packages, outputDirectory);
+            generate(name, version, library, packages, outputDirectory);
         } catch (Exception e) {
             throw new TaskExecutionException(this, e);
         }

--- a/generator/src/main/java/org/javagi/JavaGI.java
+++ b/generator/src/main/java/org/javagi/JavaGI.java
@@ -181,13 +181,14 @@ public class JavaGI implements Callable<Integer> {
                         .formatted(girFile.getName()));
 
             // Prepare module and package information
-            var namespace = repository.namespace().name();
-            var packageName = generatePackageName(namespace);
-            ModuleInfo.add(namespace, packageName, packageName, docUrl, summary);
+            var name = repository.namespace().name();
+            var version = repository.namespace().version();
+            var packageName = generatePackageName(name);
+            ModuleInfo.add(name, packageName, packageName, docUrl, summary);
             library.put(girFile.getName(), repository);
 
             // Create a directory for each module
-            var libDirectory = new File(outputDirectory, namespace.toLowerCase());
+            var libDirectory = new File(outputDirectory, name.toLowerCase());
 
             // No custom packages to export in module-info.java
             var packages = new HashSet<String>();
@@ -199,12 +200,12 @@ public class JavaGI implements Callable<Integer> {
             var ignored = srcDirectory.mkdirs();
 
             // Generate the language bindings
-            generate(namespace, library, packages, srcDirectory);
+            generate(name, version, library, packages, srcDirectory);
 
             if (generateProject) {
                 // Generate build.gradle script
                 writeBuildScript(libDirectory.toPath(), repository);
-                subprojects.add(namespace.toLowerCase());
+                subprojects.add(name.toLowerCase());
             }
         }
 
@@ -253,13 +254,14 @@ public class JavaGI implements Callable<Integer> {
     }
 
     // Generate Java language bindings for a GIR repository
-    public static void generate(String namespace,
+    public static void generate(String name,
+                                String version,
                                 Library library,
                                 Set<String> packages,
                                 File outputDirectory) throws IOException {
 
-        Namespace ns = library.lookupNamespace(namespace);
-        String packageName = ModuleInfo.packageName(namespace);
+        Namespace ns = library.lookupNamespace(name);
+        String packageName = ModuleInfo.packageName(name);
 
         // Generate class with namespace-global constants and functions
         var typeSpec = new NamespaceGenerator(ns).generateGlobalsClass();

--- a/modules/main/adw/build.gradle.kts
+++ b/modules/main/adw/build.gradle.kts
@@ -9,4 +9,5 @@ dependencies {
 
 tasks.withType<GenerateSources> {
     namespace = "Adw"
+    version = "1"
 }

--- a/modules/main/gdk/build.gradle.kts
+++ b/modules/main/gdk/build.gradle.kts
@@ -11,4 +11,5 @@ dependencies {
 
 tasks.withType<GenerateSources> {
     namespace = "Gdk"
+    version = "4.0"
 }

--- a/modules/main/gdkpixbuf/build.gradle.kts
+++ b/modules/main/gdkpixbuf/build.gradle.kts
@@ -9,4 +9,5 @@ dependencies {
 
 tasks.withType<GenerateSources> {
     namespace = "GdkPixbuf"
+    version = "2.0"
 }

--- a/modules/main/gio/build.gradle.kts
+++ b/modules/main/gio/build.gradle.kts
@@ -9,4 +9,5 @@ dependencies {
 
 tasks.withType<GenerateSources> {
     namespace = "Gio"
+    version = "2.0"
 }

--- a/modules/main/glib/build.gradle.kts
+++ b/modules/main/glib/build.gradle.kts
@@ -4,4 +4,5 @@ plugins {
 
 tasks.withType<GenerateSources> {
     namespace = "GLib"
+    version = "2.0"
 }

--- a/modules/main/gmodule/build.gradle.kts
+++ b/modules/main/gmodule/build.gradle.kts
@@ -8,4 +8,5 @@ dependencies {
 
 tasks.withType<GenerateSources> {
     namespace = "GModule"
+    version = "2.0"
 }

--- a/modules/main/gobject/build.gradle.kts
+++ b/modules/main/gobject/build.gradle.kts
@@ -8,4 +8,5 @@ dependencies {
 
 tasks.withType<GenerateSources> {
     namespace = "GObject"
+    version = "2.0"
 }

--- a/modules/main/graphene/build.gradle.kts
+++ b/modules/main/graphene/build.gradle.kts
@@ -8,4 +8,5 @@ dependencies {
 
 tasks.withType<GenerateSources> {
     namespace = "Graphene"
+    version = "1.0"
 }

--- a/modules/main/gsk/build.gradle.kts
+++ b/modules/main/gsk/build.gradle.kts
@@ -9,4 +9,5 @@ dependencies {
 
 tasks.withType<GenerateSources> {
     namespace = "Gsk"
+    version = "4.0"
 }

--- a/modules/main/gst/build.gradle.kts
+++ b/modules/main/gst/build.gradle.kts
@@ -10,4 +10,5 @@ dependencies {
 
 tasks.withType<GenerateSources> {
     namespace = "Gst"
+    version = "1.0"
 }

--- a/modules/main/gstaudio/build.gradle.kts
+++ b/modules/main/gstaudio/build.gradle.kts
@@ -8,4 +8,5 @@ dependencies {
 
 tasks.withType<GenerateSources> {
     namespace = "GstAudio"
+    version = "1.0"
 }

--- a/modules/main/gstbase/build.gradle.kts
+++ b/modules/main/gstbase/build.gradle.kts
@@ -8,4 +8,5 @@ dependencies {
 
 tasks.withType<GenerateSources> {
     namespace = "GstBase"
+    version = "1.0"
 }

--- a/modules/main/gstpbutils/build.gradle.kts
+++ b/modules/main/gstpbutils/build.gradle.kts
@@ -11,4 +11,5 @@ dependencies {
 
 tasks.withType<GenerateSources> {
     namespace = "GstPbutils"
+    version = "1.0"
 }

--- a/modules/main/gstvideo/build.gradle.kts
+++ b/modules/main/gstvideo/build.gradle.kts
@@ -8,4 +8,5 @@ dependencies {
 
 tasks.withType<GenerateSources> {
     namespace = "GstVideo"
+    version = "1.0"
 }

--- a/modules/main/gtk/build.gradle.kts
+++ b/modules/main/gtk/build.gradle.kts
@@ -9,4 +9,5 @@ dependencies {
 
 tasks.withType<GenerateSources> {
     namespace = "Gtk"
+    version = "4.0"
 }

--- a/modules/main/gtksourceview/build.gradle.kts
+++ b/modules/main/gtksourceview/build.gradle.kts
@@ -8,4 +8,5 @@ dependencies {
 
 tasks.withType<GenerateSources> {
     namespace = "GtkSource"
+    version = "5"
 }

--- a/modules/main/harfbuzz/build.gradle.kts
+++ b/modules/main/harfbuzz/build.gradle.kts
@@ -9,4 +9,5 @@ dependencies {
 
 tasks.withType<GenerateSources> {
     namespace = "HarfBuzz"
+    version = "0.0"
 }

--- a/modules/main/javascriptcore/build.gradle.kts
+++ b/modules/main/javascriptcore/build.gradle.kts
@@ -8,4 +8,5 @@ dependencies {
 
 tasks.withType<GenerateSources> {
     namespace = "JavaScriptCore"
+    version = "6.0"
 }

--- a/modules/main/pango/build.gradle.kts
+++ b/modules/main/pango/build.gradle.kts
@@ -10,4 +10,5 @@ dependencies {
 
 tasks.withType<GenerateSources> {
     namespace = "Pango"
+    version = "1.0"
 }

--- a/modules/main/pangocairo/build.gradle.kts
+++ b/modules/main/pangocairo/build.gradle.kts
@@ -9,4 +9,5 @@ dependencies {
 
 tasks.withType<GenerateSources> {
     namespace = "PangoCairo"
+    version = "1.0"
 }

--- a/modules/main/soup/build.gradle.kts
+++ b/modules/main/soup/build.gradle.kts
@@ -8,4 +8,5 @@ dependencies {
 
 tasks.withType<GenerateSources> {
     namespace = "Soup"
+    version = "3.0"
 }

--- a/modules/main/webkit/build.gradle.kts
+++ b/modules/main/webkit/build.gradle.kts
@@ -10,4 +10,5 @@ dependencies {
 
 tasks.withType<GenerateSources> {
     namespace = "WebKit"
+    version = "6.0"
 }

--- a/modules/main/webkitwebprocessextension/build.gradle.kts
+++ b/modules/main/webkitwebprocessextension/build.gradle.kts
@@ -10,4 +10,5 @@ dependencies {
 
 tasks.withType<GenerateSources> {
     namespace = "WebKitWebProcessExtension"
+    version = "6.0"
 }

--- a/modules/test/gimarshallingtests/build.gradle.kts
+++ b/modules/test/gimarshallingtests/build.gradle.kts
@@ -8,4 +8,5 @@ dependencies {
 
 tasks.withType<GenerateSources> {
     namespace = "GIMarshallingTests"
+    version = "1.0"
 }

--- a/modules/test/regress/build.gradle.kts
+++ b/modules/test/regress/build.gradle.kts
@@ -10,4 +10,5 @@ dependencies {
 
 tasks.withType<GenerateSources> {
     namespace = "Regress"
+    version = "1.0"
 }

--- a/modules/test/regressunix/build.gradle.kts
+++ b/modules/test/regressunix/build.gradle.kts
@@ -10,4 +10,5 @@ dependencies {
 
 tasks.withType<GenerateSources> {
     namespace = "RegressUnix"
+    version = "1.0"
 }

--- a/modules/test/utility/build.gradle.kts
+++ b/modules/test/utility/build.gradle.kts
@@ -8,4 +8,5 @@ dependencies {
 
 tasks.withType<GenerateSources> {
     namespace = "Utility"
+    version = "1.0"
 }

--- a/modules/test/warnlib/build.gradle.kts
+++ b/modules/test/warnlib/build.gradle.kts
@@ -8,4 +8,5 @@ dependencies {
 
 tasks.withType<GenerateSources> {
     namespace = "WarnLib"
+    version = "1.0"
 }


### PR DESCRIPTION
Different library versions can have different gir files, such as Gtk-3.0.gir and Gtk-4.0.gir. Until now, java-gi only used the name to load a gir file; now it also uses the version.