### PR TITLE
Improve handling of GValues with boxed types and string arrays

### DIFF
--- a/buildSrc/src/main/kotlin/java-gi.module.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-gi.module.gradle.kts
@@ -64,6 +64,8 @@ tasks.withType<Javadoc>().configureEach {
 }
 
 tasks.withType<Test>().configureEach {
+    outputs.upToDateWhen { false }
+    outputs.cacheIf { false }
     useJUnitPlatform()
 
     testLogging {

--- a/generator/src/main/java/org/javagi/generators/PostprocessingGenerator.java
+++ b/generator/src/main/java/org/javagi/generators/PostprocessingGenerator.java
@@ -266,8 +266,7 @@ public class PostprocessingGenerator extends TypedValueGenerator {
             var hasMemoryLayout = new MemoryLayoutGenerator().canGenerate(slt);
 
             // Don't automatically copy the return values of GLib functions
-            var skipNamespace = List.of("GLib", "GModule")
-                    .contains(target.namespace().name());
+            boolean skipNamespace = !target.namespace().parent().isInScope("GObject");
 
             // No copy function, and unknown size: copying is impossible
             if (skipNamespace || (!hasMemoryLayout && copyFunc == null)) {

--- a/generator/src/main/java/org/javagi/gir/Repository.java
+++ b/generator/src/main/java/org/javagi/gir/Repository.java
@@ -53,6 +53,33 @@ public final class Repository extends GirElement {
             throw new IllegalStateException("Gir file does not contain exactly one namespace");
     }
 
+    /**
+     * Check whether the requested namespace is in scope of this repository.
+     * In other words, check whether the requested namespace is in this
+     * repository or in one of its dependencies ({@code <include>} elements).
+     *
+     * @param otherNamespace the other namespace that may be in scope or not
+     * @return true when the other namespace is in scope, otherwise false
+     */
+    public boolean isInScope(String otherNamespace) {
+        if (otherNamespace == null)
+            return false;
+
+        for (var ns : namespaces()) {
+            if (otherNamespace.equals(ns.name()))
+                return true;
+        }
+
+        for (Include incl : includes()) {
+            var includedNamespace = lookupNamespace(incl.name());
+            var repository = includedNamespace.parent();
+            if (repository.isInScope(otherNamespace))
+                return true;
+        }
+
+        return false;
+    }
+
     public Node lookupCIdentifier(String cIdentifier) {
         return library().lookupCIdentifier(cIdentifier);
     }

--- a/modules/main/gobject/src/main/java/org/javagi/gobject/types/TypeCache.java
+++ b/modules/main/gobject/src/main/java/org/javagi/gobject/types/TypeCache.java
@@ -125,10 +125,13 @@ public class TypeCache {
         }
 
         // Check implemented interfaces
-        for (var iface : GObjects.typeInterfaces(type)) {
-            var result = tryConstruct(cls, iface);
-            if (result != null)
-                return result;
+        var typeInterfaces = GObjects.typeInterfaces(type);
+        if (typeInterfaces != null) {
+            for (var iface : typeInterfaces) {
+                var result = tryConstruct(cls, iface);
+                if (result != null)
+                    return result;
+            }
         }
 
         // Register the fallback constructor for this type

--- a/modules/main/gobject/src/test/java/org/javagi/gobject/ClosureTest.java
+++ b/modules/main/gobject/src/test/java/org/javagi/gobject/ClosureTest.java
@@ -25,7 +25,6 @@ import org.gnome.gobject.GObject;
 import org.gnome.gobject.Value;
 import org.junit.jupiter.api.Test;
 
-import java.lang.foreign.MemorySegment;
 import java.lang.reflect.Method;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -37,7 +36,7 @@ public class ClosureTest {
 
     @SuppressWarnings("unused")
     public interface MyInterface {
-        boolean timesTwo(MemorySegment p1, MemorySegment p2);
+        boolean timesTwo(Value src, Value dest);
     }
 
     @Test
@@ -49,7 +48,7 @@ public class ClosureTest {
         // Create a JavaClosure for the "timesTwo" method
         Method timesTwo = null;
         try {
-            timesTwo = ClosureTest.class.getMethod("timesTwo", MemorySegment.class, MemorySegment.class);
+            timesTwo = ClosureTest.class.getMethod("timesTwo", Value.class, Value.class);
         } catch (NoSuchMethodException ignored) {}
         JavaClosure closure = new JavaClosure(this, timesTwo);
 
@@ -87,9 +86,7 @@ public class ClosureTest {
     }
 
     // The method that is wrapped in a JavaClosure
-    public boolean timesTwo(MemorySegment boxed1, MemorySegment boxed2) {
-        Value src = new Value(boxed1);
-        Value dest = new Value(boxed2);
+    public boolean timesTwo(Value src, Value dest) {
         dest.setInt(src.getInt() * 2);
         return true;
     }

--- a/modules/test/gimarshallingtests/src/test/java/org/javagi/gimarshallingtests/TestObjectProperties.java
+++ b/modules/test/gimarshallingtests/src/test/java/org/javagi/gimarshallingtests/TestObjectProperties.java
@@ -21,9 +21,8 @@ package org.javagi.gimarshallingtests;
 
 import org.gnome.gi.gimarshallingtests.BoxedStruct;
 import org.gnome.gi.gimarshallingtests.PropertiesObject;
-import org.gnome.glib.Strv;
+import org.gnome.glib.List;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.AtomicInteger;
@@ -113,24 +112,29 @@ public class TestObjectProperties {
         assertEquals(Math.E, obj.getProperty("some-double"));
     }
 
-    @Test @Disabled // Boxed GValues not implemented yet
+    @Test
     void getSetStrv() {
         var array = new String[] {"0", "1", "2"};
         obj.setProperty("some-strv", array);
         assertArrayEquals(array, (String[]) obj.getProperty("some-strv"));
     }
 
-    @Test @Disabled // Boxed GValues not implemented yet
+    @Test
     void getSetBoxedStruct() {
-        var struct = new BoxedStruct();
-        obj.setProperty("some-boxed-struct", struct);
-        assertEquals(struct, obj.getProperty("some-boxed-struct"));
+        var in = new BoxedStruct();
+        in.writeLong(6);
+        obj.setProperty("some-boxed-struct", in);
+        var out = (BoxedStruct) obj.getProperty("some-boxed-struct");
+        assertEquals(in.readLong(), out.readLong());
     }
 
-    @Test @Disabled // Boxed GValues not implemented yet
+    @Test
     void getSetBoxedGList() {
-        var glist = glistIntNoneReturn();
+        List<Integer> glist = glistIntNoneReturn();
         obj.setProperty("some-boxed-glist", glist);
-        assertEquals(glist, obj.getProperty("some-boxed-glist"));
+        // Currently unsupported: The boxed type is not registered, and
+        // the type hint in the doc comment is not usable here
+        assertThrows(UnsupportedOperationException.class,
+                     () -> obj.getProperty("some-boxed-glist"));
     }
 }


### PR DESCRIPTION
Java-GI will now register boxed types in the TypeCache, so when a GValue contains a boxed value, Java-GI is able to construct the expected Java  proxy class instance.

Also added handling of GStrv GValues, so they are automatically converted from and to Java String[].

The GValue conversion functions will now throw an UnsupportedOperationException when a type cannot be convered.