### PR TITLE
Prepare to make ProxyInstance.address field private again

### DIFF
--- a/generator/src/main/java/org/javagi/generators/PostprocessingGenerator.java
+++ b/generator/src/main/java/org/javagi/generators/PostprocessingGenerator.java
@@ -297,8 +297,15 @@ public class PostprocessingGenerator extends TypedValueGenerator {
             // segment using BoxedUtil.copy(). It will fallback to
             // Interop.copy() when the type is not boxed.
             else if (copyFunc == null && slt.getTypeFunc() != null) {
-                builder.addStatement("$1L.address = $2T.copy($3T.getType(), $1L,$W$3T.getMemoryLayout().byteSize())",
-                                paramName, ClassNames.BOXED_UTIL, v.anyType().typeName());
+                if (v instanceof ReturnValue) {
+                    // reassign _returnValue to boxed copy
+                    builder.addStatement("$1L = new $3T($2T.copy($3T.getType(), $1L,$W$3T.getMemoryLayout().byteSize()))",
+                            paramName, ClassNames.BOXED_UTIL, v.anyType().typeName());
+                } else {
+                    // set out-parameter to boxed copy
+                    builder.addStatement("$1L.set(new $3T($2T.copy($3T.getType(), $1L.get(),$W$3T.getMemoryLayout().byteSize())))",
+                            getName(), ClassNames.BOXED_UTIL, v.anyType().typeName());
+                }
             }
 
             // Copy function is an instance method

--- a/modules/glib/src/main/java/org/javagi/base/ProxyInstance.java
+++ b/modules/glib/src/main/java/org/javagi/base/ProxyInstance.java
@@ -27,6 +27,15 @@ import java.util.Objects;
  */
 public class ProxyInstance implements Proxy {
 
+    /**
+     * The native memory address
+     *
+     * @deprecated This field <strong>will become {@code private}</strong> in a
+     *             future release. Use {@link #handle()} instead.
+     *
+     * @see #handle()
+     */
+    @Deprecated
     public MemorySegment address;
 
     /**

--- a/modules/gobject-introspection-tests/src/test/java/org/javagi/regress/TestObjectSignals.java
+++ b/modules/gobject-introspection-tests/src/test/java/org/javagi/regress/TestObjectSignals.java
@@ -263,7 +263,7 @@ public class TestObjectSignals {
         o.onSigWithGerror(err -> {
             assertNotNull(err);
             // This only works when we manually dereference the pointer like this:
-                var err2 = new GError(Interop.dereference(err.address));
+                var err2 = new GError(Interop.dereference(err.handle()));
                 assertEquals(Gio.ioErrorQuark(), err2.readDomain());
                 assertEquals(IOErrorEnum.FAILED.getValue(), err2.readCode());
             // I'm not sure why this is necessary here, so I disabled the test for now.


### PR DESCRIPTION
The address of a java-gi proxy class must be accessed with the `handle()` method (as specified in the Proxy interface). The actual address is stored in the `address` field of the ProxyInstance class. That field had private visibility until java-gi 0.12, when it was changed to public visibility. I want to revert that, so it is now marked as deprecated, and will be changed to private visibility in a future release.