### PR TITLE
Read and write to and from SequenceLayout fields

### DIFF
--- a/generator/src/main/java/org/javagi/generators/MemoryLayoutGenerator.java
+++ b/generator/src/main/java/org/javagi/generators/MemoryLayoutGenerator.java
@@ -131,9 +131,13 @@ public class MemoryLayoutGenerator {
             // Get the size of the field, in bytes
             int s = field.getSize(longAsInt);
 
+            // Get the alignment of the field, in bytes
+            // (In a SequenceLayout, this is the size of one element)
+            int aln = field.getAlignment(longAsInt);
+
             // Update alignment
-            if (s > alignment && s <= 8)
-                alignment = s;
+            if (aln > alignment && aln <= 8)
+                alignment = aln;
 
             // Bitfield?
             int bits = field.bits();
@@ -158,10 +162,10 @@ public class MemoryLayoutGenerator {
 
             // Calculate padding
             if (insertPadding) {
-                // If the previous field had a smaller byte-size than this one,
+                // If the previous field had a smaller alignment than this one,
                 // add padding (to a maximum of 8 bytes)
-                if (size % s % 8 > 0) {
-                    int padding = (s - (size % s)) % 8;
+                if (size % aln % 8 > 0) {
+                    int padding = (aln - (size % aln)) % 8;
                     stmt.add("$memoryLayout:T.paddingLayout(" + padding + ")")
                         .add(",\n");
                     size += padding;

--- a/generator/src/main/java/org/javagi/generators/RecordGenerator.java
+++ b/generator/src/main/java/org/javagi/generators/RecordGenerator.java
@@ -162,6 +162,9 @@ public class RecordGenerator extends RegisteredTypeGenerator {
                     && t.lookup() instanceof Record)
                 // Copy contents from nested struct
                 builder.addMethod(generator.generateReadCopyMethod());
+            else if (f.anyType() instanceof Array a && a.fixedSize() > 0)
+                // Copy contents from array
+                builder.addMethod(generator.generateReadArrayMethod());
             else
                 // Read pointer or primitive value
                 builder.addMethod(generator.generateReadMethod());
@@ -199,6 +202,9 @@ public class RecordGenerator extends RegisteredTypeGenerator {
                 && t.lookup() instanceof Record)
             // Generate write-method to copy contents to nested struct
             builder.addMethod(generator.generateWriteCopyMethod());
+        else if (f.anyType() instanceof Array a && a.fixedSize() > 0)
+            // Generate write-method to copy contents to nested array
+            builder.addMethod(generator.generateWriteArrayMethod());
         else if (cb == null || outerClass == null)
             // Generate write/override method for a pointer or primitive value
             builder.addMethod(generator.generateWriteMethod());

--- a/generator/src/main/java/org/javagi/gir/Array.java
+++ b/generator/src/main/java/org/javagi/gir/Array.java
@@ -108,6 +108,10 @@ public final class Array extends GirElement implements AnyType {
         return fixedSize * anyType().allocatedSize(longAsInt);
     }
 
+    public int elementSize(boolean longAsInt) {
+        return anyType().allocatedSize(longAsInt);
+    }
+
     public AnyType anyType() {
         return findAny(children(), AnyType.class);
     }

--- a/generator/src/main/java/org/javagi/gir/Field.java
+++ b/generator/src/main/java/org/javagi/gir/Field.java
@@ -58,6 +58,19 @@ public final class Field extends GirElement implements TypedValue {
     }
 
     /**
+     * Get the memory alignment of this field, in bytes
+     * @param longAsInt when true, long is 4 bytes, else long is 8 bytes
+     */
+    public int getAlignment(boolean longAsInt) {
+        AnyType anyType = anyType();
+        if (anyType instanceof Type t)
+            return t.isPointer() ? 8 : t.allocatedSize(longAsInt);
+        if (anyType instanceof Array a)
+            return a.fixedSize() < 0 ? 8 : a.elementSize(longAsInt);
+        return 8; // callback
+    }
+
+    /**
      * Check whether this field should not be exposed
      */
     public boolean isDisguised() {

--- a/modules/gobject-introspection-tests/src/test/java/org/javagi/regress/TestArraysFixedSize.java
+++ b/modules/gobject-introspection-tests/src/test/java/org/javagi/regress/TestArraysFixedSize.java
@@ -1,0 +1,93 @@
+/* Java-GI - Java language bindings for GObject-Introspection-based libraries
+ * Copyright (C) 2025 Jan-Willem Harmannij
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.javagi.regress;
+
+import org.gnome.gi.regress.*;
+import org.junit.jupiter.api.Test;
+
+import java.lang.foreign.Arena;
+import java.util.Arrays;
+
+import static org.gnome.gi.regress.Regress.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TestArraysFixedSize {
+    @Test
+    void struct() {
+        var struct = new TestStructFixedArray();
+        struct.frob();
+        assertEquals(7, struct.readJustInt());
+
+        // Read array
+        assertArrayEquals(new int[] {42, 43, 44, 45, 46, 47, 48, 49, 50, 51}, struct.readArray());
+
+        try (Arena arena = Arena.ofConfined()) {
+            // Write a new array and read it back
+            struct.writeArray(new int[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, arena);
+            assertArrayEquals(new int[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, struct.readArray());
+
+            // Write a null array and read it back
+            struct.writeArray(null, arena);
+            assertArrayEquals(new int[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, struct.readArray());
+        }
+    }
+
+    @Test
+    void int_() {
+        int[] correctSize = new int[32];
+        Arrays.fill(correctSize, 42);
+        hasParameterNamedAttrs(0, correctSize);
+
+        // Test with too small array
+        int[] wrongSize = new int[31];
+        Arrays.fill(wrongSize, 42);
+        assertThrows(IllegalArgumentException.class, () -> hasParameterNamedAttrs(0, wrongSize));
+    }
+
+    @Test
+    void fixedSizeAndZeroTerminated() {
+        // LikeXklConfigItem.name is a fixed size string of 32 bytes.
+        // All unused bytes are filled with nulls.
+        var x = new LikeXklConfigItem();
+
+        String foo = "foo";
+        x.setName(foo);
+
+        // Prepare a byte string with "foo" and 29 nulls
+        byte[] fooBytes = new byte[32];
+        Arrays.fill(fooBytes, (byte) 0);
+        for (int i = 0; i < foo.length(); i++)
+            fooBytes[i] = (byte) foo.codePointAt(i);
+
+        String str = new String(x.readName());
+        assertArrayEquals(fooBytes, str.getBytes());
+
+        String stars = "*".repeat(33);
+        x.setName(stars);
+
+        // Prepare a byte string with 31 stars and one null
+        byte[] starBytes = new byte[32];
+        Arrays.fill(starBytes, (byte) '*');
+        starBytes[31] = (byte) 0;
+
+        str = new String(x.readName());
+        assertArrayEquals(starBytes, str.getBytes());
+    }
+}


### PR DESCRIPTION
When Java-GI generates a MemoryLayout for a class, struct or union, a fixed-size array is represented by a SequenceLayout. Reading and writing values from such layouts is not possible with a regular VarHandle. This PR adds functionality to read and write these arrays by copying data from and to the memory segment directly.