### PR TITLE
Add template usage information for icons

### DIFF
--- a/docs/getting-started/getting_started_14.md
+++ b/docs/getting-started/getting_started_14.md
@@ -61,13 +61,15 @@ Then, we create the GTK XML resource file in our Java resources folder (i.e `src
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <gresources>
-    <gresource prefix="/icons">
+    <gresource prefix="/icons/scalable/actions">
         <file alias="penguin-symbolic.svg" preprocess="xml-stripblanks">icons/penguin-symbolic.svg</file>
     </gresource>
 </gresources>
 ```
 
 The `.svg` extension is required to be able to add the icon to the applications icon theme.
+Furthermore, the `/scalable/actions/` prefix is necessary for GTK to treat the icons as repaintable.
+Otherwise, the icons won't be visible with dark theme enable.
 
 #### Gradle build script to compile GTK resources file
 
@@ -108,7 +110,7 @@ We now add a gradle task to our Gradle build script to compile the GTK resources
 We can now use the icon using `Image.fromResource` and the string name of the icon, which is this `prefix` of the icon, concatenated with its `alias`:
 
 ```Java
-var image = Image.fromResource("/icons/key-symbolic.svg");
+var image = Image.fromResource("/icons/scalable/actions/icons/key-symbolic.svg");
 ```
 
 ##### Use the icon in a template

--- a/docs/getting-started/getting_started_14.md
+++ b/docs/getting-started/getting_started_14.md
@@ -69,7 +69,7 @@ Then, we create the GTK XML resource file in our Java resources folder (i.e `src
 
 The `.svg` extension is required to be able to add the icon to the applications icon theme.
 Furthermore, the `/scalable/actions/` prefix is necessary for GTK to treat the icons as repaintable.
-Otherwise, the icons won't be visible with dark theme enable.
+Otherwise, the icons won't be visible when the dark theme is enabled.
 
 #### Gradle build script to compile GTK resources file
 
@@ -115,8 +115,7 @@ var image = Image.fromResource("/icons/scalable/actions/icons/key-symbolic.svg")
 
 ##### Use the icon in a template
 
-To be able to use the icon inside a template
-it has to be added to the applications icon theme.
+To be able to use the icon inside a template it has to be added to the applications icon theme.
 
 ```java
 var theme = IconTheme.getForDisplay(Display.getDefault());
@@ -129,7 +128,7 @@ Now the icon can be used with its name.
 ```xml
 <object class="AdwViewStackPage">
     <property name="icon-name">penguin-symbolic</property>
-...
+    ...
 </object>
 ```
 

--- a/docs/getting-started/getting_started_14.md
+++ b/docs/getting-started/getting_started_14.md
@@ -62,14 +62,16 @@ Then, we create the GTK XML resource file in our Java resources folder (i.e `src
 <?xml version="1.0" encoding="UTF-8"?>
 <gresources>
     <gresource prefix="/icons">
-        <file alias="penguin-symbolic" preprocess="xml-stripblanks">icons/penguin-symbolic.svg</file>
+        <file alias="penguin-symbolic.svg" preprocess="xml-stripblanks">icons/penguin-symbolic.svg</file>
     </gresource>
 </gresources>
 ```
 
+The `.svg` extension is required to be able to add the icon to the applications icon theme.
+
 #### Gradle build script to compile GTK resources file
 
-We now add a gradle task to ou Gradle build script to compile the GTK resources file when we build our application.
+We now add a gradle task to our Gradle build script to compile the GTK resources file when we build our application.
 
 === "Gradle (Groovy)"
 
@@ -106,7 +108,27 @@ We now add a gradle task to ou Gradle build script to compile the GTK resources 
 We can now use the icon using `Image.fromResource` and the string name of the icon, which is this `prefix` of the icon, concatenated with its `alias`:
 
 ```Java
-var image = Image.fromResource("/icons/key-symbolic");
+var image = Image.fromResource("/icons/key-symbolic.svg");
+```
+
+##### Use the icon in a template
+
+To be able to use the icon inside a template
+it has to be added to the applications icon theme.
+
+```java
+var theme = IconTheme.getForDisplay(Display.getDefault());
+theme.addResourcePath("/icons");
+```
+
+This should be placed inside a `GtkApplication` `activate()` method because otherwise the display won't be available.
+Now the icon can be used with its name.
+
+```xml
+<object class="AdwViewStackPage" id="artistsPage">
+    <property name="icon-name">penguin-symbolic</property>
+...
+</object>
 ```
 
 [Previous](getting_started_13.md){ .md-button }

--- a/docs/getting-started/getting_started_14.md
+++ b/docs/getting-started/getting_started_14.md
@@ -125,7 +125,7 @@ This should be placed inside a `GtkApplication` `activate()` method because othe
 Now the icon can be used with its name.
 
 ```xml
-<object class="AdwViewStackPage" id="artistsPage">
+<object class="AdwViewStackPage">
     <property name="icon-name">penguin-symbolic</property>
 ...
 </object>


### PR DESCRIPTION
This PR contains updates to the `Using icons` chapters of the getting started tutorial.
It adds instructions to clarify how to use custom icons within a template.
It also fixes a typo.