### PR TITLE
Add bindings for librsvg

### DIFF
--- a/generator/src/main/java/org/javagi/configuration/ModuleInfo.java
+++ b/generator/src/main/java/org/javagi/configuration/ModuleInfo.java
@@ -56,6 +56,7 @@ public final class ModuleInfo {
             entry("gtk",                       new Module("GTK", "org.gnome.gtk", "org.gnome.gtk", "https://docs.gtk.org/gtk4/", "GTK is a multi-platform toolkit for creating graphical user interfaces")),
             entry("gtksource",                 new Module("GtkSourceView", "org.gnome.gtksourceview", "org.gnome.gtksourceview", "https://gnome.pages.gitlab.gnome.org/gtksourceview/gtksourceview5/", "A text editor widget for code editing")),
             entry("adw",                       new Module("LibAdwaita", "org.gnome.adw", "org.gnome.adw", "https://gnome.pages.gitlab.gnome.org/libadwaita/doc/1-latest/", "Building blocks for modern GNOME applications")),
+            entry("rsvg",                      new Module("LibRsvg", "org.gnome.rsvg", "org.gnome.rsvg", "https://gnome.pages.gitlab.gnome.org/librsvg/Rsvg-2.0/", "Load and render SVG images into Cairo surfaces")),
             entry("soup",                      new Module("LibSoup", "org.gnome.soup", "org.gnome.soup", "https://libsoup.org/libsoup-3.0/", "An HTTP client/server library for GNOME")),
             entry("javascriptcore",            new Module("JavaScriptCore", "org.webkitgtk.jsc", "org.webkitgtk", "https://webkitgtk.org/reference/jsc-glib/stable/", "The JavaScript engine used in WebKit")),
             entry("webkit",                    new Module("WebKitGTK", "org.webkitgtk", "org.webkitgtk", "https://webkitgtk.org/reference/webkit2gtk/stable/", "WebKitGTK is a full-featured port of the WebKit rendering engine")),
@@ -104,7 +105,7 @@ public final class ModuleInfo {
     private static Module get(String namespace) {
         Module info = ALL_MODULES.get(namespace.toLowerCase());
         if (info == null)
-            throw new NoSuchElementException("GIR namespace " + namespace + " not found");
+            throw new NoSuchElementException("GIR namespace " + namespace + " not found in ModuleInfo");
         return info;
     }
 

--- a/modules/rsvg/build.gradle.kts
+++ b/modules/rsvg/build.gradle.kts
@@ -1,0 +1,13 @@
+plugins {
+    id("java-gi.library-conventions")
+}
+
+dependencies {
+    api(project(":glib"))
+    api(project(":gdkpixbuf"))
+    api(libs.cairo)
+}
+
+tasks.withType<GenerateSources> {
+    girFiles.set(listOf("Rsvg-2.0"))
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,6 +15,7 @@ include("gtk")
 include("gtksourceview")
 include("harfbuzz")
 include("pango")
+include("rsvg")
 include("soup")
 include("webkit")
 


### PR DESCRIPTION
Add bindings for LibRsvg

The bindings are in a new module, with one package: `org.gnome.rsvg`.
An example will be added later to the java-gi-examples repository.