### PR TITLE
Add VariantType.toString() calling dupString()

### DIFF
--- a/generator/src/main/resources/metadata/GLib-2.0.metadata
+++ b/generator/src/main/resources/metadata/GLib-2.0.metadata
@@ -59,8 +59,11 @@ SList     java-gi-custom
  */
 {List,SList}.free_full java-gi-skip
 
-// Implement GType.toString() with g_type_name()
+// Use g_type_name for GType.toString()
 Type java-gi-to-string="org.gnome.gobject.GObjects.typeName(this)"
 
-// Use g_variant_print as the Variant.toString() method in Java.
+// Use g_variant_print for Variant.toString()
 Variant java-gi-to-string="print(true)"
+
+// Use g_variant_type_dup_string for VariantType.toString()
+VariantType java-gi-to-string="dupString()"

--- a/modules/glib/src/test/java/org/javagi/glib/VariantTest.java
+++ b/modules/glib/src/test/java/org/javagi/glib/VariantTest.java
@@ -20,6 +20,7 @@
 package org.javagi.glib;
 
 import org.gnome.glib.Variant;
+import org.gnome.glib.VariantType;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
@@ -167,5 +168,11 @@ public class VariantTest {
         expected.add((short) 43);
         expected.add("44");
         assertEquals(expected, unpacked);
+    }
+
+    @Test
+    void toStringOverride() {
+        assertEquals("'abc'", Variant.string("abc").toString());
+        assertEquals("ms", new VariantType("ms").toString());
     }
 }


### PR DESCRIPTION
This adds a custom `toString()` method to VariantType that calls `g_variant_type_dup_string()`.