### PR TITLE
Fix GError ownership when set from a Java callback

### DIFF
--- a/generator/src/main/java/org/javagi/generators/ClosureGenerator.java
+++ b/generator/src/main/java/org/javagi/generators/ClosureGenerator.java
@@ -213,24 +213,20 @@ public class ClosureGenerator {
         // Catch exceptions and set the GError** value
         if (closure.throws_()) {
             if (methodToInvoke.endsWith("invoke")) {
-                upcall.nextControlFlow("catch ($T _ite)",
-                        InvocationTargetException.class);
-                upcall.beginControlFlow("if (_ite.getCause() instanceof $T _ge)",
-                        ClassNames.GERROR_EXCEPTION);
+                upcall.nextControlFlow("catch ($T _ite)", InvocationTargetException.class)
+                      .beginControlFlow("if (_ite.getCause() instanceof $T _ge)", ClassNames.GERROR_EXCEPTION);
             } else {
-                upcall.nextControlFlow("catch ($T _ge)",
-                        ClassNames.GERROR_EXCEPTION);
+                upcall.nextControlFlow("catch ($T _ge)", ClassNames.GERROR_EXCEPTION);
             }
-            upcall.addStatement("$1T _gerror = new $1T(_ge.getDomain(), _ge.getCode(), _ge.getMessage())",
-                    ClassNames.G_ERROR);
-            upcall.addStatement("_gerrorPointer.set($T.ADDRESS, 0, _gerror.handle())",
-                    ValueLayout.class);
+            upcall.addStatement("$1T _gerror = $1T.literal(_ge.getDomain(), _ge.getCode(), _ge.getMessage())", ClassNames.G_ERROR)
+                  .addStatement("$T.yieldOwnership(_gerror)", ClassNames.MEMORY_CLEANER)
+                  .addStatement("_gerrorPointer.set($T.ADDRESS, 0, _gerror.handle())", ValueLayout.class);
             if (!returnsVoid)
                 returnNull(upcall);
             if (methodToInvoke.endsWith("invoke")) {
-                upcall.nextControlFlow("else");
-                upcall.addStatement("throw _ite");
-                upcall.endControlFlow();
+                upcall.nextControlFlow("else")
+                      .addStatement("throw _ite")
+                      .endControlFlow();
             }
             upcall.endControlFlow();
         }

--- a/modules/main/glib/src/main/java/org/javagi/base/GErrorException.java
+++ b/modules/main/glib/src/main/java/org/javagi/base/GErrorException.java
@@ -77,6 +77,7 @@ public class GErrorException extends Exception {
         this.domain = gerror.readDomain();
         this.code = gerror.readCode();
         this.message = gerror.readMessage();
+        gerror.free();
     }
 
     /**


### PR DESCRIPTION
This PR makes fixes some GError ownership issues.
Also, `GError.literal()` is used instead of `new GError()` so the message isn't interpreted as a printf-style formatted text.