### PR TITLE
Add GVariant pack and unpack methods

### DIFF
--- a/generator/src/main/java/org/javagi/configuration/ClassNames.java
+++ b/generator/src/main/java/org/javagi/configuration/ClassNames.java
@@ -50,6 +50,7 @@ public final class ClassNames {
     public static final ClassName MEMORY_CLEANER = get(PKG_INTEROP, "MemoryCleaner");
     public static final ClassName INTEROP = get(PKG_INTEROP, "Interop");
     public static final ClassName PLATFORM = get(PKG_INTEROP, "Platform");
+    public static final ClassName VARIANTS = get(PKG_INTEROP, "Variants");
 
     public static final ClassName AUTO_CLOSEABLE = get(PKG_GIO, "AutoCloseable");
     public static final ClassName LIST_MODEL_JAVA_LIST = get(PKG_GIO, "ListModelJavaList");
@@ -81,6 +82,7 @@ public final class ClassNames {
     public final static ClassName G_LOG_LEVEL_FLAGS = get("org.gnome.glib", "LogLevelFlags");
     public final static ClassName G_SOURCE_ONCE_FUNC = get("org.gnome.glib", "SourceOnceFunc");
     public final static ClassName G_TYPE = get("org.gnome.glib", "Type");
+    public final static ClassName G_VARIANT = get("org.gnome.glib", "Variant");
 
     public final static ClassName G_OBJECT = get("org.gnome.gobject", "GObject");
     public final static ClassName G_OBJECTS = get("org.gnome.gobject", "GObjects");

--- a/generator/src/main/java/org/javagi/generators/RecordGenerator.java
+++ b/generator/src/main/java/org/javagi/generators/RecordGenerator.java
@@ -141,6 +141,11 @@ public class RecordGenerator extends RegisteredTypeGenerator {
         if ("GTypeInstance".equals(rec.cType()))
             addCallParentMethods();
 
+        if ("GVariant".equals(rec.cType()))
+            builder.addMethod(gvariantPack())
+                    .addMethod(gvariantUnpack())
+                    .addMethod(gvariantUnpackRecursive());
+
         return builder.build();
     }
 
@@ -342,5 +347,49 @@ public class RecordGenerator extends RegisteredTypeGenerator {
                 .returns(boolean.class)
                 .addStatement("return this.callParent")
                 .build());
+    }
+
+    private MethodSpec gvariantPack() {
+        return MethodSpec.methodBuilder("pack")
+                .addJavadoc("""
+                        Create a GVariant from a Java Object.
+                        
+                        @param o the Java Object to pack into a GVariant
+                        @return the GVariant with the packed Object
+                        @see Variants#pack
+                        """)
+                .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+                .returns(ClassNames.G_VARIANT)
+                .addParameter(Object.class, "object")
+                .addStatement("return $T.pack(object)", ClassNames.VARIANTS)
+                .build();
+    }
+
+    private MethodSpec gvariantUnpack() {
+        return MethodSpec.methodBuilder("unpack")
+                .addJavadoc("""
+                        Unpack a GVariant into a Java Object.
+                        
+                        @return the unpacked Java Object
+                        @see Variants#unpack
+                        """)
+                .addModifiers(Modifier.PUBLIC)
+                .returns(Object.class)
+                .addStatement("return $T.unpack(this, false)", ClassNames.VARIANTS)
+                .build();
+    }
+
+    private MethodSpec gvariantUnpackRecursive() {
+        return MethodSpec.methodBuilder("unpackRecursive")
+                .addJavadoc("""
+                        Unpack a GVariant into a Java Object. Nested GVariants are recursively unpacked.
+                        
+                        @return the unpacked Java Object
+                        @see Variants#unpack
+                        """)
+                .addModifiers(Modifier.PUBLIC)
+                .returns(Object.class)
+                .addStatement("return $T.unpack(this, true)", ClassNames.VARIANTS)
+                .build();
     }
 }

