### PR TITLE
Add cast() method

### DIFF
--- a/generator/src/main/java/org/javagi/generators/RecordGenerator.java
+++ b/generator/src/main/java/org/javagi/generators/RecordGenerator.java
@@ -138,8 +138,10 @@ public class RecordGenerator extends RegisteredTypeGenerator {
         if (rec.toStringTarget() != null)
             builder.addMethod(toStringRedirect());
 
-        if ("GTypeInstance".equals(rec.cType()))
+        if ("GTypeInstance".equals(rec.cType())) {
             addCallParentMethods();
+            builder.addMethod(cast());
+        }
 
         if ("GVariant".equals(rec.cType()))
             builder.addMethod(gvariantPack())
@@ -345,6 +347,34 @@ public class RecordGenerator extends RegisteredTypeGenerator {
                 .returns(boolean.class)
                 .addStatement("return this.callParent")
                 .build());
+    }
+
+    private MethodSpec cast() {
+        TypeVariableName T = TypeVariableName.get("T", ClassNames.G_TYPE_INSTANCE);
+        return MethodSpec.methodBuilder("cast")
+                .addJavadoc("""
+                        Cast this instance to the requested type, if the GTypes are compatible.
+                        
+                        @param to the intended class
+                        @param <T> the type of the intended class (must be a GTypeInstance)
+                        @return a new instance of the requested class
+                        @throws $T when {@code to} is not a registered GType
+                        @throws $T when the GType of this instance does not derive from the GType of {@code to}
+                        """, IllegalArgumentException.class, ClassCastException.class)
+                .addModifiers(Modifier.PUBLIC)
+                .addTypeVariable(T)
+                .returns(T)
+                .addParameter(ParameterizedTypeName.get(ClassName.get(java.lang.Class.class), T), "to")
+                .addStatement("$T fromType = readGClass().readGType()", ClassNames.G_TYPE)
+                .addStatement("$T toType = $T.getType(to)", ClassNames.G_TYPE, ClassNames.TYPE_CACHE)
+                .beginControlFlow("if (toType == null)")
+                .addStatement("throw new $T(to.getName() + $S)", IllegalArgumentException.class, " is not a registered GType")
+                .endControlFlow()
+                .beginControlFlow("if (! $T.typeIsA(fromType, toType))", ClassNames.G_OBJECTS)
+                .addStatement("throw new $T(fromType + $S + toType)", ClassCastException.class, " is not a ")
+                .endControlFlow()
+                .addStatement("return (T) $T.getConstructor(toType, null).apply(handle())", ClassNames.TYPE_CACHE)
+                .build();
     }
 
     private MethodSpec gvariantPack() {

--- a/modules/glib/src/test/java/org/javagi/gobject/CastTest.java
+++ b/modules/glib/src/test/java/org/javagi/gobject/CastTest.java
@@ -1,0 +1,52 @@
+/* Java-GI - Java language bindings for GObject-Introspection-based libraries
+ * Copyright (C) 2022-2025 Jan-Willem Harmannij
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.javagi.gobject;
+
+import org.gnome.gobject.Binding;
+import org.gnome.gobject.GObject;
+import org.gnome.gobject.SignalGroup;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Test the TypeInstance.cast() method
+ */
+public class CastTest {
+    @Test
+    void testCast() {
+        SignalGroup s1 = new SignalGroup(GObject.getType());
+
+        GObject obj = s1.cast(GObject.class);
+
+        assertThrows(ClassCastException.class, () -> {
+            SignalGroup s2 = (SignalGroup) obj;
+        });
+
+        assertDoesNotThrow(() -> {
+            SignalGroup s3 = obj.cast(SignalGroup.class);
+        });
+
+        assertThrows(ClassCastException.class, () -> {
+            Binding b = obj.cast(Binding.class);
+        });
+    }
+}


### PR DESCRIPTION
This allows to cast a type instance to another type, even if the Java type would not allow it.

This is of course terribly unsafe, but there is a runtime check using `g_type_is_a()` so at least there's a runtime type check.

The cast is intended to be used in some special cases:
- When a Java wrapper class for a non-public GType doesn't fit the intended use case. In this case, a normal cast in Java to the intended type would raise a ClassCastException.
  - Example: #299
- When a GObject is subclassed in Java, and the Java class overrides a virtual function, but it is still necessary to call the invoker method from Java. This isn't possible because Java-GI "merges" instance methods and virtual methods into one Java method, and when overridden, the virtual method will always take precedence over the parent's instance method. Using the `cast()` method introduced here, to "cast" the class to the parent type, it becomes possible again to call the instance method.
  - Example: #303