### PR TITLE
Fix signals with struct args passed by value

### DIFF
--- a/modules/gobject-introspection-tests/src/test/java/org/javagi/gimarshallingtests/TestObjectSignals.java
+++ b/modules/gobject-introspection-tests/src/test/java/org/javagi/gimarshallingtests/TestObjectSignals.java
@@ -156,10 +156,7 @@ public class TestObjectSignals {
         assertEquals(1, count.get());
     }
 
-    // FIXME: The BoxedStruct is passed by value, but the FunctionDescriptor of
-    // the callback must have an ADDRESS parameter, not the actual layout, or
-    // else it will not work.
-    @Test @Disabled
+    @Test
     void boxedStruct() {
         AtomicInteger count = new AtomicInteger(0);
         obj.onSomeBoxedStruct(struct -> {


### PR DESCRIPTION
For plain struct types (i.e. struct, union, boxed types) that are not passed by reference but by value, the FunctionDescriptor normally contains the complete memory layout of the struct. But for signals, it must be ValueLayout.ADDRESS. I'm not sure why, but the JVM segfaults otherwise.