--- a/modules/main/glib/src/main/java/org/javagi/interop/Variants.java
+++ b/modules/main/glib/src/main/java/org/javagi/interop/Variants.java
@@ -1,0 +1,186 @@
+/* Java-GI - Java language bindings for GObject-Introspection-based libraries
+ * Copyright (C) 2025 Jan-Willem Harmannij
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.javagi.interop;
+
+import org.gnome.glib.Variant;
+import org.gnome.glib.VariantType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.*;
+
+public class Variants {
+
+    /**
+     * Unpack a GVariant into a Java Object.
+     * <ul>
+     * <li>A basic primitive type is returned as a Java boxed primitive.
+     * <li>A string, object path or type signature is returned as a Java String.
+     * <li>A nested GVariant is returned as a Java Variant (when {@code recursive}
+     *     is {@code false}) or recursively unpacked (when {@code recursive} is
+     *     {@code true}).
+     * <li>A Maybe type is returned as either {@code null} or the unpacked value.
+     * <li>An array is returned as an {@code ArrayList<?>} with unpacked values.
+     * <li>A dictionary is returned as a {@code HashMap<?, ?>} with unpacked entries.
+     * <li>A tuple is returned as a {@code ArrayList<Object>} with unpacked entries.
+     * </ul>
+     *
+     * @param v a Variant to unpack
+     * @param recursive whether to recursively unpack nested GVariants
+     * @return the unpacked Java Object
+     */
+    public static @Nullable Object unpack(@Nullable Variant v, boolean recursive) {
+        if (v == null)
+            return null;
+
+        VariantType t = v.getVariantType();
+        if (t.isBasic()) {
+            return switch (t.dupString()) {
+                case "b" -> v.getBoolean();
+                case "y" -> v.getByte();
+                case "n" -> v.getInt16();
+                case "q" -> v.getUint16();
+                case "i" -> v.getInt32();
+                case "u" -> v.getUint32();
+                case "x" -> v.getInt64();
+                case "t" -> v.getUint64();
+                case "h" -> v.getHandle();
+                case "d" -> v.getDouble();
+                case "s", "o", "g" -> v.getString(null);
+                default -> throw new IllegalArgumentException("Unsupported basic GVariantType " + t.dupString());
+            };
+        } else if (t.isMaybe()) {
+            Variant value = v.getMaybe();
+            return value == null ? null : unpack(value, recursive);
+        } else if (t.isArray()) {
+            if (t.element().isDictEntry()) {
+                Map<Object,Object> map = new HashMap<>();
+                for (int i = 0; i < v.nChildren(); i++) {
+                    Variant entry = v.getChildValue(i);
+                    Object key = unpack(entry.getChildValue(0), recursive);
+                    Object val = unpack(entry.getChildValue(1), recursive);
+                    map.put(key, val);
+                }
+                return map;
+            } else {
+                List<Object> list = new ArrayList<>();
+                for (int i = 0; i < v.nChildren(); i++) {
+                    list.add(unpack(v.getChildValue(i), recursive));
+                }
+                return list;
+            }
+        } else if (t.isTuple()) {
+            List<Object> tuple = new ArrayList<>();
+            for (int i = 0; i < v.nChildren(); i++) {
+                tuple.add(unpack(v.getChildValue(i), recursive));
+            }
+            return tuple;
+        } else if (t.isVariant()) {
+            return recursive ? unpack(v.getVariant(), true) : v.getVariant();
+        }
+        throw new IllegalArgumentException("Unsupported type: " + t.dupString());
+    }
+
+    /**
+     * Create a GVariant from a Java Object.
+     * <ul>
+     * <li>a {@code null} value is returned as a maybe ({@code "mv"})
+     *     GVariant with value {@code null}
+     * <li>a {@code boolean} is returned as a {@code boolean} GVariant
+     * <li>a {@code byte} is returned as a {@code byte} GVariant
+     * <li>a {@code char} is returned as a (single-character) string GVariant
+     * <li>an {@code short} is returned as an {@code int16} GVariant
+     * <li>an {@code int} is returned as an {@code int32} GVariant
+     * <li>an {@code long} is returned as an {@code int64} GVariant
+     * <li>a {@code float} or {@code double} is returned as a {@code double}
+     *     GVariant
+     * <li>a Java String is returned as a string GVariant
+     * <li>a Java List or Set is returned as an array GVariant with recursively
+     *     packed elements
+     * <li>a Java Map is returned as a dictionary GVariant with recursively
+     *     packed entries
+     * <li>a Java Optional is returned as a maybe ({@code "m"}) GVariant with
+     *     either the packed value or {@code null} (with type {@code "mv"})
+     * </ul>
+     * Note that arrays are not supported, only Lists.
+     *
+     * @param o the Java Object to pack into a GVariant
+     * @return the GVariant with the packed Object
+     */
+    public static @NotNull Variant pack(@Nullable Object o) {
+        return switch (o) {
+            case Character c -> Variant.string(c.toString());
+            case Collection<?> c -> {
+                var elemType = new VariantType(c.isEmpty() ? "mv" : formatString(c.iterator().next()));
+                var elems = c.stream().map(Variants::pack).toArray(Variant[]::new);
+                yield Variant.array(elemType, elems);
+            }
+            case Map<?, ?> map -> {
+                var elemType = new VariantType("mv");
+                if (!map.isEmpty()) {
+                    var key = map.keySet().iterator().next();
+                    var val = map.get(key);
+                    elemType = new VariantType("{" + formatString(key) + formatString(val) + "}");
+                }
+                var entries = map.entrySet().stream()
+                        .map(entry -> Variant.dictEntry(pack(entry.getKey()), pack(entry.getValue())))
+                        .toArray(Variant[]::new);
+                yield Variant.array(elemType, entries);
+            }
+            case Optional<?> opt -> {
+                if (opt.isEmpty()) yield new Variant("mv", (Object) null);
+                var elemType = new VariantType(formatString(opt.get()));
+                yield Variant.maybe(elemType, pack(opt.get()));
+            }
+            case null, default -> new Variant(formatString(o), o);
+        };
+    }
+
+    /**
+     * Create a GVariant formatString that can be used for the provided Object.
+     * For a List, Map or Optional, the formatString for the element(s) is returned.
+     *
+     * @param o a Java Object to create a GVariant formatString for
+     * @return the generated formatString
+     */
+    private static @NotNull String formatString(@Nullable Object o) {
+        return switch (o) {
+            case null -> "mv";
+            case Boolean _ -> "b";
+            case Byte _ -> "y";
+            case Character _ -> "s";
+            case Short _ -> "n";
+            case Integer _ -> "i";
+            case Long _ -> "x";
+            case Double _, Float _ -> "d";
+            case String _ -> "s";
+            case Variant _ -> "v";
+            case Collection<?> c -> "a" + (c.isEmpty() ? "mv" : formatString(c.iterator().next()));
+            case Map<?, ?> map -> {
+                if (map.isEmpty()) yield "a{mv}";
+                var key = map.keySet().iterator().next();
+                var val = map.get(key);
+                yield "a{" + formatString(key) + formatString(val) + "}";
+            }
+            case Optional<?> opt -> "m" + opt.map(Variants::formatString).orElse("v");
+            default -> throw new IllegalArgumentException("Unsupported object type: " + o.getClass());
+        };
+    }
+}

--- a/modules/main/glib/src/test/java/org/javagi/glib/VariantTest.java
+++ b/modules/main/glib/src/test/java/org/javagi/glib/VariantTest.java
@@ -1,0 +1,160 @@
+/* Java-GI - Java language bindings for GObject-Introspection-based libraries
+ * Copyright (C) 2025 Jan-Willem Harmannij
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.javagi.glib;
+
+import org.gnome.glib.Variant;
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class VariantTest {
+    @Test
+    void null_() {
+        assertNull(Variant.pack(null).unpack());
+    }
+
+    @Test
+    void boolean_() {
+        assertEquals(true, Variant.pack(true).unpack());
+        assertEquals(false, Variant.pack(false).unpack());
+    }
+
+    @Test
+    void byte_() {
+        assertEquals((byte) 1, Variant.pack((byte) 1).unpack());
+        assertEquals((byte) 0, Variant.pack((byte) 0).unpack());
+    }
+
+    @Test
+    void char_() {
+        // char is packed as a single-character string
+        assertEquals("j", Variant.pack('j').unpack());
+    }
+
+    // Compare two double/float values with 5 digits of equality
+    private static void assertIsClose(double d1, double d2) {
+        assertTrue(Math.abs(d1-d2) < 0.000001d);
+    }
+
+    @Test
+    void double_() {
+        assertIsClose(42.123, (double) Variant.pack(42.123).unpack());
+        assertEquals(Double.MAX_VALUE, Variant.pack(Double.MAX_VALUE).unpack());
+    }
+
+    @Test
+    void float_() {
+        assertIsClose(42.456f, (double) Variant.pack(42.456f).unpack());
+        assertEquals(Double.NaN, Variant.pack(Float.NaN).unpack());
+    }
+
+    @Test
+    void int_() {
+        assertEquals(42, Variant.pack(42).unpack());
+        assertEquals(-42, Variant.pack(-42).unpack());
+        assertEquals(Integer.MIN_VALUE, Variant.pack(Integer.MIN_VALUE).unpack());
+        assertEquals(Integer.MAX_VALUE, Variant.pack(Integer.MAX_VALUE).unpack());
+    }
+
+    @Test
+    void long_() {
+        assertEquals(42L, Variant.pack(42L).unpack());
+        assertEquals(Long.MIN_VALUE, Variant.pack(Long.MIN_VALUE).unpack());
+        assertEquals(Long.MAX_VALUE, Variant.pack(Long.MAX_VALUE).unpack());
+    }
+
+    @Test
+    void short_() {
+        assertEquals((short) 42, Variant.pack((short) 42).unpack());
+    }
+
+    @Test
+    void string() {
+        assertEquals("abc", Variant.pack("abc").unpack());
+        // String containing \0 is not supported
+        assertEquals("abc", Variant.pack("abc\0def").unpack());
+    }
+
+    @Test
+    void list() {
+        var list1 = List.of(1, 2, 3);
+        assertEquals(list1, Variant.pack(list1).unpack());
+
+        var list2 = List.of("a", "b", "c");
+        assertEquals(list2, Variant.pack(list2).unpack());
+
+        var list3 = List.of(list1, list1);
+        assertEquals(list3, Variant.pack(list3).unpack());
+    }
+
+    @Test
+    void set() {
+        var set = Set.of(1, 2, 3);
+        // Set is packed as an array variant, and returned as a list.
+        // Copy the unpacked list back into a set.
+        assertEquals(set, Set.copyOf((Collection<?>) Variant.pack(set).unpack()));
+    }
+
+    @Test
+    void map() {
+        var map1 = Map.of(1, "str1", 2, "str2", 3, "str3");
+        assertEquals(map1, Variant.pack(map1).unpack());
+
+        var map2 = Map.of("a", "str1", "b", "str2", "c", "str3");
+        assertEquals(map2, Variant.pack(map2).unpack());
+
+        var map3 = Map.of(42.1, map1, 42.2, map1);
+        assertEquals(map3, Variant.pack(map3).unpack());
+    }
+
+    @Test
+    void optional() {
+        var opt1 = Optional.of("str");
+        var variant1 = Variant.pack(opt1);
+        assertTrue(variant1.getVariantType().isMaybe());
+        assertEquals("str", variant1.unpack());
+
+        var opt2 = Optional.empty();
+        var variant2 = Variant.pack(opt2);
+        assertTrue(variant2.getVariantType().isMaybe());
+        assertNull(variant2.unpack());
+    }
+
+    @Test
+    void recursive() {
+        Variant str = Variant.pack("str");
+        Variant list = Variant.pack(List.of(str));
+        assertEquals("av", list.getTypeString());
+
+        // recursive
+        Object o1 = list.unpackRecursive();
+        assertInstanceOf(List.class, o1);
+        List<?> list1 = (List<?>) o1;
+        assertInstanceOf(String.class, list1.getFirst());
+
+        // not recursive
+        Object o2 = list.unpack();
+        assertInstanceOf(List.class, o2);
+        List<?> list2 = (List<?>) o2;
+        assertInstanceOf(Variant.class, list2.getFirst());
+    }
+}

--- a/modules/test/regress/src/test/java/org/javagi/regress/TestVariant.java
+++ b/modules/test/regress/src/test/java/org/javagi/regress/TestVariant.java
@@ -1,0 +1,41 @@
+/* Java-GI - Java language bindings for GObject-Introspection-based libraries
+ * Copyright (C) 2025 Jan-Willem Harmannij
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.javagi.regress;
+
+import org.junit.jupiter.api.Test;
+
+import static org.gnome.gi.regress.Regress.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TestVariant {
+    @Test
+    void i() {
+        var v = testGvariantI();
+        assertNotNull(v);
+        assertEquals(1, v.unpack());
+    }
+
+    @Test
+    void s() {
+        var v = testGvariantS();
+        assertNotNull(v);
+        assertEquals("one", v.unpack());
+    }
+}


### PR DESCRIPTION
This adds three new methods to the `org.gnome.glib.Variant` class:
* `public static Variant pack(Object object)` to create a Variant from a Java Object
* `public Object unpack()` to unpack a Variant to a Java Object
* `public Object unpackRecursive()` to unpack a Variant to a Java Object, recursively unpacking nested Variants too.

In most cases, packing and unpacking an object will result in an object that equals the original, but this is not always the case, because during the pack/unpack operations, some information gets lost. For example:
* A Variant with an unsigned datatype is unpacked to a signed Java value
* A Variant with an object path or type signature is unpacked to a Java String
* Conversely, both Java `List` and `Set` are packed into an array-type Variant
* A Java `Optional<?>` is packed into a maybe-type Variant, but a maybe-type Variant is unpacked into the Java value or null.
